### PR TITLE
Fix JS code example typos

### DIFF
--- a/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
+++ b/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
@@ -54,11 +54,12 @@ If you want to match a fee error exactly, you may write something like this:
 
 ```js
 function isFeeError(error) {
-  return;
-  error.response !== undefined &&
-    error.status == 400 &&
-    error.extras &&
-    error.extras.result_codes.transaction == sdk.TX_INSUFFICIENT_FEE;
+  return (
+    error.response !== undefined
+    && error.status == 400
+    && error.extras
+    && error.extras.result_codes.transaction == sdk.TX_INSUFFICIENT_FEE
+  );
 }
 ```
 

--- a/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
+++ b/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
@@ -55,10 +55,10 @@ If you want to match a fee error exactly, you may write something like this:
 ```js
 function isFeeError(error) {
   return (
-    error.response !== undefined
-    && error.status === 400
-    && error.extras
-    && error.extras.result_codes.transaction === sdk.TX_INSUFFICIENT_FEE
+    error.response !== undefined &&
+    error.status === 400 &&
+    error.extras &&
+    error.extras.result_codes.transaction === sdk.TX_INSUFFICIENT_FEE
   );
 }
 ```

--- a/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
+++ b/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
@@ -58,7 +58,7 @@ function isFeeError(error) {
     error.response !== undefined
     && error.status == 400
     && error.extras
-    && error.extras.result_codes.transaction == sdk.TX_INSUFFICIENT_FEE
+    && error.extras.result_codes.transaction === sdk.TX_INSUFFICIENT_FEE
   );
 }
 ```

--- a/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
+++ b/docs/encyclopedia/fees-surge-pricing-fee-strategies.mdx
@@ -56,7 +56,7 @@ If you want to match a fee error exactly, you may write something like this:
 function isFeeError(error) {
   return (
     error.response !== undefined
-    && error.status == 400
+    && error.status === 400
     && error.extras
     && error.extras.result_codes.transaction === sdk.TX_INSUFFICIENT_FEE
   );


### PR DESCRIPTION
Fixed a JavaScript code example in fee section that doesn't work
- https://developers.stellar.org/docs/encyclopedia/fees-surge-pricing-fee-strategies#track-fee-fluctuations