### PR TITLE
Remove the explicit on-disk mode setting from Horizon configuration

### DIFF
--- a/docs/run-api-server/configuring.mdx
+++ b/docs/run-api-server/configuring.mdx
@@ -46,13 +46,11 @@ As outlined at the beginning, we presume you are interested in starting an inges
 | --- | --- | --- |
 | `--captive-core-config-path` | `CAPTIVE_CORE_CONFIG_PATH` | /etc/default/stellar-captive-core.toml |
 | `--stellar-core-binary-path` | `STELLAR_CORE_BINARY_PATH` | /usr/bin/stellar-core |
-| `--captive-core-use-db` | `CAPTIVE_CORE_USE_DB` | true |
 
 Note that **ingestion is enabled by default**.
 
 - The first parameter, `--captive-core-config-path`, points to a Captive Core configuration file. This TOML file only requires a few fields (explained [below](#configuring-captive-core)) to get up and running.
 - The second parameter, `--stellar-core-binary-path`, is a filesystem path to a Stellar Core binary. Horizon will actually search your PATH for `stellar-core` by default, so if your environment is configured appropriately, you don't need to pass this.
-- The third parameter, `--captive-core-use-db`, by default this value is false, which means Captive Core ingestion will run with ledger states stored in RAM. When set to true, enables Captive Core ingestion to store ledger states in local SQLite database rather than in memory (RAM). As of this writing, ledger states require approximately 8GB, but this will continue to increase as the ledger grows over time. The database location is determined by the `DATABASE` parameter within the `--captive-core-config-path` file. By default, it is set to `sqlite3://stellar.db`, which resolves to runtime directory location derived from `--captive-core-storage-path`.
 
 #### Without Ingestion
 

--- a/docs/run-api-server/ingestion.mdx
+++ b/docs/run-api-server/ingestion.mdx
@@ -167,9 +167,6 @@ export RETRY_BACKOFF_SECONDS=20
 # If not enabled, stellar-horizon would download data in the current working directory.
 # export CAPTIVE_CORE_STORAGE_PATH="/var/lib/stellar"
 
-# For stellar-horizon to use local disk file for ledger states rather than in memory(RAM), approximately
-# 8GB of space and increasing as size of ledger entries grows over time.
-# export CAPTIVE_CORE_USE_DB=true
 ```
 
 </CodeExample>


### PR DESCRIPTION
### What
Modify the horizon configuration section to remove explicitly setting the CAPTIVE_CORE_USE_DB flag as by default it will be set.

### Why
Fixes [4856](https://github.com/stellar/go/issues/4856)