### PR TITLE
horizon: add note about adding sslmode=disable to the db connection string

### DIFF
--- a/docs/run-api-server/configuring.mdx
+++ b/docs/run-api-server/configuring.mdx
@@ -35,7 +35,7 @@ You'll see that Horizon defines a large number of flags; however, only a handful
 | `--db-url` | `DATABASE_URL` | postgres://localhost/horizon_testnet |
 | `--history-archive-urls` | `HISTORY_ARCHIVE_URLS` | https://history.stellar.org/prd/core-testnet/core_testnet_001,https://history.stellar.org/prd/core-testnet/core_testnet_002 |
 
-- The most important parameter, `--db-url`, specifies the Horizon database; its value should be a valid [PostgreSQL Connection URI](http://www.postgresql.org/docs/9.6/static/libpq-connect.html#AEN46025).
+- The most important parameter, `--db-url`, specifies the Horizon database; its value should be a valid [PostgreSQL Connection URI](http://www.postgresql.org/docs/9.6/static/libpq-connect.html#AEN46025). If you are running horizon locally, you may want to add the `sslmode=disable` query parameter to the connection string, although this is not recommended in production environments.
 - The other parameter, `--history-archive-urls`, specifies a set of comma-separated locations from which Horizon should download [history archives](../run-core-node/publishing-history-archives.mdx).
 
 #### With Ingestion


### PR DESCRIPTION
Adds a note to those configuring their horizon instance locally to add the `sslmode=disable` query parameter to the `DATABASE_URL` connection string. Horizon refuses to connect without it, and developers may mistakenly believe they need to generate SSL certificates in order to get horizon working locally.