### PR TITLE
add links to the admin guide in the node hw requirements table

### DIFF
--- a/docs/data/requirements.mdx
+++ b/docs/data/requirements.mdx
@@ -1,15 +1,16 @@
 ---
 title: Node Hardware Requirements
+hide_table_of_contents: true
 ---
 
 Here you can find the requirements for running the various types of nodes the operate the Stellar network. We offer some modest recommendations for each type of resource, as well as a generally applicable SKU for some popular cloud computing providers. These may require customizations or adjustments, depending on your specific use-case.
 
-| Node Type | CPU | RAM | Disk | AWS SKU | Google Cloud SKU |
-| --- | --- | --- | --- | --- | --- |
-| Core Validator Node | 8x Intel Xeon @ 3.4 GHz | 16 GB | 100 GB NVMe SSD | [c5d.2xlarge] | [n4-highcpu-8] |
-| Horizon API Service | 4 vCPU | 16 GB | 100 GB SSD >= 1.5K IOPS | [c5d.xlarge] | [n4-standard-4] |
-| Horizon PostgreSQL | 4 vCPU | 32 GB | 2 TB\* SSD (NVMe or Direct Attached Storage) >= 7K IOPS | [i4g.xlarge] | [c3-highmem-8] |
-| Soroban RPC | 2 vCPU | 4 GB | 30 GB persistent volume >= 3K IOPS | [c5.large] | [n4-highcpu-2] |
+| Node Type | CPU | RAM | Disk | AWS SKU | Google Cloud SKU | Admin Guide |
+| --- | --- | --- | --- | --- | --- | --- |
+| Core Validator Node | 8x Intel Xeon @ 3.4 GHz | 16 GB | 100 GB NVMe SSD | [c5d.2xlarge] | [n4-highcpu-8] | [Click here](../validators/admin-guide/README.mdx) |
+| Horizon API Service | 4 vCPU | 16 GB | 100 GB SSD >= 1.5K IOPS | [c5d.xlarge] | [n4-standard-4] | [Click here](./horizon/admin-guide/overview.mdx) |
+| Horizon PostgreSQL | 4 vCPU | 32 GB | 2 TB\* SSD (NVMe or Direct Attached Storage) >= 7K IOPS | [i4g.xlarge] | [c3-highmem-8] | [Click here](./horizon/admin-guide/overview.mdx) |
+| Soroban RPC | 2 vCPU | 4 GB | 30 GB persistent volume >= 3K IOPS | [c5.large] | [n4-highcpu-2] | [Click here](./rpc/admin-guide.mdx) |
 
 _\* Assuming a 30-day retention window for data storage._
 


### PR DESCRIPTION
Follow-up to the [discussion in #686](https://github.com/stellar/stellar-docs/pull/686#issuecomment-2176826386). This is a quick-n-simple PR to add links to the relevant admin guides in the table of hardware requirements.