### PR TITLE
Improved clarity around establishing trustlines

### DIFF
--- a/docs/encyclopedia/claimable-balances.mdx
+++ b/docs/encyclopedia/claimable-balances.mdx
@@ -9,7 +9,7 @@ Claimable balances were introduced in [CAP-0023](https://github.com/stellar/stel
 - Part 1: sending account creates a payment, or ClaimableBalanceEntry, using the Create Claimable Balance operation
 - Part 2: destination account(s), or claimant(s), accepts the ClaimableBalanceEntry using the Claim Claimable Balance operation
 
-Claimable balances allow an account to send a payment to another account that is not necessarily prepared to receive the payment. They can be used when you send a non-native asset to an account that has not yet established a trustline, which can be useful for anchors onboarding new users. The trustline is established when the claimant(s) accept the claimable balance.
+Claimable balances allow an account to send a payment to another account that is not necessarily prepared to receive the payment. They can be used when you send a non-native asset to an account that has not yet established a trustline, which can be useful for anchors onboarding new users. A trustline must be established by the claimant to the asset before it can claim the claimable balance, otherwise, the claim will result in an `op_no_trust` error.
 
 It is important to note that if a claimable balance isn’t claimed, it sits on the ledger forever, taking up space and ultimately making the network less efficient. **For this reason, it is a good idea to put one of your own accounts as a claimant for a claimable balance.** Then you can accept your own claimable balance if needed, freeing up space on the network.
 
@@ -45,7 +45,7 @@ A successful Create Claimable Balance operation will return a Balance ID, which 
 
 For basic parameters, see the Claim Claimable Balance entry in our [List of Operations section](../fundamentals-and-concepts/list-of-operations#claim-claimable-balance).
 
-This operation will load the ClaimableBalanceEntry that corresponds to the Balance ID and then search for the source account of this operation in the list of claimants on the entry. If a match on the claimant is found, and the ClaimPredicate evaluates to true, then the ClaimableBalanceEntry can be claimed. The balance on the entry will be moved to the source account if there are no limit or trustline issues (for non-native assets).
+This operation will load the ClaimableBalanceEntry that corresponds to the Balance ID and then search for the source account of this operation in the list of claimants on the entry. If a match on the claimant is found, and the ClaimPredicate evaluates to true, then the ClaimableBalanceEntry can be claimed. The balance on the entry will be moved to the source account if there are no limit or trustline issues (for non-native assets), meaning the claimant must establish a trustline to the asset before claiming it. 
 
 ### Clawback Claimable Balance
 

--- a/docs/encyclopedia/claimable-balances.mdx
+++ b/docs/encyclopedia/claimable-balances.mdx
@@ -45,7 +45,7 @@ A successful Create Claimable Balance operation will return a Balance ID, which 
 
 For basic parameters, see the Claim Claimable Balance entry in our [List of Operations section](../fundamentals-and-concepts/list-of-operations#claim-claimable-balance).
 
-This operation will load the ClaimableBalanceEntry that corresponds to the Balance ID and then search for the source account of this operation in the list of claimants on the entry. If a match on the claimant is found, and the ClaimPredicate evaluates to true, then the ClaimableBalanceEntry can be claimed. The balance on the entry will be moved to the source account if there are no limit or trustline issues (for non-native assets), meaning the claimant must establish a trustline to the asset before claiming it. 
+This operation will load the ClaimableBalanceEntry that corresponds to the Balance ID and then search for the source account of this operation in the list of claimants on the entry. If a match on the claimant is found, and the ClaimPredicate evaluates to true, then the ClaimableBalanceEntry can be claimed. The balance on the entry will be moved to the source account if there are no limit or trustline issues (for non-native assets), meaning the claimant must establish a trustline to the asset before claiming it.
 
 ### Clawback Claimable Balance
 


### PR DESCRIPTION
Made it more clear that the claimant must establish a trustline to the claimable balance asset to claim it.