### PR TITLE
Remove CATCHUP_RECENT recommendation when reaping history

### DIFF
--- a/docs/run-api-server/ingestion.mdx
+++ b/docs/run-api-server/ingestion.mdx
@@ -83,8 +83,6 @@ stellar-horizon db reap
 
 </CodeExample>
 
-If you configure this parameter, we also recommend [configuring](./configuring.mdx#configuring-captive-core) the `CATCHUP_RECENT` value for your Captive Core instance.
-
 ### Common Issues
 
 Ingestion is a complicated process, so there are a number of things to look out for.


### PR DESCRIPTION
We don't recommend this, and several partners have reached out having been misled by this