### PR TITLE
Re-write "set/clear flags" description in the list of operations to include more useful links

### DIFF
--- a/docs/learn/fundamentals/list-of-operations.mdx
+++ b/docs/learn/fundamentals/list-of-operations.mdx
@@ -237,7 +237,7 @@ Learn more about passive sell offers: [Liquidity on Stellar: SDEX and Liquidity 
 
 Set options for an account such as flags, inflation destination, signers, home domain, and master key weight
 
-Learn more about flags: [Flags Encyclopedia Entry](../glossary.mdx/#flags)  
+Learn more about flags: [Flags Encyclopedia Entry](../glossary.mdx#flags)  
 Learn more about the home domain: [Stellar Ecosystem Proposals SEP-0001](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md)  
 Learn more about signers operations and key weight: [Signature and Multisignature Encyclopedia Entry](../encyclopedia/signatures-multisig.mdx)
 
@@ -249,8 +249,8 @@ Learn more about signers operations and key weight: [Signature and Multisignatur
 | Parameters | Type | Description |
 | --- | --- | --- |
 | Inflation Destination | account ID | Account of the inflation destination. |
-| Clear flags | integer | Indicates which flags to clear. For details about the flags, please refer to the [Accounts section](./stellar-data-structures/accounts.mdx). The bit mask integer subtracts from the existing flags of the account. This allows for setting specific bits without knowledge of existing flags. |
-| Set flags | integer | Indicates which flags to set. For details about the flags, please refer to the [Accounts section](./stellar-data-structures/accounts.mdx). The bit mask integer adds onto the existing flags of the account. This allows for setting specific bits without knowledge of existing flags. |
+| Clear flags | integer | Indicates which [account](./stellar-data-structures/accounts.mdx) flags to clear. These account-level flags are primarily used by asset issuers; for details about the flags, please refer to the [Asset Design Considerations page](../../issuing-assets/control-asset-access.mdx#controlling-access-to-an-asset-with-flags). The bit mask integer subtracts from the existing flags of the account. This allows for setting specific bits without knowledge of existing flags. |
+| Set flags | integer | Indicates which [account](./stellar-data-structures/accounts.mdx) flags to set. These account-level flags are primarily used by asset issuers; for details about the flags, please refer to the [Asset Design Considerations page](../../issuing-assets/control-asset-access.mdx#controlling-access-to-an-asset-with-flags) The bit mask integer adds onto the existing flags of the account. This allows for setting specific bits without knowledge of existing flags. |
 | Master weight | integer | A number from 0-255 (inclusive) representing the weight of the master key. If the weight of the master key is updated to 0, it is effectively disabled. |
 | Low threshold | integer | A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have [a low threshold](../encyclopedia/signatures-multisig.mdx). |
 | Medium threshold | integer | A number from 0-255 (inclusive) representing the threshold this account sets on all operations it performs that have [a medium threshold](../encyclopedia/signatures-multisig.mdx). |


### PR DESCRIPTION
added a note about using the account-level flags for asset issuers so it makes more sense to direct them to the asset design page.

Refs: #299