### PR TITLE
Add Hubble Docs

### DIFF
--- a/docs/accessing-data/_category_.json
+++ b/docs/accessing-data/_category_.json
@@ -2,7 +2,7 @@
     "position": 80,
     "label": "Accessing Historical Data",
     "link": {
-      "type": "doc", "id": "index"
+      "type": "generated-index"
     }
   }
   

--- a/docs/accessing-data/_category_.json
+++ b/docs/accessing-data/_category_.json
@@ -1,0 +1,8 @@
+{
+    "position": 80,
+    "label": "Accessing Historical Data",
+    "link": {
+      "type": "doc", "id": "index"
+    }
+  }
+  

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -21,7 +21,11 @@ Google does provide a BigQuery Sandbox for free that allows users to explore dat
 2. This will open the public dataset `crypto_stellar`, where you can browse its contents in the **Explorer** pane.
 3. Click the **star** icon in the Explorer pane. This will favorite the dataset for you. More detailed information about starring resources can be found [here](https://cloud.google.com/bigquery/docs/bigquery-web-ui#star_resources).
 
-:::note Hubble cannot be found from the Explorer pane! You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar). :::
+:::note
+
+Hubble cannot be found from the Explorer pane! You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
+
+:::
 
 Copy and paste the following example query in the Editor:
 

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -43,13 +43,17 @@ This query will return the XLM balances for all Stellar wallet addresses, ordere
 
 There are multiple [BigQuery API Client Libraries](https://cloud.google.com/bigquery/docs/reference/libraries) available.
 
-The following example uses Python to access the Hubble dataset.
+The following example uses Python to access the Hubble dataset. Use [this guide](https://cloud.google.com/python/docs/setup) for help setting up a python development environment.
 
 Install the client library locally, and configure your environment to use your Google Cloud Project:
 
 <CodeExample>
 
 ```bash
+# verify python version
+python3 --version
+# if you do not have pip, install it
+python -m pip install --upgrade pip
 pip install --upgrade google-cloud-bigquery
 gcloud config set project PROJECT_ID
 ```
@@ -79,7 +83,7 @@ for table in tables:
 
 </CodeExample>
 
-Run the example below to show how to run a query and print the results:
+Run the example below to run a query and print the results:
 
 <CodeExample>
 
@@ -129,6 +133,6 @@ To connect Hubble as a data source:
 
 And you're connected!
 
-General information about Looker Studio can be found [here](https://support.google.com/looker-studio/?hl=en#topic=6267740).
+General information about Looker Studio can be found [here](https://support.google.com/looker-studio/).
 
 General information about connecting data sources can be found [here](https://support.google.com/looker-studio/topic/6370331?hl=en&ref_topic=7441382&sjid=14945902445646860578-NA).

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -96,7 +96,8 @@ SELECT
  account_id,
  balance,
 FROM `crypto-stellar.crypto_stellar.accounts_current`
-ORDER BY balance DESC;
+ORDER BY balance DESC
+LIMIT 10;
 """
 
 # Make an API request

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -1,0 +1,135 @@
+---
+title: "Connecting"
+sidebar_position: 10
+---
+
+BigQuery offers multiple connection methods to the Hubble dataset. This guide details three common methods:
+
+- [BigQuery UI](#bigquery-ui) - analysts that need to perform ad hoc analysis using SQL
+- [BigQuery SDK](#bigquery-sdk) - developers that need to integrate data into applications
+- [Looker Studio](#looker-studio) - business people that need to visualize data
+
+## Prerequisites
+
+To access the Hubble dataset, you will need a Google Cloud Project with billing and the BigQuery API enabled. For more information, please follow the instructions provided by [Google Cloud](https://cloud.google.com/bigquery/docs/quickstarts/query-public-dataset-console). 
+
+Google does provide a BigQuery Sandbox for free that allows users to explore datasets in a limited capacity. 
+
+## BigQuery UI
+
+1. From a browser, open the [crypto-stellar.crypto_stellar](http://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar) dataset.
+2. This will open the public dataset `crypto_stellar`, where you can browse its contents in the **Explorer** pane.
+3. Click the **star** icon in the Explorer pane. This will favorite the dataset for you. More detailed information about starring resources can be found [here](https://cloud.google.com/bigquery/docs/bigquery-web-ui#star_resources).
+
+
+> **_Caution:_**  Hubble cannot be found directly from the Explorer pane! <br />
+> You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
+
+Copy and paste the following example query in the Editor:
+
+<CodeExample>
+
+```sql
+select
+  account_id,
+  balance
+from `crypto-stellar.crypto_stellar.accounts_current`
+order by balance desc;
+```
+
+</CodeExample>
+
+This query will return the XLM balances for all Stellar wallet addresses, ordered from largest to smallest amounts.
+
+## BigQuery SDK
+
+There are multiple [BigQuery API Client Libraries](https://cloud.google.com/bigquery/docs/reference/libraries) available.
+
+The following example uses Python to access the Hubble dataset.
+
+Install the client library locally, and configure your environment to use your Google Cloud Project:
+
+<CodeExample>
+
+```bash
+pip install --upgrade google-cloud-bigquery
+gcloud config set project PROJECT_ID
+```
+
+</CodeExample>
+
+Use the Python Interpreter to run the example below to list the tables available in Hubble:
+
+<CodeExample>
+
+```python
+from google.cloud import bigquery
+
+# Construct a BigQuery client object.
+client = bigquery.Client()
+
+dataset_id = 'crypto-stellar.crypto_stellar'
+
+# Make an API request
+tables = client.list_tables(dataset_id)
+
+# List the tables found in Hubble
+print(f'Tables contained in {dataset_id}':)
+for table in tables:
+    print(f'{table.project}.{table.dataset_id}.{table.table_id}')
+```
+
+</CodeExample>
+
+Run the example below to show how to run a query and print the results:
+
+<CodeExample>
+
+```python
+from google.cloud import bigquery
+
+# Construct a BigQuery client object.
+client = bigquery.Client()
+
+query = """
+SELECT
+ account_id,
+ balance,
+FROM `crypto-stellar.crypto_stellar.accounts_current`
+ORDER BY balance DESC;
+"""
+
+# Make an API request
+query_job = client.query(query)
+
+print("The query data:")
+for row in query_job:
+    # Row values can be accessed by field name or index.
+    print(f'account_id={row[0]}, balance={row["balance"]}')
+```
+
+</CodeExample>
+
+There are various ways to extract and load data using BigQuery. See the [BigQuery Client Documentation](https://cloud.google.com/python/docs/reference/bigquery/latest/google.cloud.bigquery.client.Client) for more information.
+
+## Looker Studio
+
+[Looker Studio](https://cloud.google.com/looker-studio) is a business intelligence tool that can be used to connect to and visualize data from the Hubble dataset.
+
+To connect Hubble as a data source:
+
+1. Open [Looker Studio](https://lookerstudio.google.com/)
+2. Click on **Create** > **Data Source**
+3. Search for the BigQuery connector
+4. *(Optional)* Change the name of the data source at the top of the webpage
+5. Click *Shared Projects* > Select your Google Cloud Project
+6. Enter `crypto-stellar` as the Shared Project name
+7. Click on the Dataset `crypto_stellar`
+8. Select the desired table to connect 
+9. Click `CONNECT` on the top right of the webpage.
+
+And you're connected!
+
+General information about Looker Studio can be found [here](https://support.google.com/looker-studio/?hl=en#topic=6267740).
+
+General information about connecting data sources can be found [here](https://support.google.com/looker-studio/topic/6370331?hl=en&ref_topic=7441382&sjid=14945902445646860578-NA).

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -3,7 +3,7 @@ title: "Connecting"
 sidebar_position: 10
 ---
 
-BigQuery offers multiple connection methods to the Hubble dataset. This guide details three common methods:
+BigQuery offers multiple connection methods to Hubble. This guide details three common methods:
 
 - [BigQuery UI](#bigquery-ui) - analysts that need to perform ad hoc analysis using SQL
 - [BigQuery SDK](#bigquery-sdk) - developers that need to integrate data into applications
@@ -11,7 +11,7 @@ BigQuery offers multiple connection methods to the Hubble dataset. This guide de
 
 ## Prerequisites
 
-To access the Hubble dataset, you will need a Google Cloud Project with billing and the BigQuery API enabled. For more information, please follow the instructions provided by [Google Cloud](https://cloud.google.com/bigquery/docs/quickstarts/query-public-dataset-console).
+To access Hubble, you will need a Google Cloud Project with billing and the BigQuery API enabled. For more information, please follow the instructions provided by [Google Cloud](https://cloud.google.com/bigquery/docs/quickstarts/query-public-dataset-console).
 
 Google does provide a BigQuery Sandbox for free that allows users to explore datasets in a limited capacity.
 
@@ -58,6 +58,8 @@ Install the client library locally, and configure your environment to use your G
 python3 --version
 # if you do not have pip, install it
 python -m pip install --upgrade pip
+
+# install bigquery client library
 pip install --upgrade google-cloud-bigquery
 gcloud config set project PROJECT_ID
 ```

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -21,7 +21,9 @@ Google does provide a BigQuery Sandbox for free that allows users to explore dat
 2. This will open the public dataset `crypto_stellar`, where you can browse its contents in the **Explorer** pane.
 3. Click the **star** icon in the Explorer pane. This will favorite the dataset for you. More detailed information about starring resources can be found [here](https://cloud.google.com/bigquery/docs/bigquery-web-ui#star_resources).
 
-> **_Caution:_** Hubble cannot be found directly from the Explorer pane! <br /> You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
+:::note
+Hubble cannot be found from the Explorer pane! You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
+:::
 
 Copy and paste the following example query in the Editor:
 

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -21,9 +21,7 @@ Google does provide a BigQuery Sandbox for free that allows users to explore dat
 2. This will open the public dataset `crypto_stellar`, where you can browse its contents in the **Explorer** pane.
 3. Click the **star** icon in the Explorer pane. This will favorite the dataset for you. More detailed information about starring resources can be found [here](https://cloud.google.com/bigquery/docs/bigquery-web-ui#star_resources).
 
-:::note
-Hubble cannot be found from the Explorer pane! You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
-:::
+:::note Hubble cannot be found from the Explorer pane! You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar). :::
 
 Copy and paste the following example query in the Editor:
 

--- a/docs/accessing-data/connecting.mdx
+++ b/docs/accessing-data/connecting.mdx
@@ -11,9 +11,9 @@ BigQuery offers multiple connection methods to the Hubble dataset. This guide de
 
 ## Prerequisites
 
-To access the Hubble dataset, you will need a Google Cloud Project with billing and the BigQuery API enabled. For more information, please follow the instructions provided by [Google Cloud](https://cloud.google.com/bigquery/docs/quickstarts/query-public-dataset-console). 
+To access the Hubble dataset, you will need a Google Cloud Project with billing and the BigQuery API enabled. For more information, please follow the instructions provided by [Google Cloud](https://cloud.google.com/bigquery/docs/quickstarts/query-public-dataset-console).
 
-Google does provide a BigQuery Sandbox for free that allows users to explore datasets in a limited capacity. 
+Google does provide a BigQuery Sandbox for free that allows users to explore datasets in a limited capacity.
 
 ## BigQuery UI
 
@@ -21,9 +21,7 @@ Google does provide a BigQuery Sandbox for free that allows users to explore dat
 2. This will open the public dataset `crypto_stellar`, where you can browse its contents in the **Explorer** pane.
 3. Click the **star** icon in the Explorer pane. This will favorite the dataset for you. More detailed information about starring resources can be found [here](https://cloud.google.com/bigquery/docs/bigquery-web-ui#star_resources).
 
-
-> **_Caution:_**  Hubble cannot be found directly from the Explorer pane! <br />
-> You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
+> **_Caution:_** Hubble cannot be found directly from the Explorer pane! <br /> You cannot search for the dataset. To view the dataset, you **must** use the [dataset link](https://console.cloud.google.com/bigquery?ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar).
 
 Copy and paste the following example query in the Editor:
 
@@ -122,11 +120,11 @@ To connect Hubble as a data source:
 1. Open [Looker Studio](https://lookerstudio.google.com/)
 2. Click on **Create** > **Data Source**
 3. Search for the BigQuery connector
-4. *(Optional)* Change the name of the data source at the top of the webpage
-5. Click *Shared Projects* > Select your Google Cloud Project
+4. _(Optional)_ Change the name of the data source at the top of the webpage
+5. Click _Shared Projects_ > Select your Google Cloud Project
 6. Enter `crypto-stellar` as the Shared Project name
 7. Click on the Dataset `crypto_stellar`
-8. Select the desired table to connect 
+8. Select the desired table to connect
 9. Click `CONNECT` on the top right of the webpage.
 
 And you're connected!

--- a/docs/accessing-data/index.mdx
+++ b/docs/accessing-data/index.mdx
@@ -21,11 +21,10 @@ Users should be aware of the following limitations:
 
 ## Why We Chose BigQuery
 
-BigQuery is Google Cloud’s data warehouse that comes with some key features that fulfill Stellar’s analytic needs. 
+BigQuery is Google Cloud’s data warehouse that comes with some key features that fulfill Stellar’s analytic needs.
 
-First, BigQuery allows anyone to make a dataset publicly available. This means that the SDF can contribute open source repositories to build and maintain a data warehouse and also host a public instance. 
+First, BigQuery allows anyone to make a dataset publicly available. This means that the SDF can contribute open source repositories to build and maintain a data warehouse and also host a public instance.
 
 BigQuery also separates storage from compute, which makes it sustainable to host a public instance. The maintainer only has to pay the cost of storage without incurring the cost of the analytics running on the dataset.
 
 Most importantly, BigQuery is the de facto platform for blockchain datasets. By selecting BigQuery, Stellar Network data is located with other blockchain data, which allows for cross-chain analytics.
-

--- a/docs/accessing-data/index.mdx
+++ b/docs/accessing-data/index.mdx
@@ -1,0 +1,31 @@
+---
+title: "Overview"
+sidebar_position: 0
+---
+
+Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.
+
+This guide describes when to use Hubble and how to connect. For more information regarding underlying data structures, queries and examples, please refer to the Hubble Technical Docs under APIs.
+
+## Why Use Hubble?
+
+Some questions are hard to answer with the Horizon API and its underlying PostgreSQL database. This is because its infrastructure is optimized for quick database reads and writes so that it can process online transactions. Horizon can accurately store the results of these smaller transactions, however it sacrifices the ability to execute complex queries easily. The Stellar Network’s data footprint has also increased exponentially, which is creating space constraints and performance issues for Horizon instances that store the full historical record.
+
+This is where Hubble comes in. It is optimized to execute complex queries and scan large amounts of data. Hubble can store orders of magnitude more data than Horizon and will not run into the same storage constraints. Queries that require pagination in Horizon or timeout can be returned in a single query. Hubble empowers users to explore, analyze, and derive meaningful conclusions from the data without the burden of maintaining a database.
+
+Users should be aware of the following limitations:
+
+- Hubble is read-only; it cannot interact with the Stellar Network.
+- The database is updated in intraday batches. There is no guarantee for same-day data availability.
+- The SDF hosts a public instance of Hubble, and end users incur the cost to execute queries. Visit the [BigQuery Pricing Page](https://cloud.google.com/bigquery/pricing#analysis_pricing_models) to learn more.
+
+## Why We Chose BigQuery
+
+BigQuery is Google Cloud’s data warehouse that comes with some key features that fulfill Stellar’s analytic needs. 
+
+First, BigQuery allows anyone to make a dataset publicly available. This means that the SDF can contribute open source repositories to build and maintain a data warehouse and also host a public instance. 
+
+BigQuery also separates storage from compute, which makes it sustainable to host a public instance. The maintainer only has to pay the cost of storage without incurring the cost of the analytics running on the dataset.
+
+Most importantly, BigQuery is the de facto platform for blockchain datasets. By selecting BigQuery, Stellar Network data is located with other blockchain data, which allows for cross-chain analytics.
+

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -162,9 +162,9 @@ If you need to estimate costs before running a query, there are several options 
 
 The BigQuery Console comes with a built-in query validator. It verifies query syntax and provides an estimate of the number of bytes processed. The validator can be found in the upper right hand corner of the Query Editor, next to the green checkmark.
 
-To calculate the query cost, convert the number of bytes processed into terabytes, and multiply the result by $5: 
+To calculate the query cost, convert the number of bytes processed into terabytes, and multiply the result by $5:
 
-`(estimated bytes read / 1TB) *  $5`
+`(estimated bytes read / 1TB) * $5`
 
 Paste the following query into the Editor to view the estimated bytes processed.
 
@@ -185,7 +185,7 @@ group by month
 
 The validator estimates that 51.95MB of data will be read.
 
-0.00005195 TB * $5 = $0.000259. _That’s a cheap query!_
+0.00005195 TB \* $5 = $0.000259. _That’s a cheap query!_
 
 ### dryRun Config Parameter
 

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -1,0 +1,195 @@
+---
+title: "Optimizing Queries"
+sidebar_position: 30
+---
+
+Hubble has terabytes of data to explore&mdash;that’s a lot of data! With access to so much data at your fingertips, it is crucial to performance-tune your queries.
+
+One of the strengths of BigQuery is also its pitfall: you have access to tremendous compute capabilities, but you pay for what you use. If you fine-tune your queries, you will have access to powerful insights at the fraction of the cost of maintaining a data warehouse yourself. It is, however, easy to incur burdensome costs if you are not careful.
+
+## Best Practices
+
+### Pay attention to table structure.
+
+Large tables are partitioned and clustered according to common access patterns. Prune only the partitions you need, and filter or aggregate by clustered fields when possible.
+
+Joining tables on strings is expensive. Refrain from joining on string keys if you can utilize integer keys instead.
+
+Read the docs on [Viewing Metadata](/docs/accessing-data/viewing-metadata) to learn more about table metadata.
+
+#### Example - Profiling Operation Types
+
+Let’s say you wanted to profile the [types of operations](/docs/fundamentals-and-concepts/list-of-operations) submitted to the Stellar Network monthly. 
+
+<CodeExample>
+
+```sql
+# Inefficient query
+select datetime_trunc(batch_run_date, month) as `month`,
+  type_string,
+  count(id) as count_operations
+from `crypto-stellar.crypto_stellar.history_operations`
+group by `month`,
+  type_string
+order by `month`
+```
+
+</CodeExample>
+
+The `history_operations` table is partitioned by `batch_run_date` and clustered by `transaction_id`, `source_account` and `type`. Query costs are greatly reduced by pruning unused partitions. In this case, you could filter out operations submitted before 2023. This reduces the query cost by 4x.
+
+<CodeExample>
+
+```sql
+# Prune out partitions you do not need
+select datetime_trunc(batch_run_date, month) as `month`,
+  type_string,
+  count(id) as count_operations
+from `crypto-stellar.crypto_stellar.history_operations`
+where batch_run_date >= '2023-01-01T00:00:00'
+group by `month`,
+  type_string
+order by `month`
+```
+
+</CodeExample>
+
+Switching the aggregation field to `type`, which is a clustered field, will cut costs by a third:
+
+<CodeExample>
+
+```sql
+# Prune out partitions you do not need
+# Aggregate by clustered field, `type`
+select datetime_trunc(batch_run_date, month) as `month`,
+  `type`,
+  count(id) as count_operations
+from `crypto-stellar.crypto_stellar.history_operations`
+where batch_run_date >= '2023-01-01T00:00:00'
+group by `month`,
+  `type`
+order by `month`
+```
+
+</CodeExample>
+
+**Performance Summary**
+
+|                  | Bytes Processed  | Cost   |
+| ----------       | --------------   | -----  |
+| Original Query   | 408.1 GB         | $2.041 | 
+| Improved Query 1 | 83.06 GB         | $0.415 |
+| Improved Query 2 | 54.8 GB          | $0.274 |
+
+### Be as specific as possible.
+
+Do not write `SELECT *` statements unless you need every column returned in the query response. Since BigQuery is a columnar database, it can skip reading data entirely if the columns are not included in the select statement. The wider the table is, the more crucial it is to select *only* what you need.
+
+#### Example - Transaction Fees
+
+Let’s say you needed to view the fees for all transactions submitted in May 2023. What happens if you write a `SELECT *`?
+
+<CodeExample>
+
+```sql
+# Inefficient query
+select *
+from `crypto-stellar.crypto_stellar.history_transactions`
+where batch_run_date >= '2023-05-01'
+  and batch_run_date < '2023-06-01'
+```
+
+</CodeExample>
+
+This query is estimated to cost almost $4! 
+
+If you only need fee information, you can filter down the data, reducing the query costs by a factor of 50x:
+
+<CodeExample>
+
+```sql
+# Select only the columns you need
+select id,
+  transaction_hash,
+  ledger_sequence,
+  account,
+  fee_account,
+  max_fee,
+  fee_charged,
+  new_max_fee
+from `crypto-stellar.crypto_stellar.history_transactions`
+where batch_run_date >= '2023-05-01'
+  and batch_run_date < '2023-06-01'
+```
+
+</CodeExample>
+
+**Performance Summary**
+
+|                | Bytes Processed  | Cost   |
+| ----------     | --------------   | -----  |
+| Original Query | 769.45 GB        | $3.847 | 
+| Improved Query | 16.6 GB          | $0.083 |
+
+:::tip 
+The BigQuery console lets you preview table data for free, which is the equivalent of writing a `SELECT *`. Click on the table name, and pull up the preview pane.
+:::
+
+### Filter early.
+
+When writing complex queries, filter the data as early as possible. Push `WHERE` and `GROUP BY` clauses up in the query to reduce the amount of data scanned. 
+
+:::caution
+`LIMIT` clauses speed up performance, but **do not** reduce the amount of data scanned. Only the *final* results returned to the user are limited. Use with caution.
+:::
+
+Push transformations and mathematical functions to the end of the query when possible. Functions like `TRIM()`, `CAST()`, `SUM()`, and `REGEXP_*` are resource intensive and should only be applied to final table results.
+
+
+## Estimating Costs
+
+If you need to estimate costs before running a query, there are several options available to you:
+
+### BigQuery Console
+
+### dryRun Config Parameter
+
+If you are submitting a query through a [BigQuery client library](https://cloud.google.com/bigquery/docs/reference/libraries), you can perform a dry run to estimate the total bytes processed before submitting the query job.
+
+<CodeExample>
+
+```python
+from google.cloud import bigquery
+
+# Construct a BigQuery client object
+client = bigquery.Client()
+
+# Set dry run to True to get bytes processed 
+job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
+
+# Pass in job config
+sql = """
+    select timestamp_trunc(closed_at, month) as month,
+      sum(tx_set_operation_count) as total_operations
+    from `crypto-stellar.crypto_stellar.history_ledgers`
+    where batch_run_date >= '2023-01-01'
+      and closed_at >= '2023-01-01T00:00:00+00'
+    group by month
+"""
+
+# Make API request
+query_job = client.query((sql), job_config = job_config)
+
+# Calculate the cost
+cost = (query_job.total_bytes_processed / 10000000000) * 5
+
+print(f'This query will process {query_job.total_bytes_processed}')
+print(f'This query will cost approximately ${cost}')
+```
+
+</CodeExample>
+
+There are also [IDE plugins](https://plugins.jetbrains.com/plugin/15884-bigquery-query-size-estimator) that can approximate cost. 
+
+For more information regarding query costs, read the [BigQuery documentation](https://cloud.google.com/bigquery/docs/estimate-costs).
+

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -76,6 +76,8 @@ order by `month`
 
 **Performance Summary**
 
+By pruning partitions and aggregating on a clustered field, the query processing costs reduce by a factor of 8.
+
 |                  | Bytes Processed | Cost   |
 | ---------------- | --------------- | ------ |
 | Original Query   | 408.1 GB        | $2.041 |
@@ -127,6 +129,8 @@ where batch_run_date >= '2023-05-01'
 
 **Performance Summary**
 
+Hubble stores wide tables. Query performance is greatly improved by selecting only the data you need. This principle is critical when exploring the operations and transactions tables, which are the largest tables in Hubble.
+
 |                | Bytes Processed | Cost   |
 | -------------- | --------------- | ------ |
 | Original Query | 769.45 GB       | $3.847 |
@@ -155,6 +159,33 @@ Push transformations and mathematical functions to the end of the query when pos
 If you need to estimate costs before running a query, there are several options available to you:
 
 ### BigQuery Console
+
+The BigQuery Console comes with a built-in query validator. It verifies query syntax and provides an estimate of the number of bytes processed. The validator can be found in the upper right hand corner of the Query Editor, next to the green checkmark.
+
+To calculate the query cost, convert the number of bytes processed into terabytes, and multiply the result by $5: 
+
+`(estimated bytes read / 1TB) *  $5`
+
+Paste the following query into the Editor to view the estimated bytes processed.
+
+<CodeExample>
+
+```sql
+select timestamp_trunc(closed_at, month) as month,
+  sum(tx_set_operation_count) as total_operations
+from `crypto-stellar.crypto_stellar.history_ledgers`
+where batch_run_date >= '2023-01-01T00:00:00'
+  and batch_run_date < '2023-06-01T00:00:00'
+  and closed_at >= '2023-01-01T00:00:00'
+  and closed_at < '2023-06-01T00:00:00'
+group by month
+```
+
+</CodeExample>
+
+The validator estimates that 51.95MB of data will be read.
+
+0.00005195 TB * $5 = $0.000259. _That’s a cheap query!_
 
 ### dryRun Config Parameter
 

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -132,13 +132,21 @@ where batch_run_date >= '2023-05-01'
 | Original Query | 769.45 GB       | $3.847 |
 | Improved Query | 16.6 GB         | $0.083 |
 
-:::tip The BigQuery console lets you preview table data for free, which is the equivalent of writing a `SELECT *`. Click on the table name, and pull up the preview pane. :::
+:::tip
+
+The BigQuery console lets you preview table data for free, which is the equivalent of writing a `SELECT *`. Click on the table name, and pull up the preview pane.
+
+:::
 
 ### Filter early.
 
 When writing complex queries, filter the data as early as possible. Push `WHERE` and `GROUP BY` clauses up in the query to reduce the amount of data scanned.
 
-:::caution `LIMIT` clauses speed up performance, but **do not** reduce the amount of data scanned. Only the _final_ results returned to the user are limited. Use with caution. :::
+:::caution
+
+`LIMIT` clauses speed up performance, but **do not** reduce the amount of data scanned. Only the _final_ results returned to the user are limited. Use with caution.
+
+:::
 
 Push transformations and mathematical functions to the end of the query when possible. Functions like `TRIM()`, `CAST()`, `SUM()`, and `REGEXP_*` are resource intensive and should only be applied to final table results.
 

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -207,8 +207,10 @@ sql = """
     select timestamp_trunc(closed_at, month) as month,
       sum(tx_set_operation_count) as total_operations
     from `crypto-stellar.crypto_stellar.history_ledgers`
-    where batch_run_date >= '2023-01-01'
+    where batch_run_date >= '2023-01-01T00:00:00'
+      and batch_run_date < '2023-06-01T00:00:00'
       and closed_at >= '2023-01-01T00:00:00+00'
+      and closed_at < '2023-06-01T00:00:00'
     group by month
 """
 
@@ -216,9 +218,9 @@ sql = """
 query_job = client.query((sql), job_config = job_config)
 
 # Calculate the cost
-cost = (query_job.total_bytes_processed / 10000000000) * 5
+cost = (query_job.total_bytes_processed / 1000000000000) * 5
 
-print(f'This query will process {query_job.total_bytes_processed}')
+print(f'This query will process {query_job.total_bytes_processed} bytes')
 print(f'This query will cost approximately ${cost}')
 ```
 

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -19,7 +19,7 @@ Read the docs on [Viewing Metadata](/docs/accessing-data/viewing-metadata) to le
 
 #### Example - Profiling Operation Types
 
-Let’s say you wanted to profile the [types of operations](/docs/fundamentals-and-concepts/list-of-operations) submitted to the Stellar Network monthly. 
+Let’s say you wanted to profile the [types of operations](/docs/fundamentals-and-concepts/list-of-operations) submitted to the Stellar Network monthly.
 
 <CodeExample>
 
@@ -75,15 +75,15 @@ order by `month`
 
 **Performance Summary**
 
-|                  | Bytes Processed  | Cost   |
-| ----------       | --------------   | -----  |
-| Original Query   | 408.1 GB         | $2.041 | 
-| Improved Query 1 | 83.06 GB         | $0.415 |
-| Improved Query 2 | 54.8 GB          | $0.274 |
+|                  | Bytes Processed | Cost   |
+| ---------------- | --------------- | ------ |
+| Original Query   | 408.1 GB        | $2.041 |
+| Improved Query 1 | 83.06 GB        | $0.415 |
+| Improved Query 2 | 54.8 GB         | $0.274 |
 
 ### Be as specific as possible.
 
-Do not write `SELECT *` statements unless you need every column returned in the query response. Since BigQuery is a columnar database, it can skip reading data entirely if the columns are not included in the select statement. The wider the table is, the more crucial it is to select *only* what you need.
+Do not write `SELECT *` statements unless you need every column returned in the query response. Since BigQuery is a columnar database, it can skip reading data entirely if the columns are not included in the select statement. The wider the table is, the more crucial it is to select _only_ what you need.
 
 #### Example - Transaction Fees
 
@@ -101,7 +101,7 @@ where batch_run_date >= '2023-05-01'
 
 </CodeExample>
 
-This query is estimated to cost almost $4! 
+This query is estimated to cost almost $4!
 
 If you only need fee information, you can filter down the data, reducing the query costs by a factor of 50x:
 
@@ -126,25 +126,20 @@ where batch_run_date >= '2023-05-01'
 
 **Performance Summary**
 
-|                | Bytes Processed  | Cost   |
-| ----------     | --------------   | -----  |
-| Original Query | 769.45 GB        | $3.847 | 
-| Improved Query | 16.6 GB          | $0.083 |
+|                | Bytes Processed | Cost   |
+| -------------- | --------------- | ------ |
+| Original Query | 769.45 GB       | $3.847 |
+| Improved Query | 16.6 GB         | $0.083 |
 
-:::tip 
-The BigQuery console lets you preview table data for free, which is the equivalent of writing a `SELECT *`. Click on the table name, and pull up the preview pane.
-:::
+:::tip The BigQuery console lets you preview table data for free, which is the equivalent of writing a `SELECT *`. Click on the table name, and pull up the preview pane. :::
 
 ### Filter early.
 
-When writing complex queries, filter the data as early as possible. Push `WHERE` and `GROUP BY` clauses up in the query to reduce the amount of data scanned. 
+When writing complex queries, filter the data as early as possible. Push `WHERE` and `GROUP BY` clauses up in the query to reduce the amount of data scanned.
 
-:::caution
-`LIMIT` clauses speed up performance, but **do not** reduce the amount of data scanned. Only the *final* results returned to the user are limited. Use with caution.
-:::
+:::caution `LIMIT` clauses speed up performance, but **do not** reduce the amount of data scanned. Only the _final_ results returned to the user are limited. Use with caution. :::
 
 Push transformations and mathematical functions to the end of the query when possible. Functions like `TRIM()`, `CAST()`, `SUM()`, and `REGEXP_*` are resource intensive and should only be applied to final table results.
-
 
 ## Estimating Costs
 
@@ -164,7 +159,7 @@ from google.cloud import bigquery
 # Construct a BigQuery client object
 client = bigquery.Client()
 
-# Set dry run to True to get bytes processed 
+# Set dry run to True to get bytes processed
 job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
 
 # Pass in job config
@@ -189,7 +184,6 @@ print(f'This query will cost approximately ${cost}')
 
 </CodeExample>
 
-There are also [IDE plugins](https://plugins.jetbrains.com/plugin/15884-bigquery-query-size-estimator) that can approximate cost. 
+There are also [IDE plugins](https://plugins.jetbrains.com/plugin/15884-bigquery-query-size-estimator) that can approximate cost.
 
 For more information regarding query costs, read the [BigQuery documentation](https://cloud.google.com/bigquery/docs/estimate-costs).
-

--- a/docs/accessing-data/optimizing-queries.mdx
+++ b/docs/accessing-data/optimizing-queries.mdx
@@ -46,7 +46,8 @@ select datetime_trunc(batch_run_date, month) as `month`,
   type_string,
   count(id) as count_operations
 from `crypto-stellar.crypto_stellar.history_operations`
-where batch_run_date >= '2023-01-01T00:00:00'
+-- batch_run_date is a datetime object, formatted as ISO 8601
+where batch_run_date > '2023-01-01T00:00:00'
 group by `month`,
   type_string
 order by `month`

--- a/docs/accessing-data/overview.mdx
+++ b/docs/accessing-data/overview.mdx
@@ -5,9 +5,9 @@ sidebar_position: 0
 
 ## What is Hubble?
 
-Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. **Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.**
+Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. **Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.** For real time use cases, we recommend [running an API server](/docs/run-api-server).
 
-This guide describes when to use Hubble and how to connect. For more information regarding underlying data structures, queries and examples, please refer to the Hubble Technical Docs under APIs.
+This guide describes when to use Hubble and how to connect. For more information regarding underlying data structures, queries and examples, please refer to [Viewing Metadata](/docs/accessing-data/viewing-metadata) and [Optimizing Queries](/docs/accessing-data/optimizing-queries).
 
 ## Why Use Hubble?
 

--- a/docs/accessing-data/overview.mdx
+++ b/docs/accessing-data/overview.mdx
@@ -7,7 +7,7 @@ sidebar_position: 0
 
 Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. **Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.** For real time use cases, we recommend [running an API server](/docs/run-api-server).
 
-This guide describes when to use Hubble and how to connect. For more information regarding underlying data structures, queries and examples, please refer to [Viewing Metadata](/docs/accessing-data/viewing-metadata) and [Optimizing Queries](/docs/accessing-data/optimizing-queries).
+This guide describes when to use Hubble and how to connect. To view the underlying data structures, queries and examples, use the [Viewing Metadata](/docs/accessing-data/viewing-metadata) and [Optimizing Queries](/docs/accessing-data/optimizing-queries) tutorials.
 
 ## Why Use Hubble?
 

--- a/docs/accessing-data/overview.mdx
+++ b/docs/accessing-data/overview.mdx
@@ -5,7 +5,7 @@ sidebar_position: 0
 
 ## What is Hubble?
 
-Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.
+Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. **Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.**
 
 This guide describes when to use Hubble and how to connect. For more information regarding underlying data structures, queries and examples, please refer to the Hubble Technical Docs under APIs.
 

--- a/docs/accessing-data/overview.mdx
+++ b/docs/accessing-data/overview.mdx
@@ -3,6 +3,8 @@ title: "Overview"
 sidebar_position: 0
 ---
 
+## What is Hubble?
+
 Hubble is an open-source, publicly available dataset that provides a complete historical record of the Stellar network. Similar to Horizon, it ingests and presents the data produced by the Stellar network in a format that is easier to consume than the performance-oriented data representations used by Stellar Core. The dataset is hosted on BigQuery–meaning it is suitable for large, analytic workloads, historical data retrieval and complex data aggregation. Hubble should not be used for real-time data retrieval and cannot submit transactions to the network.
 
 This guide describes when to use Hubble and how to connect. For more information regarding underlying data structures, queries and examples, please refer to the Hubble Technical Docs under APIs.

--- a/docs/accessing-data/viewing-metadata.mdx
+++ b/docs/accessing-data/viewing-metadata.mdx
@@ -1,0 +1,57 @@
+---
+title: "Viewing Metadata"
+sidebar_position: 20
+---
+
+Hubble publishes metadata which can help users determine which tables to query, how frequently the dataset updates, and general information about the dataset. 
+
+There are two ways to access this information:
+
+## BigQuery Explorer
+
+When accessing Hubble from its starred link, the Explorer pane will load metadata about the `crypto-stellar.crypto_stellar` dataset.
+
+Use the Toggle to view the contents of the Dataset. Clicking a table name will load the following:
+
+- *Schema* - detailed information about the table schema, including column definitions and data types. Viewing the schema helps write a SQL query
+- *Details* - general information about the table itself, including partitioning, clustering and table size. Viewing details helps with query optimization
+- *Preview* - raw sample data from the table. The data presented is the equivalent of running a `SELECT *` statement 
+
+
+## INFORMATION_SCHEMA
+
+BigQuery supports read-only, system-defined views that provide metadata information about BigQuery objects. The views can be queried via SQL from the BigQuery UI or Client Libraries.
+
+> _*Keep in Mind*_: Queries against the `INFORMATION_SCHEMA` cannot be cached and **will** incur data processing charges for each execution.
+
+From the BigQuery Editor, the following query will list all tables in Hubble:
+
+<CodeExample>
+
+```sql
+# List all tables in Hubble
+#standardSQL 
+select * 
+from `crypto-stellar.crypto_stellar`.INFORMATION_SCHEMA.TABLES;
+```
+
+</CodeExample>
+
+If you want details on a particular table, you can return the table schema:
+
+<CodeExample>
+
+```sql
+# List all columns for the accounts table 
+select table_name,
+  column_name,
+  is_nullable,
+  data_type,
+  is_partitioning_column
+from `crypto-stellar.crypto_stellar`.INFORMATION_SCHEMA.COLUMNS
+where table_name = "accounts";
+```
+
+</CodeExample>
+
+More on the `INFORMATION_SCHEMA` can be found [here](https://cloud.google.com/bigquery/docs/information-schema-intro).

--- a/docs/accessing-data/viewing-metadata.mdx
+++ b/docs/accessing-data/viewing-metadata.mdx
@@ -3,7 +3,7 @@ title: "Viewing Metadata"
 sidebar_position: 20
 ---
 
-Hubble publishes metadata which can help users determine which tables to query, how frequently the dataset updates, and general information about the dataset. 
+Hubble publishes metadata which can help users determine which tables to query, how frequently the dataset updates, and general information about the dataset.
 
 There are two ways to access this information:
 
@@ -13,10 +13,9 @@ When accessing Hubble from its starred link, the Explorer pane will load metadat
 
 Use the Toggle to view the contents of the Dataset. Clicking a table name will load the following:
 
-- *Schema* - detailed information about the table schema, including column definitions and data types. Viewing the schema helps write a SQL query
-- *Details* - general information about the table itself, including partitioning, clustering and table size. Viewing details helps with query optimization
-- *Preview* - raw sample data from the table. The data presented is the equivalent of running a `SELECT *` statement 
-
+- _Schema_ - detailed information about the table schema, including column definitions and data types. Viewing the schema helps write a SQL query
+- _Details_ - general information about the table itself, including partitioning, clustering and table size. Viewing details helps with query optimization
+- _Preview_ - raw sample data from the table. The data presented is the equivalent of running a `SELECT *` statement
 
 ## INFORMATION_SCHEMA
 
@@ -30,8 +29,8 @@ From the BigQuery Editor, the following query will list all tables in Hubble:
 
 ```sql
 # List all tables in Hubble
-#standardSQL 
-select * 
+#standardSQL
+select *
 from `crypto-stellar.crypto_stellar`.INFORMATION_SCHEMA.TABLES;
 ```
 
@@ -42,7 +41,7 @@ If you want details on a particular table, you can return the table schema:
 <CodeExample>
 
 ```sql
-# List all columns for the accounts table 
+# List all columns for the accounts table
 select table_name,
   column_name,
   is_nullable,

--- a/docs/accessing-data/viewing-metadata.mdx
+++ b/docs/accessing-data/viewing-metadata.mdx
@@ -21,7 +21,11 @@ Use the Toggle to view the contents of the Dataset. Clicking a table name will l
 
 BigQuery supports read-only, system-defined views that provide metadata information about BigQuery objects. The views can be queried via SQL from the BigQuery UI or Client Libraries.
 
-> _*Keep in Mind*_: Queries against the `INFORMATION_SCHEMA` cannot be cached and **will** incur data processing charges for each execution.
+:::note
+
+Queries executed against the `INFORMATION_SCHEMA` cannot be cached and **will** incur data processing charges for each run.
+
+:::
 
 From the BigQuery Editor, the following query will list all tables in Hubble:
 

--- a/docs/encyclopedia/_category_.json
+++ b/docs/encyclopedia/_category_.json
@@ -1,5 +1,5 @@
 {
-  "position": 90,
+  "position": 100,
   "label": "Encyclopedia",
   "link": {
     "type": "generated-index"

--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Glossary"
-sidebar_position: 100
+sidebar_position: 110
 ---
 
 ### Account

--- a/docs/tools-and-sdks.mdx
+++ b/docs/tools-and-sdks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Tools and SDKs"
-sidebar_position: 80
+sidebar_position: 90
 ---
 
 ## Tools


### PR DESCRIPTION
Hubble does not have any public docs, and this update adds a new section under Docs called `Accessing Historical Data`. We focused on the following topics: 

* Overview - provide an overview of what Hubble is, how it differs from Horizon and when you should use it
* Connecting - details 3 different connection methods to BigQuery (UI, SDKs and viz tool)
* Viewing Metadata - shows end users how to discover information about Hubble through BigQuery Metadata

Future PRs will add more technical docs and examples, which we plan to put under `APIs`. This will include an entity relationship diagram, data dictionaries and detailed examples.