### PR TITLE
This property is actually TransactionMeta not TransactionResultMeta.

### DIFF
--- a/openrpc/src/methods/getTransaction.json
+++ b/openrpc/src/methods/getTransaction.json
@@ -65,7 +65,7 @@
                 },
                 "resultMetaXdr": {
                     "type": "string",
-                    "description": "(optional) A base64 encoded string of the raw TransactionResultMeta XDR struct for this transaction."
+                    "description": "(optional) A base64 encoded string of the raw TransactionMeta XDR struct for this transaction."
                 }
             },
             "required": [ "status", "latestLedger", "latestLedgerCloseTime", "oldestLedger", "oldestLedgerCloseTime" ]


### PR DESCRIPTION
The documentation has an incorrect XDR for the `resultMetaXdr` field, it should be `TransactionMeta` and not `TransactionResultMeta`.  This can be confirmed by trying to parse the `resultMetaXdr` from the below example using the [Stellar Laboratory](https://laboratory.stellar.org/#xdr-viewer), where `TransactionResultMeta` fails and `TransactionMeta` succeeds.

I used this `getTransaction` result of a Stellar Mainnet transaction to verify. The transaction hash is `0B578DF8EDAB61E4307E0E6C484FA884CB882588C04A200E3B682305F2B39CF2`.

```json
{
    "status": "SUCCESS",
    "latestLedger": 51007568,
    "latestLedgerCloseTime": "1711748668",
    "oldestLedger": 51006129,
    "oldestLedgerCloseTime": "1711739955",
    "applicationOrder": 599,
    "envelopeXdr": "AAAAAgAAAADwqNifvTI8nYWy0ciY5ZWLIbPkR0IAQpvx98I67xKJ6AAAAGQCqx8GAAAABQAAAAAAAAAAAAAAAQAAAAAAAAABAAAAAGNl44l0UdJOIp14bROOPOWHqAF1Mv4pTUDaX2ibZ8wtAAAAAAAAAAAAAAABAAAAAAAAAAHvEonoAAAAQJFpgfi8+G9/Lip723AMIdZmf1xxRp56lzp7V/a8fn6VaYEMlZBI1KZ64wWqdGth/LUnBgt00tNCzST5cq6GsA4=",
    "resultXdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
    "resultMetaXdr": "AAAAAwAAAAAAAAACAAAAAwMKUC8AAAAAAAAAAPCo2J+9MjydhbLRyJjllYshs+RHQgBCm/H3wjrvEonoAAAAAd7dBpkCqx8GAAAABAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAwpQAAAAAABmBzRZAAAAAAAAAAEDClAvAAAAAAAAAADwqNifvTI8nYWy0ciY5ZWLIbPkR0IAQpvx98I67xKJ6AAAAAHe3QaZAqsfBgAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAMKUC8AAAAAZgc1eAAAAAAAAAABAAAABAAAAAMDClAvAAAAAAAAAADwqNifvTI8nYWy0ciY5ZWLIbPkR0IAQpvx98I67xKJ6AAAAAHe3QaZAqsfBgAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAMKUC8AAAAAZgc1eAAAAAAAAAABAwpQLwAAAAAAAAAA8KjYn70yPJ2FstHImOWViyGz5EdCAEKb8ffCOu8SiegAAAAB3t0GmAKrHwYAAAAFAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAADClAvAAAAAGYHNXgAAAAAAAAAAwMKUAAAAAAAAAAAAGNl44l0UdJOIp14bROOPOWHqAF1Mv4pTUDaX2ibZ8wtAAAAAAX14QMDCA/nAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQMKUC8AAAAAAAAAAGNl44l0UdJOIp14bROOPOWHqAF1Mv4pTUDaX2ibZ8wtAAAAAAX14QQDCA/nAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
    "ledger": 51007535,
    "createdAt": "1711748472"
}
```