### PR TITLE
Fix the SEP1 configurations of the CodeExample

### DIFF
--- a/docs/anchoring-assets/anchor-platform/sep1/configuration.mdx
+++ b/docs/anchoring-assets/anchor-platform/sep1/configuration.mdx
@@ -34,8 +34,8 @@ In your `dev.env` file, specify the following.
 ```bash
 # dev.env
 SEP1_ENABLED=true
-SEP1_TYPE=file
-SEP1_VALUE=/home/dev.stellar.toml
+SEP1_TOML_TYPE=file
+SEP1_TOML_VALUE=/home/dev.stellar.toml
 ```
 
 </CodeExample>


### PR DESCRIPTION
- `SEP1_TYPE` should be `SEP1_TOML_TYPE`.
- `SEP1_VALUE` should be `SEP1_TOML_VALUE`.

This is to be merged after https://github.com/stellar/java-stellar-anchor-sdk/pull/883 is merged and new Anchor Platform release is published.
