### PR TITLE
Add PHP SDK to tools and sdks

### DIFF
--- a/docs/tools-and-sdks.mdx
+++ b/docs/tools-and-sdks.mdx
@@ -108,10 +108,10 @@ This SDK is split up into separate packages, all of which you can find in the [G
 
 [Source](https://github.com/Soneso/stellar_flutter_sdk) | [Docs](https://github.com/Soneso/stellar_flutter_sdk/tree/master/documentation) | [Examples](https://github.com/Soneso/stellar_flutter_sdk/tree/master/documentation/sdk_examples)
 
-### Elixir (beta)
-
-[Source](https://github.com/kommitters/stellar_sdk) | [Docs](https://hexdocs.pm/stellar_sdk/readme.html) | [Examples](https://github.com/kommitters/stellar_sdk/blob/main/docs/examples.md)
-
 ### PHP
 
 [Source](https://github.com/Soneso/stellar-php-sdk) | [Docs](https://github.com/Soneso/stellar-php-sdk#installation) | [Examples](https://github.com/Soneso/stellar-php-sdk/tree/main/examples)
+
+### Elixir (beta)
+
+[Source](https://github.com/kommitters/stellar_sdk) | [Docs](https://hexdocs.pm/stellar_sdk/readme.html) | [Examples](https://github.com/kommitters/stellar_sdk/blob/main/docs/examples.md)

--- a/docs/tools-and-sdks.mdx
+++ b/docs/tools-and-sdks.mdx
@@ -111,3 +111,7 @@ This SDK is split up into separate packages, all of which you can find in the [G
 ### Elixir (beta)
 
 [Source](https://github.com/kommitters/stellar_sdk) | [Docs](https://hexdocs.pm/stellar_sdk/readme.html) | [Examples](https://github.com/kommitters/stellar_sdk/blob/main/docs/examples.md)
+
+### PHP
+
+[Source](https://github.com/Soneso/stellar-php-sdk) | [Docs](https://github.com/Soneso/stellar-php-sdk#installation) | [Examples](https://github.com/Soneso/stellar-php-sdk/tree/main/examples)


### PR DESCRIPTION
The Soneso PHP Stellar SDK already has more than 1400 installations. Can you please add it to the list of sdks?