### PR TITLE
Update smart-contract-deployment.mdx

### DIFF
--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -869,20 +869,20 @@ fn withdraw(e: Env, to: Address, amount: i128) -> i128 {
     // First transfer the vault shares that need to be redeemed
     let share_token_client = token::Client::new(&e, &get_token_share(&e));
     share_token_client.transfer(&to, &e.current_contract_address(), &amount);
+
+    // Calculate total amount including yield
+    let total_amount = amount + (amount / 100);
+
     let token_client = token::Client::new(&e, &get_token(&e));
-    token_client.transfer(
-        &e.current_contract_address(),
-        &to,
-        &(&amount + (&amount / &100)),
-    );
+    token_client.transfer(&e.current_contract_address(), &to, &total_amount);
 
     let balance = get_token_balance(&e);
     let balance_shares = get_balance_shares(&e);
 
     burn_shares(&e, balance_shares);
-    put_reserve(&e, balance - amount);
+    put_reserve(&e, balance); // Update the reserve with the actual balance
 
-    amount
+    total_amount
 }
 ```
 
@@ -891,6 +891,7 @@ fn withdraw(e: Env, to: Address, amount: i128) -> i128 {
 - The `transfer_token` method of the `token_client` instance transfers tokens from the vault contract to the withdrawer.
 - `burn_shares` is called to burn the shares that were transferred to the vault contract.
 - `put_reserve` stores the current token balance in a reserved location.
+- Returns the total amount of tokens withdrawn by the user.
 
 > _Note_ : In the withdrawal function, you'll notice that the transfer amount is defined as `&(&amount + (&amount / &100))`. This is a simple yield calculation that assumes the yield to be 1% of the amount being withdrawn. However, it's important to note that this is a very simplistic approach and may not be suitable for production-grade systems. In reality, yield calculations are more complex and involve various factors such as market conditions, risk management, and fees.
 
@@ -952,7 +953,6 @@ soroban contract deploy \
 
 ```bash
 soroban contract invoke \
-    --wasm soroban_token_contract.wasm \
     --id <TOKEN_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -971,7 +971,6 @@ soroban contract invoke \
 
 ```bash
 soroban contract invoke \
-    --wasm soroban_token_contract.wasm \
     --id <TOKEN_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -988,7 +987,6 @@ soroban contract invoke \
 
 ```bash
 soroban contract invoke \
-    --wasm soroban_token_contract.wasm \
     --id <TOKEN_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1003,7 +1001,11 @@ soroban contract invoke \
 <TabItem value="insatll wasm" label="install.sh">
 
 ```bash
-soroban contract install --wasm soroban_token_contract.wasm
+soroban contract install \
+    --wasm soroban_token_contract.wasm \
+    --source <SECRET_KEY> \
+    --rpc-url https://soroban-testnet.stellar.org:443 \
+    --network-passphrase 'Test SDF Network ; September 2015'
 ```
 
 </TabItem>
@@ -1024,7 +1026,6 @@ soroban contract deploy \
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1041,7 +1042,6 @@ soroban contract invoke \
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1056,7 +1056,6 @@ soroban contract invoke \
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1073,7 +1072,6 @@ soroban contract invoke \
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1088,7 +1086,6 @@ soroban contract invoke \
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1130,7 +1127,6 @@ Next we need to initialize the token contract. We can do this by running the `in
 
 ```bash
 soroban contract invoke \
-    --wasm soroban_token_contract.wasm \
     --id <TOKEN_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1162,7 +1158,11 @@ CBBPLE6TGYOMO5HUF2AMYLSYYXM2VYZVAVYI5QCCM5OCFRZPBE2XA53F
 Now we need to get the Wasm hash of the token contract. We can do this by running the `get_token_wasm_hash.sh` script.
 
 ```bash
-soroban contract install --wasm soroban_token_contract.wasm
+soroban contract install \
+    --wasm soroban_token_contract.wasm \
+    --source <SECRET_KEY> \
+    --rpc-url https://soroban-testnet.stellar.org:443 \
+    --network-passphrase 'Test SDF Network ; September 2015'
 ```
 
 We should receive the Wasm hash of the token contract.
@@ -1175,7 +1175,6 @@ Now we need to initialize the vault contract. We can do this by running the `ini
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1190,7 +1189,6 @@ After recieving the transaction has been submitted, we will mint some tokens to 
 
 ```bash
 soroban contract invoke \
-    --wasm soroban_token_contract.wasm \
     --id <TOKEN_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1205,7 +1203,6 @@ After submitting the transaction, we can check the balance of the account. We ca
 
 ```bash
 soroban contract invoke \
-    --wasm soroban_token_contract.wasm \
     --id <TOKEN_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1225,7 +1222,6 @@ Now we can deposit some tokens into our vault. We can do this by running the `de
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <ACCOUNT_SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1240,7 +1236,6 @@ After submitting the transaction, we can check the reserves of the vault. We can
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
@@ -1261,7 +1256,6 @@ Now we can withdraw some tokens from the vault. We can do this by running the `w
 
 ```bash
 soroban contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/vault.wasm \
     --id <VAULT_CONTRACT_ID> \
     --source <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \


### PR DESCRIPTION
The it is an issue in the vault contract's withdraw function which will incorrectly update the value of Reserve.

In this line

    let balance = get_token_balance(&e);

balance is updated AFTER the transfer of the user deposit + yield has already occurred. 

Thus the balance fetched is already the current "reserve" balance of the Vault. 

So when the following line of code executes:

put_reserve(&e, balance - amount);

the Reserve is updated to the balance of the Vault contract - the amount withdrawn by the user, so it will count the withdrawn 2 times. 

Indeed when following the test the result from "get_rsrvs" in the first scenario will be :

"-1" 

Initial balance of the Vault: 200 - amount: 100 + yield: 1 (from the transfer) - amount: 100 (from the put_reserve input). 

For further improvements the get_rsrvs should only account for the amount of reward tokens that the vault is holding which can be useful to obtain the deposited amount (vault balance - reserves).

Additionally the --wasm argument in the "invoke" command is not needed and it was removed.