### PR TITLE
fix typo in Counter.astro script

### DIFF
--- a/docs/smart-contracts/getting-started/create-an-app.mdx
+++ b/docs/smart-contracts/getting-started/create-an-app.mdx
@@ -325,7 +325,7 @@ Current value: <strong id="current-value" aria-live="polite">???</strong><br />
 
 <script>
   import incrementor from "../contracts/soroban_increment_contract";
-  import { isAllowed, getUserInfo, signTransaction } from '@stellar/freighter-api';
+  import { isAllowed, getPublicKey, signTransaction } from '@stellar/freighter-api';
   const button = document.querySelector("[data-increment]");
   const currentValue = document.querySelector("#current-value");
   if (await isAllowed()) {


### PR DESCRIPTION
Fixes a typo I had introduced when updating the getting started tutorial.