### PR TITLE
Add Elixir SDK

### DIFF
--- a/docs/tools-and-sdks.mdx
+++ b/docs/tools-and-sdks.mdx
@@ -107,3 +107,7 @@ This SDK is split up into separate packages, all of which you can find in the [G
 ### Flutter
 
 [Source](https://github.com/Soneso/stellar_flutter_sdk) | [Docs](https://github.com/Soneso/stellar_flutter_sdk/tree/master/documentation) | [Examples](https://github.com/Soneso/stellar_flutter_sdk/tree/master/documentation/sdk_examples)
+
+### Elixir (beta)
+
+[Source](https://github.com/kommitters/stellar_sdk) | [Docs](https://hexdocs.pm/stellar_sdk/readme.html) | [Examples](https://github.com/kommitters/stellar_sdk/blob/main/docs/examples.md)


### PR DESCRIPTION
Hi there! 

This PR is created in order to add **Elixir SDK** to the documentation. Elixir SDK had already been accepted in the PR https://github.com/stellar/stellar-docs/pull/12, but we noticed that it doesn't appear now! 🤔 

We consider this is due to the design changes you are working on, however, we are wondering if anything additional needs to be done to get us included in the doc. Please let us know 😄 

