### PR TITLE
Fixing some code examples syntax languages

### DIFF
--- a/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
+++ b/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
@@ -34,11 +34,11 @@ In Horizon, assets are represented in a JSON object:
 
 ```json
 {
-  asset_code: "AstroDollar",
-  asset_issuer: "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF",
+  "asset_code": "AstroDollar",
+  "asset_issuer": "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF",
   // `asset_type` is used to determine how asset data is stored.
   // It can be `native` (lumens), `credit_alphanum4`, or `credit_alphanum12`.
-  asset_type: "credit_alphanum12",
+  "asset_type": "credit_alphanum12"
 }
 ```
 

--- a/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
+++ b/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
@@ -32,7 +32,7 @@ The public key of the issuing account is linked on the ledger to the asset. Resp
 
 In Horizon, assets are represented in a JSON object:
 
-```json5
+```json
 {
   asset_code: "AstroDollar",
   asset_issuer: "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF",

--- a/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
+++ b/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
@@ -34,11 +34,11 @@ In Horizon, assets are represented in a JSON object:
 
 ```json5
 {
-  "asset_code": "AstroDollar",
-  "asset_issuer": "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF",
+  asset_code: "AstroDollar",
+  asset_issuer: "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF",
   // `asset_type` is used to determine how asset data is stored.
   // It can be `native` (lumens), `credit_alphanum4`, or `credit_alphanum12`.
-  "asset_type": "credit_alphanum12"
+  asset_type: "credit_alphanum12",
 }
 ```
 

--- a/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
+++ b/docs/fundamentals-and-concepts/stellar-data-structures/assets.mdx
@@ -32,7 +32,7 @@ The public key of the issuing account is linked on the ledger to the asset. Resp
 
 In Horizon, assets are represented in a JSON object:
 
-```json
+```json5
 {
   "asset_code": "AstroDollar",
   "asset_issuer": "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF",

--- a/docs/tutorials/follow-received-payments.mdx
+++ b/docs/tutorials/follow-received-payments.mdx
@@ -53,7 +53,7 @@ Create a new file named `make_account.js` and paste the following text into it:
 
 <CodeExample>
 
-```javascript
+```js
 var Keypair = require("stellar-base").Keypair;
 
 var newAccount = Keypair.random();

--- a/docs/tutorials/moneygram-access-integration-guide.mdx
+++ b/docs/tutorials/moneygram-access-integration-guide.mdx
@@ -202,7 +202,7 @@ Below is a simple JavaScript example listening for a postmessage notification.
 
 <CodeExample>
 
-```javascript
+```js
 webview = window.open(moneygramURL, "webview", "width=500,height=800");
 window.addEventListener("message", closeWebView);
 


### PR DESCRIPTION
Found one that needed fixing, and then did a quick search for any others that might be wrong. Here's the three I found. No big impact, but will help to make the docs more consistent.

Using `javascript` rather than `js` rendered "Example" into the code snippet headers. Weird 🤷🏻‍♂️ 

Signed-off-by: Elliot Voris <elliot@voris.me>