### PR TITLE
Prevent OpenRPC-generated pages from using the `@theme/ApiItem` component

### DIFF
--- a/docs/data/rpc/api-reference/methods/getTransaction.mdx
+++ b/docs/data/rpc/api-reference/methods/getTransaction.mdx
@@ -12,7 +12,6 @@ import { RpcMethod } from "@site/src/components/RpcMethod";
 
 The example above is querying details of a transaction using RPC methods directly. If you are using the Stellar SDK to build applications, you can use the native functions to get the same information.
 
-<div>
 <CodeExample>
 
 ```python
@@ -73,4 +72,3 @@ public class GetTransactionExample {
 ```
 
 </CodeExample>
-</div>

--- a/docs/data/rpc/api-reference/methods/sendTransaction.mdx
+++ b/docs/data/rpc/api-reference/methods/sendTransaction.mdx
@@ -12,8 +12,6 @@ import { CodeExample } from "@site/src/components/CodeExample";
 
 The example above is sending a transaction using RPC methods directly. If you are using the Stellar SDK to build applications, you can use the native functions to get the same information.
 
-<br />
-<div>
 <CodeExample>
 
 ```python
@@ -136,4 +134,3 @@ public class SendTransactionExample {
 ```
 
 </CodeExample>
-</div>

--- a/src/theme/ApiItem/index.js
+++ b/src/theme/ApiItem/index.js
@@ -5,6 +5,7 @@ import DocItem from '@theme-original/DocItem';
 export default function ApiItemWrapper(props) {
   if (
     props.location?.pathname?.includes('api-reference')
+    && !props.location?.pathname?.includes('rpc')
   ) {
     return (
       <>


### PR DESCRIPTION
As pointed out in #709 ([here](https://github.com/stellar/stellar-docs/pull/709#discussion_r1651473483) is the exact comment), the `@theme/ApiItem` component from the `docusaurus-theme-openapi-docs` package (as well as our swizzled `/src/theme/ApiItem/Layout` component) adds some styling/layout that we don't really want to see in the pages generated using the `open-rpc-docs-react` component. Namely, as pointed out in #709, any `<CodeBlock>` components are floated to the right-hand side of the screen (wrapping the code block component in a `<div>` seems to do the trick to workaround it, btw).

This PR aims to ensure that the URL of a page rendered with `@theme/ApiItem` doesn't include `rpc`, and will use the default `@theme/DocItem` component, instead.