### PR TITLE
docs: Updating testnet reset from 9am UTC to 5pm UTC

### DIFF
--- a/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
+++ b/docs/fundamentals-and-concepts/testnet-and-pubnet.mdx
@@ -31,7 +31,7 @@ If you are creating multiple Testnet accounts, fund your first account with frie
 
 The Testnet is reset periodically to the genesis ledger to declutter the network, remove spam, reduce the time needed to catch up on the latest ledger, and help maintain the system. Resets clear all ledger entries (accounts, trustlines, offers, etc.), transactions, and historical data from Stellar Core and Horizon- which is why developers should not rely on the persistence of accounts or the state of any balances when using Testnet.
 
-Testnet resets happen once per quarter at 0900 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels. Here are the 2023 dates:
+Testnet resets happen once per quarter at 17:00 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels. Here are the 2023 dates:
 
 March 15, 2023  
 June 14, 2023  


### PR DESCRIPTION
Updating the testnet reset timing from 9am(09:00) UTC to 5pm(17:00) UTC 

