### PR TITLE
Update anchor platform guide on flyway migrations

### DIFF
--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -309,7 +309,7 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 
 ### Add Data Persistence
 
-The Anchor Platform supports [PostgreSQL][postgresql] and [Aurora PosgreSQL][aurora] for use in production, but also supports [H2][h2] or [SQLite][sqlite] for use in development. For managing migrations, the Anchor Platform uses [Flyway][flyway].
+The Anchor Platform supports [PostgreSQL][postgresql] and [Aurora PostgreSQL][aurora] for use in production, but also supports [H2][h2] or [SQLite][sqlite] for use in development. For managing migrations, the Anchor Platform uses [Flyway][flyway].
 
 Before we move forward, let's add a database to our development environment so the transactions we initiate persist after stopping the service.
 

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -311,7 +311,7 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 
 The Anchor Platform supports [PostgreSQL][postgresql] and [Aurora PosgreSQL][aurora] for use in production, but also supports [H2][h2] or [SQLite][sqlite] for use in development. For managing migrations, the Anchor Platform uses [Flyway][flyway].
 
-Before we move forward, let's add a database to our development environment so the transactions we initiate persist after stopping the service. 
+Before we move forward, let's add a database to our development environment so the transactions we initiate persist after stopping the service.
 
 <CodeExample>
 

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -98,7 +98,7 @@ touch config/dev.assets.yaml
 
 </CodeExample>
 
-The first we'll need to do is specify which assets our Anchor Platform deployment supports.
+The first thing we'll need to do is specify which assets our Anchor Platform deployment supports.
 
 <CodeExample>
 
@@ -141,7 +141,7 @@ The information provided for the `assets` value closely maps to the information 
 
 ### Publish a Stellar Info File
 
-Next, let's enable applications to learn more about your service by hosting a `stellar.toml` file at a standardized URL path. This file allows applications to find information about your business, the assets your services utilize, as well as the root URL paths for these services. We can specify this file using the Anchor Platform.
+Next, let's enable applications to learn more about your service by hosting a `stellar.toml` file at a standardized URL path. This file allows applications to find information about your business, the assets your services utilize, as well as the root URL paths for these services. We can host this file using the Anchor Platform.
 
 Let's create a file called `dev.stellar.toml` file using the contents below as a starting point. For the full set of attributes, see the [SEP-1 specification][sep-1].
 
@@ -309,7 +309,9 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 
 ### Add Data Persistence
 
-Before we move forward, let's add a database to our development environment so the transactions we initiate persist after stopping the service.
+The Anchor Platform supports [PostgreSQL][postgresql] and [Aurora PosgreSQL][aurora] for use in production, but also supports [H2][h2] or [SQLite][sqlite] for use in development. For managing migrations, the Anchor Platform uses [Flyway][flyway].
+
+Before we move forward, let's add a database to our development environment so the transactions we initiate persist after stopping the service. 
 
 <CodeExample>
 
@@ -347,9 +349,9 @@ Now let's update our environment so the platform server can connect to the datab
 DATA_TYPE=postgres
 DATA_SERVER=db
 DATA_DATABASE=platform
-DATA_FLYWAY_ENABLED=false
 SECRET_DATA_USERNAME=postgres
 SECRET_DATA_PASSWORD=password
+DATA_FLYWAY_ENABLED=true
 
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
@@ -833,3 +835,8 @@ Let's make some additions to the `server.js` file so we can poll the Anchor Plat
 [ap-default-values]: https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/platform/src/main/resources/config/anchor-config-default-values.yaml
 [stellar-demo-wallet]: https://demo-wallet.stellar.org
 [stellar-lab]: https://laboratory.stellar.org/
+[postgresql]: https://www.postgresql.org/
+[aurora-postgresql]: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraPostgreSQL.html
+[h2]: https://www.h2database.com/html/main.html
+[sqlite]: https://www.sqlite.org/index.html
+[flyway]: https://documentation.red-gate.com/fd/welcome-to-flyway-184127914.html

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -309,7 +309,7 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 
 ### Add Data Persistence
 
-The Anchor Platform supports [PostgreSQL][postgresql] and [Aurora PostgreSQL][aurora] for use in production, but also supports [H2][h2] or [SQLite][sqlite] for use in development. For managing migrations, the Anchor Platform uses [Flyway][flyway].
+The Anchor Platform supports [PostgreSQL][postgresql] and [Aurora PostgreSQL][aurora-postgresql] for use in production, but also supports [H2][h2] or [SQLite][sqlite] for use in development. For managing migrations, the Anchor Platform uses [Flyway][flyway].
 
 Before we move forward, let's add a database to our development environment so the transactions we initiate persist after stopping the service.
 


### PR DESCRIPTION
Updates `DATA_FLYWAY_ENABLED` to `true` and adds some more information on what databases are supported.

<a href="https://gitpod.io/#https://github.com/stellar/stellar-docs/pull/82"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

