### PR TITLE
Fix the fully typed examples

### DIFF
--- a/docs/learn/smart-contract-internals/types/fully-typed-contracts.mdx
+++ b/docs/learn/smart-contract-internals/types/fully-typed-contracts.mdx
@@ -69,11 +69,17 @@ Options:
   -h, --help  Print help
 ```
 
-Like any other CLI, you can also get help for any of these subcommands using something like `native balance --help`. Soroban CLI again fetches the on-chain interface types, this time using it to generate a full list of all arguments to the function, and even generates examples. And just to be totally clear, you don't need to alias these commands. This would work, too:
+Like any other CLI, you can also get help for any of these subcommands using something like `native balance --help`. Soroban CLI again fetches the on-chain interface types, this time using it to generate a full list of all arguments to the function, and even generates examples.
+
+:::tip
+
+And just to be totally clear, you don't need to alias these commands. This would work, too:
 
 ```bash
 soroban contract invoke --network testnet --id CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC -- balance --help
-```
+ ```
+
+:::
 
 If you're unfamiliar with the `--` double dash separator, this is a pattern used by other CLIs. Everything after the double dash, sometimes called the [slop](https://github.com/clap-rs/clap/issues/971), gets passed to the child process. An example of another CLI that makes use of this is `cargo run`.
 

--- a/docs/learn/smart-contract-internals/types/fully-typed-contracts.mdx
+++ b/docs/learn/smart-contract-internals/types/fully-typed-contracts.mdx
@@ -35,49 +35,44 @@ So that's what Soroban CLI gives you.
 
 A unique CLI for each smart contract. Constructed on-the-fly, right from the on-chain interface types. Including the author's comments. An _implicit CLI_.
 
-With aliases in your shell, you can also easily make explicit CLIs out of your most-used contracts. For example, if you use the [Smart Deploy](https://communityfund.stellar.org/projects/smart-deploy-scf-13) contract:
+With aliases in your shell, you can also easily make explicit CLIs out of your most-used contracts. For example, if you use the native asset contract on the Test Network:
 
 ```bash
-$ alias smartdeploy="soroban contract invoke --id 6808e8e2cce73cfca472a8197080938b320d72e7b696e34eb52ebf17070f4ee --"
-$ smartdeploy --help
-Usage: 6808e8e2cce73cfca472a8197080938b320d72e7b696e34eb52ebf17070f4ee [COMMAND]
+$ alias native="soroban contract invoke --network testnet --id CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC --"
+$ native --help
+Usage: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC [COMMAND]
 
 Commands:
-  register_name   Register a contract name to allow publishing.
-  publish         Publish a contract.
-                    Currently a contract's version is a `u32` and publishing will increment it.
-                    If no repo is provided, then the previously published binary's repo will be used. If it's the first
-                    time then it will be empty.
-  fetch           Fetch the hash for a given contract_name.
-                    If version is not provided, it is the most recent version.
-  fetch_metadata  Fetch metadata for a given contract_name.
-                    If version is not provided, it is the most recent version.
-  deploy          Deploys a new published contract returning the deployed contract's id.
-  help            Print this message or the help of the given subcommand(s)
+  balance         Returns the balance of `id`.
+
+                      # Arguments
+
+                      * `id` - The address for which a balance is being queried. If the
+                      address has no existing balance, returns 0.
+  ...
+  transfer        Transfer `amount` from `from` to `to`.
+
+                      # Arguments
+
+                      * `from` - The address holding the balance of tokens which will be
+                      withdrawn from.
+                      * `to` - The address which will receive the transferred tokens.
+                      * `amount` - The amount of tokens to be transferred.
+
+                      # Events
+
+                      Emits an event with topics `["transfer", from: Address, to: Address],
+                      data = [amount: i128]`
+  ...
 
 Options:
   -h, --help  Print help
 ```
 
-Like any other CLI, you can also get help for any of these subcommands using something like `smartdeploy deploy --help`. Soroban CLI again fetches the on-chain interface types, this time using it to generate a full list of all arguments to the function, and even generates examples. And just to be totally clear, you don't need to alias these commands. This would work, too:
+Like any other CLI, you can also get help for any of these subcommands using something like `native balance --help`. Soroban CLI again fetches the on-chain interface types, this time using it to generate a full list of all arguments to the function, and even generates examples. And just to be totally clear, you don't need to alias these commands. This would work, too:
 
 ```bash
-soroban contract invoke --id 6808e8e2cce73cfca472a8197080938b320d72e7b696e34eb52ebf17070f4ee -- deploy --help
-```
-
-Or, if you clone [soroban-examples](https://github.com/stellar/soroban-examples) and `make build` them all, you can get CLI help for any individual contract or a specific function within a contract:
-
-```bash
-$ soroban contract invoke --id 1 --wasm target/wasm32-unknown-unknown/release/soroban_hello_world_contract.wasm -- hello --help
-Usage: hello [OPTIONS]
-
-Options:
-      --to <Symbol>
-          Example:
-            --to hello
-
-  -h, --help
-          Print help (see a summary with '-h')
+soroban contract invoke --network testnet --id CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC -- balance --help
 ```
 
 If you're unfamiliar with the `--` double dash separator, this is a pattern used by other CLIs. Everything after the double dash, sometimes called the [slop](https://github.com/clap-rs/clap/issues/971), gets passed to the child process. An example of another CLI that makes use of this is `cargo run`.

--- a/docs/learn/smart-contract-internals/types/fully-typed-contracts.mdx
+++ b/docs/learn/smart-contract-internals/types/fully-typed-contracts.mdx
@@ -77,7 +77,7 @@ And just to be totally clear, you don't need to alias these commands. This would
 
 ```bash
 soroban contract invoke --network testnet --id CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC -- balance --help
- ```
+```
 
 :::
 


### PR DESCRIPTION
### What
Update the examples in the fully typed docs learn page to use contract IDs and the latest CLI command structure.

### Why
It appears it's way out of date and these commands won't work. One of the example commands no longer exist. And the use of hashes for contract IDs is no longer supported. 