### PR TITLE
Use icons for navbar links to github and discord

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -238,13 +238,15 @@ const config = {
           },
           {
             href: "https://github.com/stellar/stellar-docs",
-            label: "GitHub",
             position: "right",
+            className: "header-github-link",
+            'aria-label': "GitHub",
           },
           {
             href: "https://discord.gg/stellardev",
-            label: "Discord",
             position: "right",
+            className: "header-discord-link",
+            'aria-label': "Discord",
           },
           {
             type: "search",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,6 +137,10 @@ const config = {
       integrity: 'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
       crossorigin: 'anonymous',
     },
+    {
+      href: "https://use.fontawesome.com/releases/v6.5.2/css/all.css",
+      type: 'text/css',
+    },
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -252,10 +252,6 @@ const config = {
             className: "header-discord-link",
             'aria-label': "Discord",
           },
-          {
-            type: "search",
-            position: "right",
-          },
         ],
       },
       algolia: {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -169,3 +169,17 @@ select[data-testid="example-pairing-select"] {
 .sidebar-category-items-hidden ul {
   display: none !important;
 }
+
+/* Header link icons */
+
+.header-github-link::before {
+  content: "\f09b";
+  font-family: "Font Awesome 6 Brands";
+  font-size: x-large;
+}
+
+.header-discord-link::before {
+  content: "\f392";
+  font-family: "Font Awesome 6 Brands";
+  font-size: x-large;
+}


### PR DESCRIPTION
In an attempt to save space in the navbar, and still link to the github repository and the discord server, let's consider using icons for those links (with appropriate accessible labels).