### PR TITLE
Extend sep-06 wallet sdk doc for flutter

### DIFF
--- a/docs/building-apps/wallet/component/dart/install.mdx
+++ b/docs/building-apps/wallet/component/dart/install.mdx
@@ -4,8 +4,8 @@ import { CodeExample } from "@site/src/components/CodeExample";
 
 ```dart
 // pubspec.yaml
-stellar_wallet_flutter_sdk: ^0.2.0
-stellar_flutter_sdk: ^1.7.4
+stellar_wallet_flutter_sdk: ^0.3.0
+stellar_flutter_sdk: ^1.7.7
 ```
 
 </CodeExample>

--- a/docs/building-apps/wallet/sep6.mdx
+++ b/docs/building-apps/wallet/sep6.mdx
@@ -8,7 +8,7 @@ import { LanguageSpecific } from "@site/src/components/LanguageSpecific";
 import { WalletCodeExample as CodeExample } from "@site/src/components/WalletCodeExample";
 import Header from "./component/header.mdx";
 
-<Header WIPLangs={["kotlin", "dart"]} />
+<Header WIPLangs={["kotlin"]} />
 
 The [SEP-6] standard defines a way for anchors and wallets to interact on behalf of users. Wallets use this standard to facilitate exchanges between on-chain assets (such as stablecoins) and off-chain assets (such as fiat, or other network assets such as BTC).
 
@@ -24,6 +24,10 @@ Let's start with creating a sep6 object, which we'll use for all SEP-6 interacti
 const sep6 = anchor.sep6();
 ```
 
+```dart
+var sep6 = anchor.sep6();
+```
+
 </CodeExample>
 
 First, let's get information about the anchor's support for [SEP-6]. This request doesn't require authentication, and will return generic info, such as supported currencies, and features supported by the anchor. You can get a full list of returned fields in the [SEP-6 specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#info).
@@ -32,6 +36,10 @@ First, let's get information about the anchor's support for [SEP-6]. This reques
 
 ```typescript
 const info = await sep6.info();
+```
+
+```dart
+var info = await sep6.info();
 ```
 
 </CodeExample>
@@ -60,6 +68,13 @@ const deposit = await sep6.deposit({
     account,
   },
 });
+```
+
+```dart
+var deposit = await anchor.sep6().deposit(
+  Sep6DepositParams(assetCode: assetCode, account: accountId),
+  authToken,
+);
 ```
 
 </CodeExample>
@@ -108,6 +123,12 @@ if (deposit.type === "non_interactive_customer_info_needed") {
 }
 ```
 
+```dart
+if (deposit is Sep6MissingKYC) {
+  print(deposit.fields);
+}
+```
+
 </CodeExample>
 
 The wallet will need to handle displaying to the user which fields are missing. And then to add those fields, we can use the sep12 class like so.
@@ -126,6 +147,20 @@ await sep12.add({
     tax_id: "123",
   },
 });
+```
+
+```dart
+var sep12 = await anchor.sep12(authToken);
+
+// adding the missing kyc info (sample data)
+var sep9Info = {
+  'family_name': 'smith',
+  'given_name': 'john',
+  'address': '123 street',
+  'tax_id': '123',
+};
+
+var addResponse = await sep12.add(sep9Info);
 ```
 
 </CodeExample>
@@ -160,6 +195,28 @@ await sep12.add({
 });
 ```
 
+```dart
+var sep12 = await anchor.sep12(authToken);
+
+var sep9Info = {
+  'first_name': 'john',
+  'last_name': 'smith',
+  'email_address': '123@gmail.com',
+  'bank_number': '12345',
+  'bank_account_number': '12345',
+};
+
+var photoIdFront = await Util.readFile('./path/to/image/front');
+var photoIdBack = await Util.readFile('./path/to/image/back');
+
+var sep9Files = {
+  'photo_id_front': photoIdFront,
+  'photo_id_back': photoIdBack,
+};
+
+await sep12.add(sep9Info, sep9Files: sep9Files);
+```
+
 </CodeExample>
 
 ## Start a withdrawal
@@ -179,6 +236,18 @@ const resp = await sep6.withdraw({
     dest_extra: "12345",
   },
 });
+```
+
+```dart
+var params = Sep6WithdrawParams(
+    assetCode: 'SRT',
+    account: accountId,
+    type: 'bank_account',
+    dest: '123',
+    destExtra: '12345',
+);
+
+var resp = await anchor.sep6().withdraw(params, authToken);
 ```
 
 </CodeExample>
@@ -205,6 +274,16 @@ const resp = await sep6.depositExchange({
 });
 ```
 
+```dart
+var params = Sep6DepositExchangeParams(
+    destinationAssetCode: 'SRT',
+    sourceAssetId: FiatAssetId('USD'),
+    amount: '10',
+);
+
+var resp = await anchor.sep6().depositExchange(params, authToken);
+```
+
 </CodeExample>
 
 The response follows the same types as all the deposits and withdrawals for SEP-6.
@@ -224,6 +303,17 @@ const resp = await sep6.withdrawExchange({
     type: "bank_account",
   },
 });
+```
+
+```dart
+var params = Sep6WithdrawExchangeParams(
+    sourceAssetCode: 'SRT',
+    destinationAssetId: FiatAssetId('USD'),
+    amount: '10',
+    type: 'bank_account',
+);
+
+var resp = await anchor.sep6().withdrawExchange(params, authToken);
 ```
 
 </CodeExample>
@@ -253,6 +343,23 @@ const { stop, refresh } = watcher.watchOneTransaction({
 });
 ```
 
+```dart
+var watcher = anchor.sep6.watcher();
+var result = watcher.watchOneTransaction(authToken, 'transaction id');
+
+result.controller.stream.listen(
+  (event) {
+    if (event is StatusChange) {
+      print('Status changed to ${event.status}. Transaction: ${event.transaction.id}');
+    } else if (event is ExceptionHandlerExit) {
+      print('Exception handler exited the job');
+    } else if (event is StreamControllerClosed) {
+      print('Stream controller closed. Job is done');
+    }
+  }
+);
+```
+
 </CodeExample>
 
 Alternatively, we can track multiple transactions for the same asset.
@@ -270,6 +377,23 @@ const { stop, refresh } = watcher.watchAllTransactions({
 });
 ```
 
+```dart
+var watcher = anchor.sep6.watcher();
+var result = watcher.watchAsset(authToken, asset);
+
+result.controller.stream.listen(
+  (event) {
+    if (event is StatusChange) {
+      print('Status changed to ${event.status}. Transaction: ${event.transaction.id}');
+    } else if (event is ExceptionHandlerExit) {
+      print('Exception handler exited the job');
+    } else if (event is StreamControllerClosed) {
+      print('Stream controller closed. Job is done');
+    }
+  }
+);
+```
+
 </CodeExample>
 
 ### Fetching Transaction
@@ -284,6 +408,13 @@ const transaction = await anchor
   .getTransactionBy({ authToken, id: transactionId });
 ```
 
+```dart
+var transaction = await anchor.sep6().getTransactionBy(
+    authToken: authToken,
+    id: transactionId,
+);
+```
+
 </CodeExample>
 
 It's also possible to fetch transactions by the asset.
@@ -295,6 +426,13 @@ const transactions = await anchor.sep6().getTransactionsForAsset({
   authToken,
   assetCode,
 });
+```
+
+```dart
+var transactions = await anchor.sep6().getTransactionsForAsset(
+  authToken: authToken,
+  assetCode: assetCode,
+);
 ```
 
 </CodeExample>


### PR DESCRIPTION
The flutter wallet sdk now supports sep-06.
This PR adds the dart code examples to the sep-06 wallet sdk doc. 