### PR TITLE
use the regular DocItem for the horizon providers page

### DIFF
--- a/src/theme/ApiItem/index.js
+++ b/src/theme/ApiItem/index.js
@@ -8,6 +8,7 @@ export default function ApiItemWrapper(props) {
     || props.location?.pathname?.startsWith('/network/hubble')
     || props.location?.pathname?.startsWith('/network/soroban-rpc')
     || props.location?.pathname?.startsWith('/network/core-node')
+    || props.location?.pathname === '/network/horizon/horizon-providers'
   ) {
     return (
       <>


### PR DESCRIPTION
[This page](https://developers.stellar.org/network/horizon/horizon-providers) makes use of tables to display the various ecosystem providers. When using the `ApiItem` component for that, the tables are pushed off to the side. This PR will add this path to our exceptions, and render the normal `DocItem` for this page.