### PR TITLE
Fix fields explanations on SDP's authentication section

### DIFF
--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -258,7 +258,7 @@ ANCHOR_PLATFORM_OUTGOING_JWT_SECRET:
 SECRET_PLATFORM_API_AUTH_SECRET:
 #
 # The private key is used to sign JWT tokens for authenticating the requests incoming to the SDP. The Public key is used
-# to validate that the JWT token was signed by the SDP's prvate key. They can be generated with these commands:
+# to validate that the JWT token was signed by the SDP's private key. They can be generated with these commands:
 # openssl ecparam -name prime256v1 -genkey -noout -out ec_private_key.pem
 # openssl pkcs8 -topk8 -nocrypt -in ec_private_key.pem -out ec_private_key_pkcs8.pem
 # openssl ec -in ec_private_key.pem -pubout -out ec_public_key.pem

--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -235,25 +235,33 @@ In `docker-compose-sdp-anchor.yml`, update the following:
 <CodeExample>
 
 ```yaml
-# the public key of the account used for authentication
-# it should be the same public key for both attributes
-SEP10_ACCOUNT:
+# the public key of the Stellar account used for SEP-10 authentication
 SEP10_SIGNING_PUBLIC_KEY:
-# the private key of the account used for authentication
-# it should be the same secret key for both attributes
+#
+# the private key of the Stellar account used for SEP-10 authentication
+# it should be the same secret key for both attributes, in SDP and AP
 SEP10_SIGNING_PRIVATE_KEY:
 SECRET_SEP10_SIGNING_SEED:
-# the encryption key (any secret string) for the authentication token shared with wallets
-# it should be the same key for both attributes
-SEP24_JWT_SECRET:
+#
+# The secret used to sign the resulting SEP-10 JWT token. This should be a strong random string for encryption.
 SECRET_SEP10_JWT_SECRET:
-# the encryption key for the authentication token used for internal services
-# These could be different or the same value
-ANCHOR_PLATFORM_OUTGOING_JWT_SECRET:
+#
+# A shared encryption key used to sign JWT tokens in the SEP24 communications from AP->SDP.
+# The value needs to be the same for all three attributes below.
+SEP24_JWT_SECRET:
 SECRET_SEP24_INTERACTIVE_URL_JWT_SECRET:
 SECRET_SEP24_MORE_INFO_URL_JWT_SECRET:
-# used to encrypt passwords of the SDP users
-# NOTE: you'll need to recreate any existing users in the database if this is reset
+#
+# A shared encryption key used to sign JWT tokens in the PlatformAPI communications from SDP->AP.
+# The value needs to be the same for both attributes below.
+ANCHOR_PLATFORM_OUTGOING_JWT_SECRET:
+SECRET_PLATFORM_API_AUTH_SECRET:
+# The private key is used to sign JWT tokens for authenticating the requests incoming to the SDP. The Public key is used
+# to validate that the JWT token was signed by the SDP's prvate key. They can be generated with these commands:
+# openssl ecparam -name prime256v1 -genkey -noout -out ec_private_key.pem
+# openssl pkcs8 -topk8 -nocrypt -in ec_private_key.pem -out ec_private_key_pkcs8.pem
+# openssl ec -in ec_private_key.pem -pubout -out ec_public_key.pem
+EC256_PUBLIC_KEY:
 EC256_PRIVATE_KEY:
 ```
 

--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -235,30 +235,35 @@ In `docker-compose-sdp-anchor.yml`, update the following:
 <CodeExample>
 
 ```yaml
-# the public key of the Stellar account used for SEP-10 authentication
+# The public key of the Stellar account used for SEP-10 authentication:
 SEP10_SIGNING_PUBLIC_KEY:
 #
-# the private key of the Stellar account used for SEP-10 authentication
-# it should be the same secret key for both attributes, in SDP and AP
+# The private key of the Stellar account used for SEP-10 authentication. It
+# should be the same secret key for both attributes below, for the Stellar
+# Disbursement Platform and Anchor Platform:
 SEP10_SIGNING_PRIVATE_KEY:
 SECRET_SEP10_SIGNING_SEED:
 #
-# The secret used to sign the resulting SEP-10 JWT token. This should be a strong random string for encryption.
+# The encryption key used to sign the resulting SEP-10 JWT token:
 SECRET_SEP10_JWT_SECRET:
 #
-# A shared encryption key used to sign JWT tokens in the SEP24 communications from AP->SDP.
-# The value needs to be the same for all three attributes below.
+# A shared encryption key used to sign JWT tokens in the SEP-24 from the Anchor
+# Platform to the Stellar Disbursement Platform. The value needs to be the same
+# for all three attributes below:
 SEP24_JWT_SECRET:
 SECRET_SEP24_INTERACTIVE_URL_JWT_SECRET:
 SECRET_SEP24_MORE_INFO_URL_JWT_SECRET:
 #
-# A shared encryption key used to sign JWT tokens in the PlatformAPI communications from SDP->AP.
-# The value needs to be the same for both attributes below.
+# A shared encryption key used to sign JWT tokens in the PlatformAPI
+# communications from the Stellar Disbursement Platform to the Anchor Platform.
+# The value needs to be the same for both attributes below:
 ANCHOR_PLATFORM_OUTGOING_JWT_SECRET:
 SECRET_PLATFORM_API_AUTH_SECRET:
 #
-# The private key is used to sign JWT tokens for authenticating the requests incoming to the SDP. The Public key is used
-# to validate that the JWT token was signed by the SDP's private key. They can be generated with these commands:
+# The private key is used to sign JWT tokens for authenticating the requests
+# incoming to the Stellar Disbursement Platform. The Public key is used to
+# validate that the JWT token was signed by the SDP's private key. They can be
+# generated with these commands:
 # openssl ecparam -name prime256v1 -genkey -noout -out ec_private_key.pem
 # openssl pkcs8 -topk8 -nocrypt -in ec_private_key.pem -out ec_private_key_pkcs8.pem
 # openssl ec -in ec_private_key.pem -pubout -out ec_public_key.pem

--- a/docs/stellar-disbursement-platform/getting-started.mdx
+++ b/docs/stellar-disbursement-platform/getting-started.mdx
@@ -256,6 +256,7 @@ SECRET_SEP24_MORE_INFO_URL_JWT_SECRET:
 # The value needs to be the same for both attributes below.
 ANCHOR_PLATFORM_OUTGOING_JWT_SECRET:
 SECRET_PLATFORM_API_AUTH_SECRET:
+#
 # The private key is used to sign JWT tokens for authenticating the requests incoming to the SDP. The Public key is used
 # to validate that the JWT token was signed by the SDP's prvate key. They can be generated with these commands:
 # openssl ecparam -name prime256v1 -genkey -noout -out ec_private_key.pem
@@ -263,6 +264,7 @@ SECRET_PLATFORM_API_AUTH_SECRET:
 # openssl ec -in ec_private_key.pem -pubout -out ec_public_key.pem
 EC256_PUBLIC_KEY:
 EC256_PRIVATE_KEY:
+#
 ```
 
 </CodeExample>


### PR DESCRIPTION
### What

Fix SDP Authentication section

### Why

* Some fields were missing
* Some fields didn't exist
* Some fields had a wrong description of how they were used
* Some fields were paired with the wrong ones in SDP-AP synchronization.