### PR TITLE
Remove mention of quickstart from package based stellar-core install instructions

### DIFF
--- a/docs/run-core-node/installation.mdx
+++ b/docs/run-core-node/installation.mdx
@@ -45,8 +45,6 @@ If you are using Ubuntu 18.04 LTS or later, we provide the latest stable release
 
 You may choose to install these packages individually, which offers the greatest flexibility but requires **manual** creation of the relevant configuration files and configuration of a **PostgreSQL** database.
 
-Most people, however, choose to install the [stellar-quickstart](https://github.com/stellar/packages/blob/master/docs/quickstart.md) package which configures a **Testnet** `stellar-core` and `stellar-horizon` both backed by a local PostgreSQL database. Once installed you can easily modify either the Stellar Core configuration if you want to connect to the public network.
-
 ## Installing from source
 
 See the [install from source](https://github.com/stellar/stellar-core/blob/master/INSTALL.md) for build instructions.


### PR DESCRIPTION
### What
Remove mention of quickstart from the package based stellar-core install instructions.

### Why
The mention feels out of place and misleading.

Quickstart is only intended for use in development and test environments, and discussing it as an option outside of that context could lead someone to think they should use it for a production environment.

Further up in the document under "development environments" the doc page already mentions quickstart and we don't need to mention it again under the package section.