### PR TITLE
Update pubnet link in stellar documentation

### DIFF
--- a/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
+++ b/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
@@ -17,7 +17,7 @@ Stellar has two networks: the public network (pubnet, also called mainnet) and t
 ### Pubnet
 
 - Validator nodes are run by the public
-- SDF offers a free [Horizon instance](https://horizon-testnet.stellar.org/) to interact with the pubnet, or you can run your own
+- SDF offers a free [Horizon instance](https://horizon.stellar.org/) to interact with the pubnet, or you can run your own
 - You need to fund your account with XLM from another account
 - Pubnet is limited to 1,000 operations per ledger
 


### PR DESCRIPTION
Fixes wrong link to testnet when link should point to pubnet