### PR TITLE
2023 testnet reset dates

### DIFF
--- a/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
+++ b/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
@@ -31,12 +31,12 @@ If you are creating multiple testnet accounts, fund your first account with frie
 
 The testnet is reset periodically to the genesis ledger to declutter the network, remove spam, reduce the time needed to catch up on the latest ledger, and help maintain the system. Resets clear all ledger entries (accounts, trustlines, offers, etc.), transactions, and historical data from Stellar Core and Horizon- which is why developers should not rely on the persistence of accounts or the state of any balances when using testnet.
 
-Testnet resets happen once per quarter at 0900 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels. Here are the 2022 dates:
+Testnet resets happen once per quarter at 0900 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels. Here are the 2023 dates:
 
-3/16/2022  
-6/15/2022  
-9/14/2022  
-12/14/2022
+March 15, 2023  
+June 14, 2023 
+September 13, 2023  
+December 13, 2023
 
 If you run a testnet Horizon instance, you need to re-join and re-sync to the network after a reset. Check out how to do that here: [Testnet Reset](https://github.com/stellar/packages/blob/master/docs/testnet-reset.md).
 

--- a/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
+++ b/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
@@ -33,9 +33,9 @@ The testnet is reset periodically to the genesis ledger to declutter the network
 
 Testnet resets happen once per quarter at 0900 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels. Here are the 2023 dates:
 
-March 15, 2023  
-June 14, 2023 
-September 13, 2023  
+March 15, 2023
+June 14, 2023
+September 13, 2023
 December 13, 2023
 
 If you run a testnet Horizon instance, you need to re-join and re-sync to the network after a reset. Check out how to do that here: [Testnet Reset](https://github.com/stellar/packages/blob/master/docs/testnet-reset.md).

--- a/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
+++ b/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
@@ -33,9 +33,9 @@ The testnet is reset periodically to the genesis ledger to declutter the network
 
 Testnet resets happen once per quarter at 0900 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels. Here are the 2023 dates:
 
-March 15, 2023
-June 14, 2023
-September 13, 2023
+March 15, 2023  
+June 14, 2023  
+September 13, 2023  
 December 13, 2023
 
 If you run a testnet Horizon instance, you need to re-join and re-sync to the network after a reset. Check out how to do that here: [Testnet Reset](https://github.com/stellar/packages/blob/master/docs/testnet-reset.md).


### PR DESCRIPTION
Updated to include the Testnet reset dates for 2023.