### PR TITLE
Add txHash field to getEvents response items:

### DIFF
--- a/openrpc/src/schemas/Event.json
+++ b/openrpc/src/schemas/Event.json
@@ -35,6 +35,10 @@
             },
             "value": {
                 "$ref": "#/components/schemas/EventValue"
+            },
+            "txHash": {
+                "type": "string",
+                "description": "The transaction which triggered this event."
             }
         }
     },


### PR DESCRIPTION
See https://github.com/stellar/js-stellar-sdk/issues/938 and the actual proof here:

```bash
curl -s --location 'https://soroban-testnet.stellar.org/' \
  --header 'Content-Type: application/json' \
  --data '{
    "jsonrpc": "2.0",
    "id": 10235,
    "method": "getEvents", "params": {"startLedger": 1184000, "endLedger": 1185072, "filters": [{"topics": []}]}
}' | jq '.result.events[0]'
```

returns the following:

```json
{
  "type": "diagnostic",
  "ledger": 1184016,
  "ledgerClosedAt": "2024-04-18T18:05:21Z",
  "contractId": "",
  "id": "0005085309997948928-0000000000",
  "pagingToken": "0005085309997948928-0000000000",
  "topic": [
    "AAAADwAAAAdmbl9jYWxsAA==",
    "AAAADQAAACBVkqNeeMWaJ6fGFVD0NhNxSTQdXVfI6TONZODy5H/xvg==",
    "AAAADwAAAAlzZXRfcHJpY2UAAAA="
  ],
  "value": "AAAAEAAAAAEAAAADAAAAEgAAAAAAAAAA858ZjeNabvXLtYtAqjhYbr6rR/MbcXLFLbxWY8fGUAgAAAAQAAAAAQAAABAAAAAKAAAAAAAAAABXRvHCbwj65AAAAAoAAAAAAAAAAAQ4yO9TO7OMAAAACgAAAAAAAAAAAABbAB765A8AAAAKAAAAAAAAAAAAAC1H3/aULQAAAAoAAAAAAAAAAAAwtqc4+tCOAAAACgAAAAAAAAAAAABa8z3hydQAAAAKAAAAAAAAAAAAACi/bpIDegAAAAoAAAAAAAAAAAAMPLqqRGApAAAACgAAAAAAAAAAAAJfPnxcwZMAAAAKAAAAAAAAAAAAADzKIUClLQAAAAoAAAAAAAAAAAAEy7aTOEj9AAAACgAAAAAAAAAAAABa9SV9s+sAAAAKAAAAAAAAAAAAAuc8SPdVrQAAAAoAAAAAAAAAAAAACd2C0+nNAAAACgAAAAAAAAAAAAKHGLRYXagAAAAKAAAAAAAAAAAAAGCj0K+BMAAAAAUAAAGO8mIc4A==",
  "inSuccessfulContractCall": true,
  "txHash": "95b874e9462e2b69fa5150e11025d3bb1bc54c4d86ba67ad8eb114ce41269478"
}
```

as you can see, there is an undocumented `txHash` field.