### PR TITLE
fix tx meta deprecation notice links to be relative filenames

### DIFF
--- a/docs/data/horizon/api-reference/resources/transactions/README.mdx
+++ b/docs/data/horizon/api-reference/resources/transactions/README.mdx
@@ -5,7 +5,7 @@ order: 0
 
 :::info
 
-Transaction meta `result_meta_xdr` will be removed from the SDF hosted Horizon API (horizon.stellar.org) in Q3 2024. Instead of using Horizon to access transaction metadata, developers could access it with the [`getTransactions`](docs/data/rpc/api-reference/methods/getTransactions.mdx) endpoint in the Soroban RPC.
+Transaction meta `result_meta_xdr` will be removed from the SDF hosted Horizon API (`horizon.stellar.org`) in Q3 2024. Instead of using Horizon to access transaction metadata, developers could access it with the [`getTransactions`](../../../../rpc/api-reference/methods/getTransactions.mdx) endpoint in the Soroban RPC.
 
 :::
 

--- a/docs/data/horizon/api-reference/resources/transactions/README.mdx
+++ b/docs/data/horizon/api-reference/resources/transactions/README.mdx
@@ -13,7 +13,7 @@ import { EndpointsTable } from "@site/src/components/EndpointsTable";
 
 Transactions are commands that modify the ledger state and consist of one or more operations.
 
-Learn more about [transactions](/docs/learn/glossary/#transaction).
+Learn more about [transactions](../../../../../learn/glossary.mdx#transaction).
 
 <EndpointsTable title="Endpoints">
 

--- a/docs/data/horizon/api-reference/resources/transactions/object.mdx
+++ b/docs/data/horizon/api-reference/resources/transactions/object.mdx
@@ -5,7 +5,7 @@ order: 10
 
 :::info
 
-Transaction meta `result_meta_xdr` will be removed from the SDF hosted Horizon API (horizon.stellar.org) in Q3 2024. Instead of using Horizon to access transaction metadata, developers could access it with the [`getTransactions`](docs/data/rpc/api-reference/methods/getTransactions.mdx) endpoint in the Soroban RPC.
+Transaction meta `result_meta_xdr` will be removed from the SDF hosted Horizon API (`horizon.stellar.org`) in Q3 2024. Instead of using Horizon to access transaction metadata, developers could access it with the [`getTransactions`](../../../../rpc/api-reference/methods/getTransactions.mdx) endpoint in the Soroban RPC.
 
 :::
 

--- a/docs/data/horizon/api-reference/resources/transactions/object.mdx
+++ b/docs/data/horizon/api-reference/resources/transactions/object.mdx
@@ -45,10 +45,10 @@ When Horizon returns information about a transaction, it uses the following form
   - The source account's sequence number that this transaction consumed.
 - fee_charged
   - number
-  - The fee (in [stroops](/docs/learn/fundamentals/lumens)) paid by the source account to apply this transaction to the ledger.
+  - The fee (in [stroops](../../../../../learn/fundamentals/lumens.mdx)) paid by the source account to apply this transaction to the ledger.
 - max_fee
   - number
-  - The maximum fee (in [stroops](/docs/learn/fundamentals/lumens)) that the source account was willing to pay.
+  - The maximum fee (in [stroops](../../../../../learn/fundamentals/lumens.mdx)) that the source account was willing to pay.
 - operation_count
   - number
   - The number of operations contained within this transaction.


### PR DESCRIPTION
The links added in #782, aren't relative filepaths, and could lead to some build errors.