### PR TITLE
Fix ElixirSDK Examples URL

### DIFF
--- a/docs/tools-and-sdks.mdx
+++ b/docs/tools-and-sdks.mdx
@@ -114,4 +114,4 @@ This SDK is split up into separate packages, all of which you can find in the [G
 
 ### Elixir (beta)
 
-[Source](https://github.com/kommitters/stellar_sdk) | [Docs](https://hexdocs.pm/stellar_sdk/readme.html) | [Examples](https://github.com/kommitters/stellar_sdk/blob/main/docs/examples.md)
+[Source](https://github.com/kommitters/stellar_sdk) | [Docs](https://hexdocs.pm/stellar_sdk/readme.html) | [Examples](https://github.com/kommitters/stellar_sdk/blob/main/docs)


### PR DESCRIPTION
### Description

A change in the Examples URL for the Elixir SDK is required.

Now the URL is not pointing to any specific file but only to the `docs/` folder.

Thanks! 👋🏻 