### PR TITLE
Fix Anchor Platform docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,6 +84,7 @@ const config = {
         sidebarPath: require.resolve("./sidebarsNetwork.js"),
         sidebarItemsGenerator: require("./src/sidebar-network-generator"),
         editUrl: "https://github.com/stellar/stellar-docs/tree/main",
+        exclude: ['**/component/**', '**/README.md'],
         showLastUpdateTime: true,
         showLastUpdateAuthor: true,
       },

--- a/network/anchor-platform/admin-guide/events/getting-started.mdx
+++ b/network/anchor-platform/admin-guide/events/getting-started.mdx
@@ -3,10 +3,6 @@ title: Getting Started
 sidebar_position: 10
 ---
 
-Anchor Platform provides an event service that allows your business application and wallets to receive updates about transaction updates via HTTP webhooks.
+Anchor Platform provides an event service that allows your business application and wallets to receive updates about transaction updates via HTTP webhooks without the need to poll the transactions API.
 
 By integrating your business server with the event service, you will be able to receive updates about the status of transactions, including when they are submitted, completed, and failed as well as any quotes created or when customer information is updated.
-
-The event service is **required** for the [SEP-6 integration][sep-6] as there are no SEP-6 callbacks.
-
-[sep-6]: ../sep6/README.mdx


### PR DESCRIPTION
This PR fixes two things:
1. Removes requirement of event service for SEP-6.
2. Exclude the `/component` directory from the sidebar.