### PR TITLE
SDP-857 Change create account steps for SDP setup

### DIFF
--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -122,12 +122,16 @@ We need to create an organization owner account with privileges (or role) to use
 
 ```bash
 docker exec -it sdp-api bash
-./stellar-disbursement-platform auth add-user owner@stellar.org john doe --password --owner --roles owner
+./stellar-disbursement-platform auth add-user owner@stellar.org john doe --owner --roles owner
 ```
 
 </CodeExample>
 
-The command will ask you to define a password and then create the user.
+The command will return the body of an email that will ask you to go through the forgot password flow to set your password.
+
+Open the [link displayed in the terminal](http://localhost:3000/forgot-password) in a browser and enter the email address you used to create the account.
+
+You can now check the terminal you used to run docker-compose to see the [reset password link](http://localhost:3000/reset-password) and code printed in the logs. Note that if you have an email service configured, you will receive an email with the reset password code and link.
 
 ## Log In
 


### PR DESCRIPTION
In order to simplify our account creation process, we're using the reset password flow for user creation through CLI. 
