### PR TITLE
[SDP] Enforce home domain in the SEP-10 challenge transaction

### DIFF
--- a/network/stellar-disbursement-platform/admin-guide/making-your-wallet-sdp-ready.mdx
+++ b/network/stellar-disbursement-platform/admin-guide/making-your-wallet-sdp-ready.mdx
@@ -79,10 +79,10 @@ Once the user has installed the wallet application, the wallet should be able to
 https://<host-with-optional-path>?asset=<asset>&domain=<domain>&name=<name>&signature=<signature>
 ```
 
-- `asset`: the Stellar asset
-- `domain`: the domain hosting the SDP's `stellar.toml` file
-- `name`: the name of the organization sending payments
-- `signature`: a signature from the SDP's [SEP-10] signing key
+- `asset`: the Stellar asset.
+- `domain`: the domain hosting the SDP's `stellar.toml` file. The wallet will need to use it to both fetch the `stellar.toml` file, and to populate the `home_domain` field in the [SEP-10] GET challenge transaction.
+- `name`: the name of the organization sending payments.
+- `signature`: a signature from the SDP's [SEP-10] signing key.
 
 > Note that the deep link is specific to each SDP, payer org, and asset. It is not specific per individual receiver. There is no risk in sharing the link with receivers who are part of the same disbursement. The link will be the same for multiple receivers and they will prove their identity as part of the [SEP-24] deposit flow.
 
@@ -140,7 +140,10 @@ When opening registration [deep link], these are the steps the wallet should fol
 1. Check the `asset` from the link and confirm that the recipient user has a trustline for that asset. Create one if it doesn't exist.
 1. (Optional) Use the `name` from the link to update the wallet user interface.
 1. Initiate the [SEP-24] deposit flow with that asset using the `TRANSFER_SERVER_SEP0024` value from the SDP's toml file.
-   - This includes using [SEP-10] to authenticate the user with the SDP's server and implementing the `client_domain` check, as detailed in the [SEP-10] spec.
+   - This includes using [SEP-10] to authenticate the user with the SDP server. Please notice that the SDP requires both the `client_domain` and `home_domain` fields to be provided in the `GET <WEB_AUTH_ENDPOINT>` request, and they should be set as follows:
+     - `client_domain`: the domain of the wallet server that exposes the wallet server's `stellar.toml` file.
+	 - `home_domain`: the domain of the SDP's server that was present in the registration link.
+	 - `account`: the Stellar account of the receiver's wallet.
 1. Launch the deposit flow interactive _in-app browser_ within your mobile app, following the instructions in the [SEP-24] spec.
    - ATTENTION: the wallet should not, in any circumstances, scrape or attempt to scrape the content from the _in-app browser_ for the recipient's information.
    - NOTE: it's highly recommended to use an _in-app browser_ rather than a webview.


### PR DESCRIPTION
### Why

To keep the docs up to date with the code. This is now required in the multitenant instance.