### PR TITLE
Update channel-accounts.mdx

### DIFF
--- a/docs/encyclopedia/channel-accounts.mdx
+++ b/docs/encyclopedia/channel-accounts.mdx
@@ -26,8 +26,10 @@ For example:
 // create payment from baseAccount to customerAddress
 var transaction = new StellarSdk.TransactionBuilder(
   channelAccounts[channelIndex],
-  {fee: StellarSdk.BASE_FEE, networkPassphrase: StellarSdk.Networks.TESTNET}
-)
+  {
+    fee: StellarSdk.BASE_FEE, 
+    networkPassphrase: StellarSdk.Networks.TESTNET
+  })
   .addOperation(
     StellarSdk.Operation.payment({
       source: baseAccount.address(),

--- a/docs/encyclopedia/channel-accounts.mdx
+++ b/docs/encyclopedia/channel-accounts.mdx
@@ -19,7 +19,6 @@ For example:
 <CodeExample>
 
 ```js
-StellarSdk.Network.useTestNetwork();
 // channelAccounts[] is an array of accountIDs, one for each channel
 // channelKeys[] is an array of secret keys, one for each channel
 // channelIndex is the channel you want to send this transaction over
@@ -27,6 +26,7 @@ StellarSdk.Network.useTestNetwork();
 // create payment from baseAccount to customerAddress
 var transaction = new StellarSdk.TransactionBuilder(
   channelAccounts[channelIndex],
+  {fee: StellarSdk.BASE_FEE, networkPassphrase: StellarSdk.Networks.TESTNET}
 )
   .addOperation(
     StellarSdk.Operation.payment({


### PR DESCRIPTION
Remove reference to deprecated `Network.useTestNetwork()` method in JS example of channel-accounts documentation:
* https://developers.stellar.org/docs/encyclopedia/channel-accounts