### PR TITLE
SDP-635 use docker-compose instead of makefile

### DIFF
--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -98,7 +98,7 @@ Then build it using the pre-defined docker compose files.
 <CodeExample>
 
 ```bash
-make all
+docker-compose up
 ```
 
 </CodeExample>


### PR DESCRIPTION
Use docker-compose instead of makefile. 

This documentation change is required because of this change https://github.com/stellar/stellar-disbursement-platform-backend/pull/328