### PR TITLE
Updates to Getting Started Docs

### DIFF
--- a/docs/smart-contracts/getting-started/create-an-app.mdx
+++ b/docs/smart-contracts/getting-started/create-an-app.mdx
@@ -18,7 +18,7 @@ You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) 
 
 We want to initialize our current project as an Astro project. To do this, we can again turn to the `soroban contract init` command, which has a `--frontend-template` flag that allows us to pass the url of a frontend template repository. As we learned in [Storing Data](storing-data.mdx#adding-the-increment-contract), `soroban contract init` will not overwrite existing files, and is safe to use to add to an existing project.
 
-From our `getting-started-tutorial` directory, run the following command to add the Astro template files.
+From our `soroban-hello-world` directory, run the following command to add the Astro template files.
 
 ```sh
 soroban contract init ./ \

--- a/docs/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/smart-contracts/getting-started/hello-world.mdx
@@ -260,10 +260,10 @@ The contract is registered with the environment using the contract type. Contrac
 let contract_id = env.register_contract(None, Contract);
 ```
 
-All public functions within an `impl` block that is annotated with the `#[contractimpl]` attribute have a corresponding function generated in a generated client type. The client type will be named the same as the contract type with `Client` appended. For example, in our contract the contract type is `Contract`, and the client is named `ContractClient`.
+All public functions within an `impl` block that is annotated with the `#[contractimpl]` attribute have a corresponding function generated in a generated client type. The client type will be named the same as the contract type with `Client` appended. For example, in our contract the contract type is `HelloContract`, and the client is named `HelloContractClient`.
 
 ```rust
-let client = ContractClient::new(&env, &contract_id);
+let client = HelloContractClient::new(&env, &contract_id);
 let words = client.hello(&symbol_short!("Dev"));
 ```
 

--- a/docs/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/smart-contracts/getting-started/hello-world.mdx
@@ -23,7 +23,7 @@ Once you've [set up](./setup.mdx) your development environment, you're ready to 
 
 ## Create a New Project
 
-Create a new project using the `init` command to create a `getting-started-tutorial` project.
+Create a new project using the `init` command to create a `soroban-hello-world` project.
 
 ```sh
 soroban contract init soroban-hello-world

--- a/docs/smart-contracts/getting-started/setup.mdx
+++ b/docs/smart-contracts/getting-started/setup.mdx
@@ -105,28 +105,29 @@ soroban
 $ soroban
 Build, deploy, & interact with contracts; set identities to sign with; configure networks; generate keys; and more.
 
-Intro: https://soroban.stellar.org
-CLI Reference: https://github.com/stellar/soroban-tools/tree/main/docs/soroban-cli-full-docs.md
+Stellar Docs: https://developers.stellar.org
+CLI Full Hep Docs: https://github.com/stellar/soroban-cli/tree/main/FULL_HELP_DOCS.md
 
 Usage: soroban [OPTIONS] <COMMAND>
 
 Commands:
   completion  Print shell completion code for the specified shell
-  config      Deprecated, use `soroban keys` and `soroban network` instead
   contract    Tools for smart contract developers
   events      Watch the network for contract events
   keys        Create and manage identities including keys and addresses
-  lab         Experiment with early features and expert tools
+  xdr         Decode and encode XDR
   network     Start and configure networks
   version     Print version information
+  cache       Cache for tranasctions and contract specs
 
 Options:
       --global                     Use global config
-  -f, --filter-logs <FILTER_LOGS>  Filter logs output. To turn on "soroban_cli::log::footprint=debug" or off "=off". Can also use env var `RUST_LOG`
+  -f, --filter-logs <FILTER_LOGS>  Filter logs output. To turn on "stellar_cli::log::footprint=debug" or off "=off". Can also use env var `RUST_LOG`
   -q, --quiet                      Do not write logs to stderr including `INFO`
   -v, --verbose                    Log DEBUG events
       --very-verbose               Log DEBUG and TRACE events [aliases: vv]
-      --list                       List installed plugins. E.g. `soroban-hello`
+      --list                       List installed plugins. E.g. `stellar-hello`
+      --no-cache                   Do not cache your simulations and transactions [env: STELLAR_NO_CACHE=]
   -h, --help                       Print help (see more with '--help')
   -V, --version                    Print version
 

--- a/docs/smart-contracts/getting-started/storing-data.mdx
+++ b/docs/smart-contracts/getting-started/storing-data.mdx
@@ -29,7 +29,7 @@ This tutorial assumes that you've already completed the previous steps in Gettin
 
 The `soroban contract init` command allows us to initialize a new project with any of the example contracts from the [soroban-examples](https://github.com/stellar/soroban-examples) repo, using the `--with-example` (or `-w`) flag.
 
-It will not overwrite existing files, so we can also use this command to add a new contract to an existing project. Run the command again with a `--with-example` flag to add an `increment` contract to our project. From inside our `getting-started-tutorial` directory, run:
+It will not overwrite existing files, so we can also use this command to add a new contract to an existing project. Run the command again with a `--with-example` flag to add an `increment` contract to our project. From inside our `soroban-hello-world` directory, run:
 
 ```sh
 soroban contract init ./ --with-example increment
@@ -138,7 +138,7 @@ For now, it's worth knowing that there are three kinds of storage: `Persistent`,
 
 ### Build the contract
 
-From inside `getting-started-tutorial`, run:
+From inside `soroban-hello-world`, run:
 
 ```sh
 soroban contract build

--- a/docs/smart-contracts/tokens/wayfinding.mdx
+++ b/docs/smart-contracts/tokens/wayfinding.mdx
@@ -26,7 +26,7 @@ Stellar’s transactions are fast and cost-effective, making the network great f
 Stellar assets:
 
 - Are compatible with Stellar ecosystem products (such as Stellar wallets) and other ecosystem products (such as exchanges).
-- Benefit from [anchors](../../learn/encyclopedia/anchors.mdx), the bridges between the Stellar network and traditional financial systems. Explore the global [Stellar anchor directory](https://anchors.stellar.org/) for further details.
+- Benefit from [anchors](../../learn/fundamentals/anchors.mdx), the bridges between the Stellar network and traditional financial systems. Explore the global [Stellar anchor directory](https://anchors.stellar.org/) for further details.
 - Give the issuer granular control over asset management with features that allow the issuer to [name the asset](../../issuing-assets/control-asset-access.mdx#naming-an-asset), [determine access control](../../issuing-assets/control-asset-access.mdx#controlling-access-to-an-asset-with-flags), [limit asset supply](../../issuing-assets/control-asset-access.mdx#limiting-the-supply-of-an-asset), [publish asset information](../../issuing-assets/publishing-asset-info.mdx), and [ensure compliance](../../issuing-assets/anatomy-of-an-asset.mdx#compliance).
 
 :::note


### PR DESCRIPTION
A few things I found while going through the Getting Started tutorial:

- Updated the expected output of `$ soroban`, the old output here referenced out of date docs links
- There were parts of the docs that said `ContractClient` that I believe should read `HelloContractClient`
- The directory the tutorial makes is `soroban-hello-world`, not `getting-started-tutorial` so I updated references that ask you to use a directory you don't have