### PR TITLE
remove "SDF" from the platforms group in the Network dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -206,7 +206,7 @@ const config = {
               },
               {
                 type: 'html',
-                value: '<hr><small>SDF Platforms</small>',
+                value: '<hr><small>Platforms</small>',
                 className: 'subtitle',
               },
               {


### PR DESCRIPTION
The phrase "SDF Platforms" can lead to some confusion about what or if SDF has access to if someone's using those platforms, or if it's a service we're providing/selling, etc. "Platforms" will (hopefully) mitigate some of this confusion/hesitancy.