### PR TITLE
docs: remove `/offers` from the endpoints that support streaming

### DIFF
--- a/api/horizon/introduction/streaming.mdx
+++ b/api/horizon/introduction/streaming.mdx
@@ -21,7 +21,6 @@ All attributes for the endpoints that allow streaming are the same as regular re
 | [Payments](../resources/operations/object/payment.mdx) |
 | [Effects](../resources/effects/index.mdx)              |
 | [Accounts](../resources/accounts/index.mdx)            |
-| [Offers](../resources/offers/index.mdx)                |
 | [Trades](../resources/trades/index.mdx)                |
 | [Order Books](../aggregations/order-books/index.mdx)   |
 


### PR DESCRIPTION
Resolves #254. The introductory horizon api page on streaming lists `/offers` among the endpoints that support streaming. This is not, in fact, the truth.

Refs: #254