### PR TITLE
typo fix in cli guide

### DIFF
--- a/docs/smart-contracts/guides/cli/deploy-contract.mdx
+++ b/docs/smart-contracts/guides/cli/deploy-contract.mdx
@@ -3,7 +3,7 @@ title: Deploy a Contract from Installed Wasm Bytecode
 hide_table_of_contents: true
 ---
 
-To deploy an instance of a compiled smart contract that has already been isntalled onto the Stellar network, use the `soroban contract deploy` command:
+To deploy an instance of a compiled smart contract that has already been installed onto the Stellar network, use the `soroban contract deploy` command:
 
 ```bash
 soroban contract deploy \


### PR DESCRIPTION
A simple typo fix. The word 'isntalled' should be 'installed'. Nothing much apart from that.