### PR TITLE
Fix stellar-core docker image link

### DIFF
--- a/docs/run-core-node/installation.mdx
+++ b/docs/run-core-node/installation.mdx
@@ -15,7 +15,7 @@ In addition to SDF images, Satoshipay maintains separate Docker images for [Stel
 
 ### Production environments
 
-The SDF also maintains a Stellar-Core-only [standalone image](https://hub.docker.com/repository/docker/stellar/stellar-core).
+The SDF also maintains a Stellar-Core-only standalone image: [`stellar/stellar-core`](https://hub.docker.com/r/stellar/stellar-core).
 
 Example usage:
 


### PR DESCRIPTION
### What
Change the docker hub link for stellar-core image to be the /r/ link.

### Why
The /repository/docker/ URL isn't publicly accessible.