### PR TITLE
Add info status of testnet and mainnet status

### DIFF
--- a/docs/reference/networks.mdx
+++ b/docs/reference/networks.mdx
@@ -4,6 +4,12 @@ title: Networks
 description: Specs for Stellar's various networks
 ---
 
+:::info
+
+To see the current status of Mainnet and Testnet, please see the [Stellar.org Dashboard](https://dashboard.stellar.org/).
+
+:::
+
 Read more about the different networks in the [Networks section](../learn/fundamentals/networks.mdx).
 
 |  | Mainnet | Testnet | Futurenet |


### PR DESCRIPTION
This came back from an interviewee who provided feedback on not being able to find the status of testnet and mainnet.