### PR TITLE
typescript-wallet-sdk: adding last missing code examples

### DIFF
--- a/docs/building-apps/wallet/stellar.mdx
+++ b/docs/building-apps/wallet/stellar.mdx
@@ -8,7 +8,7 @@ import { WalletCodeExample as CodeExample } from "@site/src/components/WalletCod
 import Header from "./component/header.mdx";
 import CreateKeyPairInfo from "./component/ts/createKeypairInfo.mdx";
 
-<Header WIPLangs={["ts", "dart"]} />
+<Header WIPLangs={["dart"]} />
 
 In the previous section we learned how to create a wallet and a `Stellar` object that provides a connection to Horizon. In this section, we will look at the usages of this class.
 
@@ -86,6 +86,15 @@ suspend fun lockMasterKey(): Transaction {
 }
 ```
 
+```typescript
+const txBuilder = await stellar.transaction({
+  sourceAddress: sourceAccountKeyPair,
+  baseFee: 100,
+});
+
+const tx = txBuilder.lockAccountMasterKey().build();
+```
+
 </CodeExample>
 
 Add a new signer to the account. Use caution when adding new signers and make sure you set the correct signer weight. Otherwise, you will lock the account irreversibly.
@@ -100,6 +109,12 @@ suspend fun addSigner(): Transaction {
 }
 ```
 
+```typescript
+const newSignerKeyPair = account.createKeypair();
+
+const tx = txBuilder.addAccountSigner(newSignerKeyPair, 10).build();
+```
+
 </CodeExample>
 
 Remove a signer from the account.
@@ -112,6 +127,10 @@ suspend fun removeSigner(): Transaction {
 }
 ```
 
+```typescript
+const tx = txBuilder.removeAccountSigner(newSignerKeyPair).build();
+```
+
 </CodeExample>
 
 Modify account thresholds (useful when multiple signers are assigned to the account). This allows you to restrict access to certain operations when the limit is not reached.
@@ -122,6 +141,10 @@ Modify account thresholds (useful when multiple signers are assigned to the acco
 suspend fun setThreshold(): Transaction {
   return stellar.transaction(sourceAccountKeyPair).setThreshold(low = 1, medium = 10, high = 30).build()
 }
+```
+
+```typescript
+const tx = txBuilder.setThreshold({ low: 1, medium: 10, high: 30 }).build();
 ```
 
 </CodeExample>
@@ -179,6 +202,12 @@ val externalKeyPair = "MySponsorAddress".toPublicKeyPair()
 val newKeyPair = account.createKeyPair()
 ```
 
+```typescript
+// Third-party key that will sponsor creating new account
+const externalKeyPair = new PublicKeypair.fromPublicKey("GC5GD...");
+const newKeyPair = account.createKeypair();
+```
+
 </CodeExample>
 
 First, the account must be created.
@@ -191,6 +220,10 @@ suspend fun makeCreateTx(): Transaction {
 }
 ```
 
+```typescript
+const createTxn = txBuilder.createAccount(newKeyPair).build();
+```
+
 </CodeExample>
 
 This transaction must be sent to external signer (holder of `externalKeyPair`) to be signed.
@@ -200,10 +233,21 @@ This transaction must be sent to external signer (holder of `externalKeyPair`) t
 ```kt
 suspend fun remoteSignTransaction(transaction: Transaction) {
   val xdrString = transaction.toEnvelopeXdrBase64()
-  // Send xdr encoded transaction to your backend server
-  val signedTransaction = sendTransactionToBackend(xdrString)
-  val decodedTransaction = stellar.decodeTransaction(xdrString)
+  // Send xdr encoded transaction to your backend server to sign
+  val xdrStringFromBackend = sendTransactionToBackend(xdrString)
+
+  // Decode xdr to get the signed transaction
+  val signedTransaction = stellar.decodeTransaction(xdrStringFromBackend)
 }
+```
+
+```typescript
+const xdrString = createTxn.toXDR();
+// Send xdr encoded transaction to your backend server to sign
+const xdrStringFromBackend = await sendTransactionToBackend(xdrString);
+
+// Decode xdr to get the signed transaction
+const signedTransaction = stellar.decodeTransaction(xdrStringFromBackend);
 ```
 
 </CodeExample>
@@ -223,6 +267,10 @@ suspend fun submitCreateTx(signedCreateTx: Transaction) {
   wallet.stellar().submitTransaction(signedCreateTx)
 }
 
+```
+
+```typescript
+await wallet.stellar().submitTransaction(signedTransaction);
 ```
 
 </CodeExample>
@@ -250,13 +298,29 @@ suspend fun addDeviceKeyPair() {
 }
 ```
 
+```typescript
+const deviceKeyPair = account.createKeypair();
+
+const txBuilder = await stellar.transaction({
+  sourceAddress: newKeyPair,
+  baseFee: 100,
+});
+const modifyAccountTransaction = txBuilder
+  .addAccountSigner(deviceKeyPair, 1)
+  .lockAccountMasterKey()
+  .build();
+newKeyPair.sign(modifyAccountTransaction);
+
+await wallet.stellar().submitTransaction(modifyAccountTransaction);
+```
+
 </CodeExample>
 
 ### Sponsoring Transactions
 
 #### Sponsor Operations
 
-Some operations, that modify account reserves can be [sponsored](https://developers.stellar.org/docs/encyclopedia/sponsored-reserves#sponsored-reserves-operations). For sponsored operations, the sponsoring account will be paying for the reserves instead of the account that being sponsored. This allows you to do some operations, even if account doesn't have enough funds to perform such operations. To sponsor a transaction, simply start a `sponsoring` block:
+Some operations, that modify account reserves can be [sponsored](https://developers.stellar.org/docs/encyclopedia/sponsored-reserves#sponsored-reserves-operations). For sponsored operations, the sponsoring account will be paying for the reserves instead of the account that being sponsored. This allows you to do some operations, even if account doesn't have enough funds to perform such operations. To sponsor a transaction, <LanguageSpecific kt={<span>simply start a <b>sponsoring</b> block:</span>} ts={<span>simply create a building function (describing which operations are to be sponsored) and pass it to the <b>sponsoring</b> method:</span>}/>
 
 <CodeExample>
 
@@ -272,11 +336,26 @@ suspend fun sponsorOperation() {
 }
 ```
 
+```typescript
+const txBuilder = await stellar.transaction({
+  sourceAddress: sponsoredKeyPair,
+  baseFee: 100,
+});
+
+const buildingFunction = (bldr) => bldr.addAssetSupport(asset);
+const transaction = txBuilder
+  .sponsoring(sponsorKeyPair, buildingFunction)
+  .build();
+
+sponsoredKeyPair.sign(transaction);
+sponsorKeyPair.sign(transaction);
+```
+
 </CodeExample>
 
 :::info
 
-Only some operations can be sponsored, and a sponsoring block has a slightly different set of functions available compared to the regular `TransactionBuilder`. Note, that a transaction must be signed by both the sponsor account (`sponsoringKeyPair`) and the account being sponsored (`sponsoredKeyPair`).
+Only some operations can be sponsored, and a sponsoring <LanguageSpecific kt={<span>block</span>} ts={<span>builder</span>} /> has a slightly different set of functions available compared to the regular `TransactionBuilder`. Note, that a transaction must be signed by both the sponsor account (`sponsoringKeyPair`) and the account being sponsored (`sponsoredKeyPair`).
 
 :::
 
@@ -300,15 +379,32 @@ suspend fun sponsorAccountCreation() {
 }
 ```
 
+```typescript
+const txBuilder = await stellar.transaction({
+  sourceAddress: sponsorKeyPair,
+  baseFee: 100,
+});
+
+const newKeyPair = account.createKeypair();
+
+const buildingFunction = (bldr) => bldr.createAccount(newKeyPair);
+const transaction = txBuilder
+  .sponsoring(sponsorKeyPair, buildingFunction, newKeyPair)
+  .build();
+
+newKeyPair.sign(transaction);
+sponsorKeyPair.sign(transaction);
+```
+
 </CodeExample>
 
-Note how the transaction source account should be set to `sponsorKeyPair`. This time, we need to pass the sponsored account. In the example above, it was omitted and was defaulted to the transaction source account (`sponsoredKey`).
+Note how in the first example the transaction source account is set to `sponsoredKeyPair`. Due to this, we did not need to pass a sponsored account value to the `sponsoring` method. Since when ommitted, the sponsored account defaults to the transaction source account (`sponsoredKeyPair`).
 
-However, this time, the sponsored account (freshly created) is different from the transaction source account. Therefore, it's necessary to specify it. Otherwise, the transaction will contain a malformed operation. As before, the transaction must be signed by both keys.
+However, this time, the sponsored account (freshly created `newKeyPair`) is different from the transaction source account. Therefore, it's necessary to specify it. Otherwise, the transaction will contain a malformed operation. As before, the transaction must be signed by both keys.
 
 #### Sponsoring Account Creation and Modification
 
-If you want to create an account and modify it in one transaction, it's possible to do so with passing a `sponsoredAccount` optional argument to the sponsored block. If this argument is present, all operations inside the sponsored block will be sourced by `sponsoredAccount`. (Except account creation, which is always sourced by the sponsor).
+If you want to create an account and modify it in one transaction, it's possible to do so with passing a `sponsoredAccount` optional argument to the <LanguageSpecific kt={<span> sponsored block</span>} ts={<span>sponsoring method</span>} /> (`newKeyPair` below). If this argument is present, all operations inside the sponsored block will be sourced by this `sponsoredAccount`. (Except account creation, which is always sourced by the sponsor).
 
 <CodeExample>
 
@@ -322,6 +418,7 @@ suspend fun sponsorAccountCreationAndModification() {
         .transaction(sponsorKeyPair)
         .sponsoring(sponsorKeyPair, newKeyPair) {
           createAccount(newKeyPair)
+          // source account for below operations will be newKeyPair
           addAccountSigner(replaceWith, 1)
           lockAccountMasterKey()
         }
@@ -331,11 +428,35 @@ suspend fun sponsorAccountCreationAndModification() {
 }
 ```
 
+```typescript
+const txBuilder = await stellar.transaction({
+  sourceAddress: sponsorKeyPair,
+  baseFee: 100,
+});
+
+const newKeyPair = account.createKeypair();
+const replaceWith = account.createKeypair();
+
+const buildingFunction = (bldr) =>
+  bldr
+    .createAccount(newKeyPair)
+    // source account for below operations will be newKeyPair
+    .addAccountSigner(replaceWith, 1)
+    .lockAccountMasterKey();
+
+const transaction = txBuilder
+  .sponsoring(sponsorKeyPair, buildingFunction, newKeyPair)
+  .build();
+
+newKeyPair.sign(transaction);
+sponsorKeyPair.sign(transaction);
+```
+
 </CodeExample>
 
 ### Fee-Bump Transaction
 
-If you wish to modify a newly created account with a 0 balance, it's also possible to do so via `FeeBump`. It can be combined with a sponsoring block to achieve the same result as in the example above. However, with `FeeBump` it's also possible to add more operations (that don't require sponsoring), such as a transfer.
+If you wish to modify a newly created account with a 0 balance, it's also possible to do so via `FeeBump`. It can be combined with a sponsoring <LanguageSpecific kt={<span>block</span>} ts={<span>method</span>} /> to achieve the same result as in the example above. However, with `FeeBump` it's also possible to add more operations (that don't require sponsoring), such as a transfer.
 
 First, let's create a transaction that will replace the master key of an account with a new keypair.
 
@@ -355,6 +476,21 @@ val transaction =
 
 ```
 
+```typescript
+const txBuilder = await stellar.transaction({
+  sourceAddress: sponsoredKeyPair,
+  baseFee: 100,
+});
+
+const replaceWith = account.createKeypair();
+
+const buildingFunction = (bldr) =>
+  bldr.lockAccountMasterKey().addAccountSigner(replaceWith, 1);
+const transaction = txBuilder
+  .sponsoring(sponsorKeyPair, buildingFunction)
+  .build();
+```
+
 </CodeExample>
 
 Second, sign transaction with both keys.
@@ -363,6 +499,11 @@ Second, sign transaction with both keys.
 
 ```kt
 transaction.sign(sponsoredKeyPair).sign(sponsorKeyPair)
+```
+
+```typescript
+sponsorKeyPair.sign(transaction);
+sponsoredKeyPair.sign(transaction);
 ```
 
 </CodeExample>
@@ -376,6 +517,14 @@ val feeBump = stellar.makeFeeBump(sponsorKeyPair, transaction)
 feeBump.sign(sponsorKeyPair)
 ```
 
+```typescript
+const feeBump = stellar.makeFeeBump({
+  feeAddress: sponsorKeyPair,
+  transaction,
+});
+sponsorKeyPair.sign(feeBump);
+```
+
 </CodeExample>
 
 Finally, submit a fee-bump transaction. Executing this transaction will be fully covered by the `sponsorKeyPair` and `sponsoredKeyPair` and may not even have any XLM funds on its account.
@@ -384,6 +533,10 @@ Finally, submit a fee-bump transaction. Executing this transaction will be fully
 
 ```kt
 wallet.stellar().submitTransaction(feeBump)
+```
+
+```typescript
+await wallet.stellar().submitTransaction(feeBump);
 ```
 
 </CodeExample>
@@ -396,6 +549,10 @@ Note, that a wallet may not have a signing key for `sponsorKeyPair`. In that cas
 
 ```kt
 val sponsorKeyPair = "SponsorAddress".toPublicKeyPair()
+```
+
+```typescript
+const sponsorKeyPair = new PublicKeypair.fromPublicKey("GC5GD...");
 ```
 
 </CodeExample>
@@ -418,6 +575,20 @@ suspend fun sponsorAccountCreation(): String {
 
 ```
 
+```typescript
+const txBuilder = await stellar.transaction({
+  sourceAddress: sponsorKeyPair,
+  baseFee: 100,
+});
+
+const newKeyPair = account.createKeypair();
+
+const transaction = txBuilder
+  .sponsoring(sponsorKeyPair, (bldr) => bldr.createAccount(newKeyPair))
+  .build();
+const xdrString = newKeyPair.sign(transaction).toXDR();
+```
+
 </CodeExample>
 
 It can now be sent to the server. On the server, sign it with a private key for the sponsor address:
@@ -427,12 +598,23 @@ It can now be sent to the server. On the server, sign it with a private key for 
 ```kt
 // On the server
 fun signTransaction(xdrString: String): String {
-  val sponsorPrivateKey = SigningKeyPair.fromSecret("MySecred")
+  val sponsorPrivateKey = SigningKeyPair.fromSecret("MySecret")
 
   val signedTransaction = stellar.decodeTransaction(xdrString).sign(sponsorPrivateKey)
 
   return signedTransaction.toEnvelopeXdrBase64()
 }
+```
+
+```typescript
+// On the server
+const sponsorPrivateKey = SigningKeyPair.fromSecret("SD3LH4...");
+
+const signedTransaction = sponsorPrivateKey.sign(
+  stellar.decodeTransaction(xdrString),
+);
+
+return signedTransaction.toXDR();
 ```
 
 </CodeExample>
@@ -448,6 +630,12 @@ suspend fun recoverSigned(xdrString: String) {
   stellar.submitTransaction(signedTransaction)
 }
 
+```
+
+```typescript
+const signedTransaction = stellar.decodeTransaction(xdrString);
+
+await wallet.stellar().submitTransaction(signedTransaction);
 ```
 
 </CodeExample>


### PR DESCRIPTION
adds typescurpt code examples for these missing sections of the Build A Wallet section:
- fee-bump
- sponsoring
- modifying accounts

will hold to merge after https://github.com/stellar/typescript-wallet-sdk/pull/46