### PR TITLE
Fixing `*` parsing in Markdown on federation page

### DIFF
--- a/docs/encyclopedia/federation.mdx
+++ b/docs/encyclopedia/federation.mdx
@@ -6,7 +6,7 @@ The [Stellar federation protocol](https://github.com/stellar/stellar-protocol/bl
 
 ## Federated addresses
 
-Stellar federated addresses are divided into two parts separated by *: the username and the domain. For example: `jed*stellar.org:`
+Stellar federated addresses are divided into two parts separated by the asterisk character (`*`): the username and the domain. For example: `jed*stellar.org:`
 
 - `jed` is the username
 - `stellar.org` is the domain
@@ -39,14 +39,10 @@ Federation requests are http GET requests with the following form:
 
 Supported types:
 
-- Name  
-  Example: https://YOUR_FEDERATION_SERVER/federation?q=jed\*stellar.org&type=name
-- Forward  
-  Used for forwarding the payment to a different network or different financial institution. The other parameters of the query will vary depending on what kind of institution is the ultimate destination of the payment and what you as the forwarding anchor supports. Your stellar.toml file should specify what parameters you expect in a forward federation request. If you are unable to forward or the other parameters in the request are incorrect you should return an error to this effect. Example request: https://YOUR_FEDERATION_SERVER/federation?type=forward&forward_type=bank_account&swift=BOPBPHMM&acct=2382376
-- Id  
-  Not supported by all federation servers. Reverse federation will return the federation record of the Stellar address associated with the given account ID. In some cases, this is ambiguous. For instance, if an anchor sends transactions on behalf of its users, the account id will be of the anchor, and the federation server won’t be able to resolve the particular user that sent the transaction. In cases like that, you may need to use txid instead. Example: https://YOUR_FEDERATION_SERVER/federation?q=GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD&type=id
-- Txid  
-  Not supported by all federation servers. Will return the federation record of the sender of the transaction if known by the server. Example: https://YOUR_FEDERATION_SERVER/federation?q=c1b368c00e9852351361e07cc58c54277e7a6366580044ab152b8db9cd8ec52a&type=txid
+- Name Example: https://YOUR_FEDERATION_SERVER/federation?q=jed\*stellar.org&type=name
+- Forward Used for forwarding the payment to a different network or different financial institution. The other parameters of the query will vary depending on what kind of institution is the ultimate destination of the payment and what you as the forwarding anchor supports. Your stellar.toml file should specify what parameters you expect in a forward federation request. If you are unable to forward or the other parameters in the request are incorrect you should return an error to this effect. Example request: https://YOUR_FEDERATION_SERVER/federation?type=forward&forward_type=bank_account&swift=BOPBPHMM&acct=2382376
+- Id Not supported by all federation servers. Reverse federation will return the federation record of the Stellar address associated with the given account ID. In some cases, this is ambiguous. For instance, if an anchor sends transactions on behalf of its users, the account id will be of the anchor, and the federation server won’t be able to resolve the particular user that sent the transaction. In cases like that, you may need to use txid instead. Example: https://YOUR_FEDERATION_SERVER/federation?q=GD6WU64OEP5C4LRBH6NK3MHYIA2ADN6K6II6EXPNVUR3ERBXT4AN4ACD&type=id
+- Txid Not supported by all federation servers. Will return the federation record of the sender of the transaction if known by the server. Example: https://YOUR_FEDERATION_SERVER/federation?q=c1b368c00e9852351361e07cc58c54277e7a6366580044ab152b8db9cd8ec52a&type=txid
 
 ## Federation Response
 


### PR DESCRIPTION
The federation encyclopedia entry has an errant `*` that is being parsed as a Markdown italics formatter: https://developers.stellar.org/docs/encyclopedia/federation#supporting-federation

This commit fixes that bug, and also cleans up a bit of the language surrounding it.