### PR TITLE
SDP: add guidance for funding distribution account

### DIFF
--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -3,17 +3,47 @@ title: Getting Started
 sidebar_position: 30
 ---
 
-## Set Up the Development Environment (BASH)
+## Set Up the Development Environment
 
-In this guide, we'll help you set up your local workstation with a complete end-to-end development environment using docker-compose, Stellar demo-wallet, USDC on Stellar, and Stellar Testnet. Let’s bring up all the services.
+In this guide, we'll help you set up your local workstation with a complete end-to-end development environment using docker-compose, the Stellar demo wallet, and USDC on Stellar's test network. Let’s bring up all the services.
 
-Disclaimer: USDC and the [Demo Wallet](https://demo-wallet.stellar.org/) are used in the following walk-through demo as an example asset and wallet, though they are not the only options.
+Note that while we'll be using USDC and the [Demo Wallet][demo-wallet] in this guide, other Stellar assets and wallets can be used in development or production.
 
-### 1. Configure SDP secrets
+### 1. Create a Distribution Account
+
+You'll need a minimum of two accounts when using the Stellar Disbursement Platform, a distribution and receiver account. We'll create the distribution account now and will create the receiver account while making our first disbursment.
+
+1. Go to the [Stellar Demo Wallet][demo-wallet] and select "Generate keypair for new account"
+1. Select the "Create account" button next to the public key to fund your account with XLM
+1. Select the "Select from preset assets" button, and select USDC
+1. Finally, select "Add trustline" to enable payments of USDC
+
+Now that we have an account that can send & receive USDC, lets fund it with enough USDC for our first disbursement. We'll use the Circle Sandbox in this guide, but you can fund your distribution account from any liquidity source of Stellar USDC.
+
+1. Create a [Circle Sandbox][circle-sandbox] account
+1. Once you're at the dashboard, Select "Get API Key", and copy it to your clipboard
+1. Go to the [Circle Sample App][circle-sample-app] and enter your API key after selecting the settings icon in the top right corner
+1. Select "Charge Flow", then "Prefill Form", and select a card to use (it doesn't matter which)
+1. Enter the amount you'd like to purchase, then select "Make Payment"
+
+This will fund your Circle Sandbox Account with USDC. You can repeat the process above when you run out or the test network resets, which happens quarterly.
+
+Your USDC should appear in your account within a few minutes, which you can check using the [balances endpoint](https://sample-sandbox.circle.com/debug/payments/balances/fetch). Once funded, you can send it to your distribution account created earlier.
+
+1. Select the icon in the top left, then "Payouts API", and finally "POST /transfers"
+1. Select "Get Master Wallet ID" to load the wallet funded with USDC
+1. Enter the amount you'd like to send
+1. Select the "blockchain" destination type and then "XLM"
+1. Paste the public key of the account you created with the demo wallet earlier
+1. Select "Make API Call"
+
+Circle will submit payment of USDC to the Stellr test network and you should receive funds in your demo wallet account almost immediately!
+
+### 2. Configure SDP Secrets
 
 Before bringing up the services, make sure the secrets that the Stellar Disbursement Platform will use are configured.
 
-1.  Create the Stellar account used for SEP-10 authentication and configure the following values in docker-compose-sdp-anchor.yml
+1.  Create the Stellar account used for SEP-10 authentication and configure the following values in `docker-compose-sdp-anchor.yml`
 
     **SDP**  
     `SEP10_ACCOUNT`  
@@ -23,7 +53,7 @@ Before bringing up the services, make sure the secrets that the Stellar Disburse
     **Anchor**  
     `SECRET_SEP10_SIGNING_SEED` (secret)
 
-2.  Create a Stellar account and fund it with the digital asset you will send in your disbursement (ex: USDC). This account will be used as the Distribution Account. Configure the following values in docker-compose-sdp-anchor.yml
+2.  Create a Stellar account. This account will be used as the Distribution Account. Configure the following values in `docker-compose-sdp-anchor.yml`
 
     **SDP**  
     `DISTRIBUTION_PUBLIC_KEY`
@@ -34,7 +64,7 @@ Before bringing up the services, make sure the secrets that the Stellar Disburse
     **TSS**  
     `DISTRIBUTION_SEED` (secret)
 
-3.  **Optional for testnet but must be done in production**: Get a Google Recaptcha site key/secret and configure the following values in docker-compose-sdp-anchor.yml
+3.  **Optional for testnet but must be done in production**: Get a Google Recaptcha site key/secret and configure the following values in `docker-compose-sdp-anchor.yml`
 
     **SDP**  
     `RECAPTCHA_SITE_KEY`  
@@ -56,7 +86,7 @@ TWILIO_SERVICE_SID
 
 In order to use Twilio, we also have to set the following environment variable: MESSAGE_SENDER_TYPE: TWILIO_SMS
 
-### 2. Configure sdp-api and Anchor Platform hosts
+### 3. Configure sdp-api and Anchor Platform hosts
 
 Add the following two hosts to your `/etc/hosts` file:
 
@@ -64,7 +94,7 @@ Add the following two hosts to your `/etc/hosts` file:
 
 <pre class="prettyprint">127.0.0.1 anchor-platform</pre>
 
-### 3. Bring SDP services up via docker-compose
+### 4. Bring SDP services up via docker-compose
 
 From the stellar-disbursement-platform-backend main directory, navigate to the dev directory in the repository and bring all SDP services up and running using docker-compose.
 
@@ -76,7 +106,7 @@ Your window will contain the logs from all services, making it easy to follow sy
 
 ![Window Log](/assets/SDP/SDP3.png)
 
-### 4. Create organization owner
+### 5. Create organization owner
 
 Next we need to create an organization owner account with privileges (role) to use the SDP. We will use the SDP CLI to add the user. Connect to the sdp-api container and create an owner account.
 
@@ -94,7 +124,7 @@ root@a7437e9ed3ca:/app#
 
 </CodeExample>
 
-### 5. Log in with your account
+### 6. Log in with your account
 
 Now that you have created an owner account, navigate to the dashboard by opening a browser to [localhost:3000](http://localhost:3000/) and login with the account you just created.
 
@@ -104,7 +134,7 @@ Click the Sign in button and the SDP Dashboard will open. You will have no disbu
 
 ![Dashboard](/assets/SDP/SDP5.png)
 
-### 6. Create your first disbursement
+### 7. Create your first disbursement
 
 Create your first disbursement by clicking the New Disbursement button. Use Demo Wallet as your wallet and USDC as your asset. You can choose whatever values you like for Country and Name. Then upload your disbursement file with receiver information. A sample file is available in the /dev/sample directory. Make sure to edit the file with a valid phone number that you have access to before using it.
 
@@ -126,39 +156,21 @@ Review and confirm the disbursement.
 
 ![Confirm](/assets/SDP/SDP7.png)
 
-### 7. Verify your identity
+### 8. Verify your identity
 
 You should receive an SMS message containing the link, enabling you to verify your identity with the information from the CSV and register with the SDP. Note: If you do not have an SMS provider configured for your development environment, you can find the URL in the logs.
 
 ![Verify Identity](/assets/SDP/SDP8.png)
 
-### 8. Create a Stellar account
+### 9. Create a Receiver Account
 
-Click the link to open the Stellar Demo Wallet application in your web browser. Since the Demo Wallet functions differently than live wallet service providers, you must first create a Stellar account by clicking on Generate Keypair for new account (testnet only). This step is handled automatically by production Stellar wallets.
-
-![Demo Wallet](/assets/SDP/SDP9.png)
-
-Next, click Create Account (in front of public key)
-
-![Create Account](/assets/SDP/SDP10.png)
-
-### 9. Add USDC
-
-Click the Add Asset button and input the following values:
-
-**ASSET CODE**: USDC  
-**ANCHOR HOME DOMAIN**: localhost:8080  
-**ISSUER PUBLIC KEY**: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
-
-![Add Asset](/assets/SDP/SDP11.png)
-
-Next, click Add Trustline for the USDC asset you added above. This will enable your account to receive USDC from the SDP.
-
-![Add Trustline](/assets/SDP/SDP12.png)
+Clicking on the link within the SMS message will bring you back to the Stellar Demo Wallet, where you'll need to create another account to receive the USDC. Follow the same process described earlier to create the account and add a USDC trustline.
 
 ### 10. Initiate SEP-24 webflow
 
-Now beside USDC, select SEP-24 Deposit to initiate a SEP-24 webflow, which triggers the User Registration process to link the new wallet to the phone number in the SDP.
+Now we'll need to connect the demo wallet to the SDP instance running locally. To do that, select the pencil icon next to "centre.io" below your USDC balance and enter "localhost:8080".
+
+In the "Select Action" dropdown, select "SEP-24 Deposit" to initiate a SEP-24 webflow, which triggers the User Registration process to link the new wallet to the phone number in the SDP.
 
 ![SEP-24](/assets/SDP/SDP13.png)
 

--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -195,3 +195,7 @@ Refresh your account. The Demo Wallet should now show a balance of 2 USDC sent f
 Keep an eye on the dashboard until the payment status reaches Success. If everything was set up correctly, your money should be disbursed successfully.
 
 ![Disbursement](/assets/SDP/SDP18.png)
+
+[demo-wallet]: https://demo-wallet.stellar.org
+[circle-sandbox]: https://login-sandbox.circle.com/
+[circle-sample-app]: https://sample-sandbox.circle.com/

--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -37,7 +37,7 @@ Your USDC should appear in your account within a few minutes, which you can chec
 1. Paste the public key of the account you created with the demo wallet earlier
 1. Select "Make API Call"
 
-Circle will submit payment of USDC to the Stellr test network and you should receive funds in your demo wallet account almost immediately!
+Circle will submit payment of USDC to the Stellar test network and you should receive funds in your demo wallet account almost immediately!
 
 ### 2. Configure SDP Secrets
 


### PR DESCRIPTION
Adds a new section to the "Getting Started Guide" for funding a distribution account with testnet USDC.