### PR TITLE
[ANCHOR-591] Update SEP10 clients config with sub header and env example

### DIFF
--- a/network/anchor-platform/admin-guide/sep10/README.mdx
+++ b/network/anchor-platform/admin-guide/sep10/README.mdx
@@ -35,6 +35,12 @@ By default, the Anchor Platform allows anyone with a Stellar account to authenti
 
 :::
 
+## Config With Client Attribution
+
+`SEP10_CLIENT_ATTRIBUTION_REQUIRED` informs the Anchor Platform whether it should allow users of noncustodial wallets to authenticate without the wallet also identifying itself.
+
+`CLIENTS` is the list of outside wallet servers or clients for the Anchor server to safely communicate with.
+
 <CodeExample>
 
 ```bash
@@ -69,7 +75,7 @@ clients:
     signing_key: "the custodial SEP-10 signing key of the client1"
     callback_url: https://callback.custodial-client1.com/api/v1/anchor/callback
     allow_any_destination: false
-    destination_accounts:
+    destination_accounts: destAccount1,destAccount2
   - name: custodial-client2
     type: custodial
     signing_key: "the custodial SEP-10 signing key of the client2"
@@ -79,17 +85,37 @@ clients:
     type: noncustodial
     domain: noncustodial-client1.co
     callback_url: https://callback.noncustodial-client1.co/api/v2/anchor/callback
-    signing_key: "the signing key of the client1"
+    signing_key: "the signing key of the noncustodial-client1"
   - name: noncustodial-client2
     type: noncustodial
     domain: noncustodial-client2.com
 ```
 
+```bash
+# dev.env
+# custodial client
+CLIENTS[0]_NAME=custodial-client1
+CLIENTS[0]_TYPE=custodial
+CLIENTS[0]_SIGNING_KEY="the custodial SEP-10 signing key of the client1"
+CLIENTS[0]_CALLBACK_URL=https://callback.custodial-client1.com/api/v1/anchor/callback
+CLIENTS[0]_ALLOW_ANY_DESTINATION=false
+CLIENTS[0]_DESTINATION_ACCOUNTS=destAccount1,destAccount2
+CLIENTS[1]_NAME=custodial-client2
+CLIENTS[1]_TYPE=custodial
+CLIENTS[1]_SIGNING_KEY="the custodial SEP-10 signing key of the client2"
+
+# noncustodial client
+CLIENTS[2]_NAME=noncustodial-client1
+CLIENTS[2]_TYPE=noncustodial
+CLIENTS[2]_DOMAIN=noncustodial-client1.co
+CLIENTS[2]_CALLBACK_URL=https://callback.noncustodial-client1.co/api/v2/anchor/callback
+CLIENTS[2]_SIGNING_KEY="the signing key of the noncustodial-client1"
+CLIENTS[3]_NAME=noncustodial-client2
+CLIENTS[3]_TYPE=noncustodial
+CLIENTS[3]_DOMAIN=noncustodial-client2.com
+```
+
 </CodeExample>
-
-`SEP10_CLIENT_ATTRIBUTION_REQUIRED` informs the Anchor Platform whether it should allow users of noncustodial wallets to authenticate without the wallet also identifying itself.
-
-`CLIENTS` is the list of outside wallet servers or clients for the Anchor server to safely communicate with.
 
 ## Modify a Stellar Info File
 


### PR DESCRIPTION
- Add sub header for config client attribution
- add example of env config

Here is the preview:
<img width="892" alt="Screenshot 2024-03-20 at 10 42 25 AM" src="https://github.com/stellar/stellar-docs/assets/16715182/6dd39b99-bfb5-4f7d-b756-3a10f2412e25">
