### PR TITLE
Fixed 404 to source folder of XDR data structures

### DIFF
--- a/docs/encyclopedia/xdr.mdx
+++ b/docs/encyclopedia/xdr.mdx
@@ -16,4 +16,4 @@ Since XDR is a binary format and not as widely known as simpler formats like JSO
 
 In addition, the Horizon API server generally exposes the most important parts of the XDR data in JSON, so they are easier to parse if you are not using an SDK. The XDR data is still included (encoded as a base64 string) inside the JSON in case you need direct access to it. .X files
 
-Data structures in XDR are specified in an interface definition file (IDL). The IDL files used for the Stellar Network are available on [GitHub](https://github.com/stellar/stellar-core/tree/master/src/xdr).
+Data structures in XDR are specified in an interface definition file (IDL). The IDL files used for the Stellar Network are available on [GitHub](https://github.com/stellar/stellar-core/tree/master/src/protocol-curr/xdr).


### PR DESCRIPTION
The XDR encyclopedia was linking to this 404 Not Found: https://github.com/stellar/stellar-core/tree/master/src/xdr