### PR TITLE
Hide the `/api/READ_FIRST` document from the site

### DIFF
--- a/api/READ_FIRST.md
+++ b/api/READ_FIRST.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # STOP WHAT YOU'RE DOING
 
 If you're here to make some fixes to Stellar's API documentation (first, thank

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,9 +97,6 @@ const config = {
         theme: {
           customCss: [require.resolve("./src/css/custom.scss")],
         },
-        sitemap: {
-          ignorePatterns: ['/api/READ_FIRST']
-        },
       }),
     ],
   ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,6 +97,9 @@ const config = {
         theme: {
           customCss: [require.resolve("./src/css/custom.scss")],
         },
+        sitemap: {
+          ignorePatterns: ['/api/READ_FIRST']
+        },
       }),
     ],
   ],


### PR DESCRIPTION
I noticed it was present in the sitemap while working on #169, but also realized it could be accessed by visiting the URL. The page is intended for contributors to the site, and shouldn't be viewable in the production site.

This change makes it inaccessible, and also removes it from the sitemap. The document is set as a `draft` in the markdown frontmatter, and that takes care of both.