### PR TITLE
Update the anchor platform's event service documentation

### DIFF
--- a/platforms/anchor-platform/admin-guide/events/getting-started.mdx
+++ b/platforms/anchor-platform/admin-guide/events/getting-started.mdx
@@ -3,6 +3,6 @@ title: Getting Started
 sidebar_position: 10
 ---
 
-Anchor Platform provides an event service that allows your business application and wallets to receive updates about transaction updates via HTTP webhooks without the need to poll the transactions API.
+Anchor Platform provides an event service that allows your business application and client applications such as wallets to receive updates about transaction updates via HTTP webhooks without the need to poll the transactions API.
 
-By integrating your business server with the event service, you will be able to receive updates about the status of transactions, including when they are submitted, completed, and failed as well as any quotes created or when customer information is updated.
+By integrating with the event service, you or your clients will be able to receive updates about the status of transactions, including when they are submitted, completed, and failed as well as any quotes created.

--- a/platforms/anchor-platform/admin-guide/events/integration.mdx
+++ b/platforms/anchor-platform/admin-guide/events/integration.mdx
@@ -13,7 +13,38 @@ Anchor Platform will send events to the `TRANSACTION` Kafka topic. The event ser
 
 ## Configuration
 
-First, the event processor needs to be configured in the `event_processor` section of the Anchor Platform Configuration file or setting the environment variables.
+Next, the event service's Kafka producer need to be configured using the `event.queue` section of the configuration file or setting the environment variables. The following is the set of required environment variables needed to configure the event service's Kafka producer:
+
+<CodeExample>
+
+```bash
+# dev.env
+EVENTS_ENABLED=true
+EVENTS_QUEUE_TYPE=kafka
+EVENTS_QUEUE_KAFKA_BOOTSTRAP_SERVER=localhost:9092
+```
+
+</CodeExample>
+
+**OR**
+
+<CodeExample>
+
+```yaml
+# dev.services.yaml
+events:
+  enabled: true
+  queue:
+    type: kafka
+    kafka:
+      bootstrap_server: localhost:9092
+```
+
+</CodeExample>
+
+Anchor Platform allows a subset of the Kafka producer's client configuration to be set. See the [default values file][default-values-file] for more information what is available. For more information on the Kafka producer's client configuration, see the [Kafka documentation](https://kafka.apache.org/documentation/#producerconfigs).
+
+Next, the event processor needs to be configured in the `event_processor` section of the Anchor Platform Configuration file or setting the environment variables.
 
 <CodeExample>
 
@@ -42,54 +73,6 @@ event_processor:
 
 This will enable the event processor to start processing events from `TRANSACTION` topic. In this example, the event processor will send events to client and business server callback endpoints.
 
-Next, the event service's Kafka producer need to be configured using the `event.queue` section of the configuration file or setting the environment variables. The following is an example of how to configure the event service's Kafka producer:
-
-<CodeExample>
-
-```bash
-# dev.env
-EVENT_QUEUE_TYPE=kafka
-EVENT_QUEUE_KAFKA_BOOTSTRAP_SERVER=localhost:29092,localhost:29093
-EVENT_QUEUE_KAFKA_CLIENT_ID=ap-event-service
-EVENT_QUEUE_KAFKA_RETRIES=0
-EVENT_QUEUE_KAFKA_LINGER_MS=1000
-EVENT_QUEUE_KAFKA_BATCH_SIZE=10
-EVENT_QUEUE_KAFKA_POLL_TIMEOUT_SECONDS=10
-```
-
-</CodeExample>
-
-**OR**
-
-<CodeExample>
-
-```yaml
-# dev.services.yaml
-event:
-  enabled: true
-  queue:
-    type: kafka
-    kafka:
-      bootstrap_server: localhost:29092,localhost:29093
-      client_id: ap-event-service
-      retries: 0
-      linger_ms: 1000
-      batch_size: 10
-      poll_timeout_seconds: 10
-```
-
-</CodeExample>
-
-Anchor Platform allows a subset of the Kafka producer's client configuration to be set. The following are the supported configuration options:
-
-- `bootstrap_server`: A comma-separated list of Kafka brokers in the format `host:port`. This corresponds to the Kafka producer's `bootstrap.servers` configuration.
-- `client_id`: The client ID to be used by the Kafka producer. This corresponds to the Kafka producer's `client.id` configuration.
-- `retries`: The number of times the Kafka producer will retry sending a message. This corresponds to the Kafka producer's `retries` configuration.
-- `linger_ms`: The time in milliseconds the Kafka producer will wait before sending a batch of messages. This corresponds to the Kafka producer's `linger.ms` configuration.
-- `batch_size`: The maximum number of messages the Kafka producer will send in a single batch. This corresponds to the Kafka producer's `batch.size` configuration.
-
-For more information on the Kafka producer's client configuration, see the [Kafka documentation](https://kafka.apache.org/documentation/#producerconfigs).
-
 ## Receiving Events
 
 The event service can be used to send events to client and business server callback endpoints. The event service will send events to these endpoints as HTTP POST requests with the event data in the request body.
@@ -100,7 +83,7 @@ Client applications can receive updates whenever the `status` of a SEP transacti
 
 To receive events as a client application, you will need to expose a callback URL that the event service can send events to. The event service will send a POST request to this endpoint with the event data in the request body.
 
-Anchor Platform will only send events to clients listed in the client configuration. See the client configuration documentation for more information.
+Anchor Platform will only send events to clients listed in the client configuration. See the [client configuration documentation][clients-config] for more information.
 
 #### Callback Signing
 
@@ -118,17 +101,29 @@ To receive events as a business server, you will need to expose a callback URL t
 
 #### Configuration
 
-The event service's callback API can be configured using the `callback_api` section of the Anchor Platform configuration file or setting the environment variables. The following is an example of how to configure the event service's callback API with JWT authentication:
+The event service's callback API can be configured using the `callback_api` section of the Anchor Platform configuration file or setting the environment variables. 
+
+:::caution
+
+The `--event-processor` will ignore any path segments specified in `callback_api.base_url` and will instead send events to `[scheme]://[host]:[port]/event`. This is a bug, but in order not to disrupt those using the event processor, we will defer the fix of including path segments in version 3 of the Anchor Platform.
+
+:::
+
+The following is an example of how to configure the event service's callback API with JWT authentication:
 
 <CodeExample>
 
 ```bash
 # dev.env
+
+# note `/callback` will not be used for event callbacks
+# instead events will be sent to `http://localhost:8081/event`
+# all other callbacks (rates, customer, etc.) will use the provided `/callback` root path
 CALLBACK_API_BASE_URL=http://localhost:8081/callback
-CALLBACK_API_SECRET=my-secret
 CALLBACK_API_AUTH_TYPE=jwt
-CALLBACK_API_JWT_EXPIRATION_MILLISECONDS=30000
-CALLBACK_API_JWT_HTTP_HEADER=Authorization
+CALLBACK_API_AUTH_JWT_EXPIRATION_MILLISECONDS=30000
+CALLBACK_API_AUTH_JWT_HTTP_HEADER=Authorization
+SECRET_CALLBACK_API_AUTH_SECRET="a secret for signing jwts"
 ```
 
 </CodeExample>
@@ -141,12 +136,11 @@ CALLBACK_API_JWT_HTTP_HEADER=Authorization
 # dev.services.yaml
 callback_api:
   base_url: http://localhost:8081/callback
-  secret: my-secret
   auth:
-  type: jwt
-  jwt:
-    expiration_milliseconds: 30000
-    http_header: Authorization
+    type: jwt
+    jwt:
+      expiration_milliseconds: 30000
+      http_header: Authorization
 ```
 
 </CodeExample>
@@ -158,9 +152,9 @@ The following is an example of how to configure the event service's callback API
 ```bash
 # dev.env
 CALLBACK_API_BASE_URL=http://localhost:8081/callback
-CALLBACK_API_SECRET=my-secret
 CALLBACK_API_AUTH_TYPE=api_key
-CALLBACK_API_API_KEY_HTTP_HEADER=X-Api-Key
+CALLBACK_API_AUTH_API_KEY_HTTP_HEADER=X-Api-Key
+SECRET_CALLBACK_API_AUTH_SECRET="your API key"
 ```
 
 </CodeExample>
@@ -173,11 +167,10 @@ CALLBACK_API_API_KEY_HTTP_HEADER=X-Api-Key
 # dev.services.yaml
 callback_api:
   base_url: http://localhost:8081/callback
-  secret: bf7c2c5b-5c76-4974-a318-ac9c4a2b8514
   auth:
-  type: api_key
-  jwt:
-    http_header: X-Api-Key
+    type: api_key
+    api_key:
+      http_header: X-Api-Key
 ```
 
 :::caution
@@ -200,3 +193,6 @@ This configures the event service's callback API that will be used to send event
     - `http_header`: The header in which the JWT will be sent.
   - `API_KEY`: The event service will send an API key in the `Authorization` header of the request. The following are the supported configuration options:
     - `http_header`: The header in which the API key will be sent.
+
+[default-values-file]: https://github.com/stellar/java-stellar-anchor-sdk/blob/develop/platform/src/main/resources/config/anchor-config-default-values.yaml
+[clients-config]: ../../admin-guide/sep10/README.mdx#config-with-client-attribution

--- a/platforms/anchor-platform/admin-guide/events/integration.mdx
+++ b/platforms/anchor-platform/admin-guide/events/integration.mdx
@@ -13,7 +13,7 @@ Anchor Platform will send events to the `TRANSACTION` Kafka topic. The event ser
 
 ## Configuration
 
-Next, the event service's Kafka producer need to be configured using the `event.queue` section of the configuration file or setting the environment variables. The following is the set of required environment variables needed to configure the event service's Kafka producer:
+First, the event service's Kafka producer need to be configured using the `event.queue` section of the configuration file or setting the environment variables. The following is the set of required environment variables needed to configure the event service's Kafka producer:
 
 <CodeExample>
 


### PR DESCRIPTION
Updates the event page, includes the bug where path segments of the `callback_api.base_url` are not respected for event callbacks.