### PR TITLE
[ANCHOR-714] Add documentation for SEP-38 in SEP-6 guide

### DIFF
--- a/network/anchor-platform/admin-guide/sep31/configuration.mdx
+++ b/network/anchor-platform/admin-guide/sep31/configuration.mdx
@@ -231,7 +231,7 @@ You should get the following:
 
 ## Enable the RFQ API
 
-Businesses need to provide their send-side counterparts with an API to check the exchange rates they're offering between the on-chain asset being used for settlement and the fiat asset being used to pay the recipient. If the rate is competitive, senders also need to be able to request a commitment to the rate currently being offered from business for a short period of time.
+Businesses need to provide their send-side counterparts with a [Rate][get-rates-api] API to check the exchange rates they're offering between the on-chain asset being used for settlement and the fiat asset being used to pay the recipient. If the rate is competitive, senders also need to be able to request a commitment to the rate currently being offered from business for a short period of time.
 
 The Anchor Platform provides the [SEP-38 RFQ API][sep38] to senders for this purpose.
 
@@ -370,6 +370,7 @@ We'll define the server that implements the endpoints defined in the Callback AP
 
 [sep31-get-info]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#get-info
 [sep1-ap]: ../sep1/README.mdx
+[get-rates-api]: ../../api-reference/callbacks/get-rates.api.mdx
 [sep38]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
 [sep38-post-quote]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md#post-quote
 [platform-api-kyc]: ../../api-reference/callbacks/customer/README.mdx

--- a/network/anchor-platform/admin-guide/sep31/configuration.mdx
+++ b/network/anchor-platform/admin-guide/sep31/configuration.mdx
@@ -134,8 +134,6 @@ To make this API available to clients, lets add the service URL to our Stellar I
 
 ```toml
 # dev.stellar.toml
-DIRECT_PAYMENT_SERVER = "http://localhost:8080/sep31"
-WEB_AUTH_ENDPOINT = "http://localhost:8080/auth"
 KYC_SERVER = "http://localhost:8080/sep12"
 ```
 
@@ -146,7 +144,7 @@ Lets enable it in our environment too.
 <CodeExample>
 
 ```bash
-# dev.enva
+# dev.env
 SEP12_ENABLED=true
 ```
 
@@ -182,7 +180,7 @@ sep31:
 
 </CodeExample>
 
-Lets ping the info endpoint again to verify. After `docker compose up`, run the following command:
+Let's ping the info endpoint again to verify. After `docker compose up`, run the following command:
 
 <CodeExample>
 
@@ -235,7 +233,7 @@ You should get the following:
 
 Businesses need to provide their send-side counterparts with an API to check the exchange rates they're offering between the on-chain asset being used for settlement and the fiat asset being used to pay the recipient. If the rate is competitive, senders also need to be able to request a commitment to the rate currently being offered from business for a short period of time.
 
-The Anchor Platform provides the [SEP-38 RFQ API][sep38] to senders for this purpose and requires receive-side services to implement the simplified `GET /rate` and `GET /fee` endpoints for the Anchor Platform to use on the backend.
+The Anchor Platform provides the [SEP-38 RFQ API][sep38] to senders for this purpose.
 
 To make this API available to clients, lets add the service URL to our Stellar Info File.
 
@@ -245,7 +243,7 @@ To make this API available to clients, lets add the service URL to our Stellar I
 # dev.stellar.toml
 DIRECT_PAYMENT_SERVER = "http://localhost:8080/sep31"
 WEB_AUTH_ENDPOINT = "http://localhost:8080/auth"
-KYC_SERVER = "http://localhost:8080/kyc"
+KYC_SERVER = "http://localhost:8080/sep12"
 QUOTE_SERVER = "http://localhost:8080/sep38"
 ```
 

--- a/network/anchor-platform/admin-guide/sep6/configuration.mdx
+++ b/network/anchor-platform/admin-guide/sep6/configuration.mdx
@@ -115,7 +115,7 @@ SEP12_ENABLED=true
 
 To enable asset exchanges using Stellar, follow the steps below to configure the relevant settings and ensure the services are properly integrated. SEP-6 facilitates deposit and withdrawal interactions, and enabling SEP-38 allows for quote-based exchange rates for these transactions.
 
-Businesses need to provide their send-side counterparts with an API to check the exchange rates they're offering between the on-chain asset being used for settlement and the fiat asset being used to pay the recipient. If the rate is competitive, senders also need to be able to request a commitment to the rate currently being offered from business for a short period of time.
+Businesses need to provide their send-side counterparts with a [Rate][get-rates-api] API to check the exchange rates they're offering between the on-chain asset being used for settlement and the fiat asset being used to pay the recipient. If the rate is competitive, senders also need to be able to request a commitment to the rate currently being offered from business for a short period of time.
 
 The Anchor Platform provides the [SEP-38 RFQ API][sep38] to senders for this purpose
 
@@ -240,5 +240,6 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 [sep-6]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md
 [sep1-ap]: ../sep1/README.mdx
 [stellar-demo-wallet]: https://demo-wallet.stellar.org/
+[get-rates-api]: ../../api-reference/callbacks/get-rates.api.mdx
 [sep38]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
 [platform-api-kyc]: ../../api-reference/callbacks/customer/README.mdx

--- a/network/anchor-platform/admin-guide/sep6/configuration.mdx
+++ b/network/anchor-platform/admin-guide/sep6/configuration.mdx
@@ -40,6 +40,17 @@ Note that you will need to create another file for your production deployment th
 
 ## Enable Programmatic Deposits & Withdrawals
 
+Add the following variable to your environment file.
+
+<CodeExample>
+
+```bash
+# dev.env
+SEP6_ENABLED=true
+```
+
+</CodeExample>
+
 Now you're ready to enable programmatic deposits and withdrawals using the SEP-6 API. Specify the following in your `dev.assets.yaml` file, and change the values depending on your use case. This example asset file enables support for Circle's USDC and a fiat USD to deposit from and withdraw to. The methods specified in the `deposit` and `withdraw` sections are the methods that will be exposed by the [`GET /info`][sep-6] SEP-6 endpoint under the `type` field in the case of `deposit` and `types` field in the case of `withdraw`.
 
 <CodeExample>
@@ -72,6 +83,103 @@ assets:
 
 The information provided for the `assets` value closely maps to the information that will be exposed to the wallet application using the [`GET /info`][sep-6] SEP-6 endpoint. The Anchor Platform also uses this information to validate requests made to your service.
 
+## Enable the Customer KYC API
+
+Businesses need to collect and validate KYC information on the customers they're facilitating transactions for. Clients determine what KYC information needs to be collected and send that information via a SEP-12 KYC API hosted by the Anchor Platform, but the Anchor Platform never stores personally-identifiable information (PII). Instead, it forwards requests from clients to the business server, and returns the business' responses back to the client, acting as a proxy server.
+
+See the [Anchor Platform KYC API specification][platform-api-kyc] for details on the endpoints that must be implemented on your business' server.
+
+To make this API available to clients, lets add the service URL to our Stellar Info File.
+
+<CodeExample>
+
+```toml
+# dev.stellar.toml
+KYC_SERVER = "http://localhost:8080/sep12"
+```
+
+</CodeExample>
+
+And enable it in our environment.
+
+<CodeExample>
+
+```bash
+# dev.env
+SEP12_ENABLED=true
+```
+
+</CodeExample>
+
+## Enable Asset Exchanges
+
+To enable asset exchanges using Stellar, follow the steps below to configure the relevant settings and ensure the services are properly integrated. SEP-6 facilitates deposit and withdrawal interactions, and enabling SEP-38 allows for quote-based exchange rates for these transactions.
+
+Businesses need to provide their send-side counterparts with an API to check the exchange rates they're offering between the on-chain asset being used for settlement and the fiat asset being used to pay the recipient. If the rate is competitive, senders also need to be able to request a commitment to the rate currently being offered from business for a short period of time.
+
+The Anchor Platform provides the [SEP-38 RFQ API][sep38] to senders for this purpose
+
+Add Service URLs to the Stellar Info File
+
+<CodeExample>
+
+```toml
+# dev.stellar.toml
+ANCHOR_QUOTE_SERVER = "http://localhost:8080/sep38"
+```
+
+</CodeExample>
+
+And enable the API in your environment configuration file.
+
+<CodeExample>
+
+```bash
+# dev.env
+SEP38_ENABLED=true
+```
+
+</CodeExample>
+
+Finally, configure assets to include the exchangeable assets in the `sep38` section.
+
+<CodeExample>
+
+```yaml
+assets:
+  - schema: stellar
+    code: USDC
+    issuer: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+    distribution_account: GBLSAHONJRODSFTLOV225NZR4LHICH63RIFQTQN37L5CRTR2IMQ5UEK7
+    significant_decimals: 2
+    sep6_enabled: true
+    deposit:
+      enabled: true
+      methods:
+        - SEPA
+        - SWIFT
+        - cash
+    withdraw:
+      enabled: true
+      methods:
+        - bank_account
+        - cash
+    sep38_enabled: true
+    sep38:
+      exchangeable_assets:
+        - iso4217:USD
+  - schema: iso4217
+    code: USD
+    significant_decimals: 2
+    sep38_enabled: true
+    sep38:
+      exchangeable_assets:
+        - stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+```
+
+</CodeExample>
+
+
 ## Test With the Demo Wallet
 
 Wallets should now be able to discover, authenticate, and initiate transactions with your service! Your project and source files should now look something like this.
@@ -101,10 +209,18 @@ SEP1_ENABLED=true
 SEP1_TOML_TYPE=file
 SEP1_TOML_VALUE=/home/dev.stellar.toml
 
+SEP6_ENABLED=true
+SEP6_MORE_INFO_URL_BASE_URL=http://example.com
+SECRET_SEP6_MORE_INFO_URL_JWT_SECRET="your encryption key shared with your business server"
+
 SEP10_ENABLED=true
 SEP10_HOME_DOMAIN=localhost:8080
 SECRET_SEP10_SIGNING_SEED="a Stellar private key"
 SECRET_SEP10_JWT_SECRET="a secret encryption key"
+
+SEP12_ENABLED=true
+
+SEP38_ENABLED=true
 ```
 
 </CodeExample>
@@ -124,3 +240,5 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 [sep-6]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md
 [sep1-ap]: ../sep1/README.mdx
 [stellar-demo-wallet]: https://demo-wallet.stellar.org/
+[sep38]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
+[platform-api-kyc]: ../../api-reference/callbacks/customer/README.mdx


### PR DESCRIPTION
As title.

Sep6:
- Add section for config KYC API
- Add sectioN for config SEP38
- Update code exmaple

Sep31:
- nits
- remove the mention of `/rate` and `/fee` endpoint