### PR TITLE
update anchor platform to use JWT's sub value

### DIFF
--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -423,8 +423,7 @@ The Anchor Platform adds a JWT `token` query parameter to the business' URL give
 
 1. Pass the `token` added to the URL of your backend system
 2. Verify the signature on the `token` and check its expiration
-3. Fetch the transaction data using the token's `jti` from the Anchor Platform
-4. Create an authenticated session for the user identified in the transaction
+3. Create an authenticated session for the user identified in the transaction
 
 The decoded contents of the `token` will look something like this:
 

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -538,8 +538,8 @@ const sessions = {};
  * Create an authenticated session for the user.
  *
  * Return a session token to be used in future requests as well as the
- * user data. Note that you may not have a user for the stellar account 
- * provided, in which case the user should go through your onboarding 
+ * user data. Note that you may not have a user for the stellar account
+ * provided, in which case the user should go through your onboarding
  * process.
  */
 app.post("/session", async (req, res) => {

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -698,7 +698,7 @@ function validateSessionToken(authorizationHeader) {
     } catch {
         throw "invalid session token";
     }
-    if (sessions[sessionToken]) {
+    if (!sessions[sessionToken]) {
         throw "expired session";
     }
     return sessionToken;

--- a/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep24-user-guide.mdx
@@ -533,15 +533,15 @@ app.use(express.json());
  * We'll store user session data in memory, but production systems
  * should store this data somewhere more persistent.
  */
-const sessions = new Set();
+const sessions = {};
 
 /*
  * Create an authenticated session for the user.
  *
  * Return a session token to be used in future requests as well as the
- * transaction and user data. Note that you may not have a user for the
- * stellar account provided, in which case the user should go through
- * your onboarding process.
+ * user data. Note that you may not have a user for the stellar account 
+ * provided, in which case the user should go through your onboarding 
+ * process.
  */
 app.post("/session", async (req, res) => {
   let decodedPlatformToken;
@@ -552,23 +552,15 @@ app.post("/session", async (req, res) => {
     res.send({ "error": err });
     return;
   }
-  let platformTransaction;
-  try {
-    platformTransaction = await getPlatformTransaction(decodedPlatformToken.jti);
-  } catch (err) {
-    res.status = 500;
-    res.send({ "error": err })
-    return;
-  }
+  let user = getUser(decodedPlatformToken.sub);
   let sessionToken = jwt.sign(
-    { "jti": platformTransaction.id },
+    { "jti": decodedPlatformToken.jti },
     process.env.SESSION_JWT_SECRET
   );
-  sessions.add(sessionToken)
+  sessions[sessionToken] = user;
   res.send({
     "token": sessionToken,
-    "transaction": platformTransaction,
-    "user": getUser(decodedPlatformToken.sub)
+    "user": user
   });
 });
 
@@ -589,19 +581,6 @@ function validatePlatformToken(token) {
     throw "invalid 'platformToken': missing 'jti'";
   }
   return decodedToken;
-}
-
-/*
- * Fetch the transaction data from the Platform API
- *
- * Production systems should have proper retry mechanisms.
- */
-async function getPlatformTransaction(transactionId) {
-  let response = await fetch(`${process.env.PLATFORM_SERVER}/transactions/${transactionId}`)
-  if (response.status != 200) {
-    throw `unexpected status code: ${response.status}`;
-  }
-  return await response.json();
 }
 
 /*
@@ -719,7 +698,7 @@ function validateSessionToken(authorizationHeader) {
     } catch {
         throw "invalid session token";
     }
-    if (!sessions.has(sessionToken)) {
+    if (sessions[sessionToken]) {
         throw "expired session";
     }
     return sessionToken;
@@ -803,6 +782,19 @@ Let's make some additions to the `server.js` file so we can poll the Anchor Plat
 ```js
 # server.js
 ...
+/*
+ * Fetch the transaction data from the Platform API
+ *
+ * Production systems should have proper retry mechanisms.
+ */
+async function getPlatformTransaction(transactionId) {
+  let response = await fetch(`${process.env.PLATFORM_SERVER}/transactions/${transactionId}`)
+  if (response.status != 200) {
+    throw `unexpected status code: ${response.status}`;
+  }
+  return await response.json();
+}
+
 (async () => {
   while (true) {
     await new Promise(r => setTimeout(r, 2000));


### PR DESCRIPTION
Updates the SEP-24 Anchor Platform guide by utilizing the `sub` value of the Anchor Platform's JWT added to the interactive URL. This attribute allows businesses to fetch their user record without having to fetch the transaction object using the Platform API prior, simplifying the authentication step.

<a href="https://gitpod.io/#https://github.com/stellar/stellar-docs/pull/85"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

