### PR TITLE
update SEP-24 Anchor Platform guide to use yaml assets file

### DIFF
--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -139,12 +139,6 @@ Update the above values based on the assets you'll be issuing. Make sure to spec
 
 The information provided for the `assets` value closely maps to the information that will be expsosed to the wallet application using the [`GET /info`][sep24-get-info] SEP-24 endpoint. The Anchor Platform also uses this information to validate requests made to your service.
 
-:::note
-
-A future release of the Anchor Platform will support providing this JSON in a `.json` file or specifying this information in YAML format.
-
-:::
-
 ### Publish a Stellar Info File
 
 Next, let's enable applications to learn more about your service by hosting a `stellar.toml` file at a standardized URL path. This file allows applications to find information about your business, the assets your services utilize, as well as the root URL paths for these services. We can specify this file using the Anchor Platform.

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -60,73 +60,82 @@ A future release of the Anchor Platform will add an additional command line opti
 
 :::
 
-### Create a Configuration File
-
-The Anchor Platform supports two approaches for configuration: using environment variables or a YAML configuration file. While its possible to only use one of the two approaches, most deployments will use both due to each variable's value structure or security requirements.
-
-We'll use environment variables for most of our configuration and only use our YAML file when simple key-value pairs aren't a good way to represent our values.
-
-See the full set of configuration options in the Anchor Platform's [default values file][ap-default-values].
-
-Let's create a file for our environment variables and a directory containing our YAML configuration.
-
-<CodeExample>
+The Anchor Platform supports two approaches for configuration: using environment variables or a YAML configuration file. For example, enabling SEP-24 in the Anchor Platform using an environment variable would look like the following:
 
 ```bash
-touch dev.env
-mkdir config
-touch config/dev.config.yaml
+# dev.env
+SEP24_ENABLED=true
 ```
 
-</CodeExample>
-
-Add an environment variable that specifies the path to our YAML configuration file.
-
-<CodeExample>
+Alternatively, enabling SEP-24 using a yaml configuration file would look like the following:
 
 ```bash
 # dev.env
 ANCHOR_CONFIG_FILE=/home/dev.config.yaml
 ```
 
+```yaml
+# dev.config.yaml
+sep24:
+  enabled: true
+```
+
+Businesses are able to use one approach exclusively or a combination of both approaches. Nested variables in the YAML file are expressed using underscores or dots (`_`, `.`) when using environment variables. We'll use environment variables for our configuration in this guide.
+
+See the full set of configuration options in the Anchor Platform's [default values file][ap-default-values].
+
+### Specify Your Service's Assets
+
+Let's create a file for our environment variables, and a directory for containing files referenced in our environment.
+
+<CodeExample>
+
+```bash
+touch dev.env
+mkdir config
+touch config/dev.assets.yaml
+```
+
 </CodeExample>
 
-Specify the following in your `dev.config.yaml` file, and change the values depending on your preferences.
+The first we'll need to do is specify which assets our Anchor Platform deployment supports.
+
+<CodeExample>
+
+```bash
+# dev.env
+ASSETS_TYPE=file
+ASSETS_VALUE=/home/dev.assets.yaml
+```
+
+</CodeExample>
+
+Specify the following in your `dev.assets.yaml` file, and change the values depending on your preferences.
 
 <CodeExample>
 
 ```yaml
-# dev.config.yaml
-version: 1
-
+# dev.assets.yaml
 assets:
-  type: json
-  value: |
-    {
-        "assets": [
-          {
-            "schema": "stellar",
-            "code": "USDC",
-            "issuer": "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-            "distribution_account": "GBLSAHONJRODSFTLOV225NZR4LHICH63RIFQTQN37L5CRTR2IMQ5UEK7",
-            "significant_decimals": 2,
-            "deposit": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "withdraw": {
-              "enabled": true,
-              "min_amount": 1,
-              "max_amount": 1000000
-            },
-            "sep24_enabled": true
-          }
-        ]
-    }
+  - schema: stellar
+    code: USDC
+    issuer: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+    distribution_account: GBLSAHONJRODSFTLOV225NZR4LHICH63RIFQTQN37L5CRTR2IMQ5UEK7
+    significant_decimals: 2
+    deposit:
+      enabled: true
+      min_amount: 1
+      max_amount: 1000000
+    withdraw:
+      enabled: true
+      min_amount: 1
+      max_amount: 1000000
+    sep24_enabled: true
 ```
 
 </CodeExample>
+
+Update the above values based on the assets you'll be issuing. Make sure to specify the testnet `issuer` in your development file, and create your own `distribution_account` using a tool like [Stellar Lab][stellar-lab].
 
 The information provided for the `assets` value closely maps to the information that will be expsosed to the wallet application using the [`GET /info`][sep24-get-info] SEP-24 endpoint. The Anchor Platform also uses this information to validate requests made to your service.
 
@@ -257,7 +266,7 @@ Wallets should now be able to discover, authenticate, and initiate transactions 
 ├── dev.env
 ├── docker-compose.yaml
 ├── config
-│   ├── dev.config.yaml
+│   ├── dev.assets.yaml
 │   ├── dev.stellar.toml
 ```
 
@@ -269,7 +278,8 @@ Your environment should now look like the following.
 
 ```bash
 # dev.env
-ANCHOR_CONFIG_FILE=/home/dev.config.yaml
+ASSETS_TYPE=file
+ASSETS_VALUE=/home/dev.assets.yaml
 
 SEP1_ENABLED=true
 SEP1_TYPE=file
@@ -828,3 +838,4 @@ Let's make some additions to the `server.js` file so we can poll the Anchor Plat
 [nginx]: https://www.nginx.com/
 [ap-default-values]: https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/platform/src/main/resources/config/anchor-config-default-values.yaml
 [stellar-demo-wallet]: https://demo-wallet.stellar.org
+[stellar-lab]: https://laboratory.stellar.org/


### PR DESCRIPTION
The Anchor Platform added support for specifying asset data via YAML files. This PR update the guide to use this approach.

<a href="https://gitpod.io/#https://github.com/stellar/stellar-docs/pull/81"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

