### PR TITLE
SDFSOF-122 - Changed URL to OpenRPC spec.

### DIFF
--- a/api/anchor-platform/rpc/methods/index.mdx
+++ b/api/anchor-platform/rpc/methods/index.mdx
@@ -7,7 +7,7 @@ import {EndpointsTable} from "@site/src/components/EndpointsTable";
 
 This section lists the Anchor Platform JSON-RPC API methods that should be called by Stellar clients to update status of the transaction.
 
-The OpenRPC Specification for JSON-RPC API is available [here](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/MazurakIhor/stellar-docs/SDFSOF-122/static/assets/rpc-methods/open-rpc.json).
+The OpenRPC Specification for JSON-RPC API is available [here](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/stellar/stellar-docs/main/static/assets/rpc-methods/open-rpc.json).
 
 Postman collection is available [here](https://documenter.getpostman.com/view/9257637/2s9Y5U1kra)
 


### PR DESCRIPTION
OpenRPC spec document was originally added in a forked MazurakIhor/stellar-docs repository.
Since, this file existed only in this repo, link to OpenRPC playground had a refference to a file in this forked repo.
After changes were merged into stellar-docs, it's necessary to update URL to the OpenRPC spec of stellar-docs repo.

