### PR TITLE
SDP update getting started with rebuild instructions

### DIFF
--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -114,6 +114,16 @@ docker-compose up
 
 You should now have the Stellar Disbursement Platform running locally on port 3000. However, you won't be able to log in until you create a user.
 
+**Note:** If you make a code change, you'll need to instruct docker-compose to rebuild the sdp image. You can do this by adding the `--build` flag to the `docker-compose up` command.
+
+<CodeExample>
+
+```bash
+docker-compose up --build
+```
+
+</CodeExample>
+
 ## Create an Organization Owner
 
 We need to create an organization owner account with privileges (or role) to use the SDP. We will use the SDP CLI to add the user. Connect to the sdp-api container and create an owner account.


### PR DESCRIPTION
Few partners had the issue of code updates not being properly reflected  when running SDP in docker. Adding these instructions to help them rebuild the docker images. 