### PR TITLE
Update section name to include operations

### DIFF
--- a/docs/learn/fundamentals/transactions/README.mdx
+++ b/docs/learn/fundamentals/transactions/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: Transactions
+title: Operations & Transactions
 sidebar_position: 60
 ---
 


### PR DESCRIPTION
I was having issue finding the 26 operations and I heard the same issue from another developer recently. I think the section header should indicate this section includes operations and transactions. Right now, the list of operations is buried under a section titled `Transactions` which makes it very difficult to find. 