### PR TITLE
remove use of DocCardList component in guides README

### DIFF
--- a/docs/build/guides/README.mdx
+++ b/docs/build/guides/README.mdx
@@ -5,8 +5,4 @@ sidebar_position: 40
 hide_table_of_contents: true
 ---
 
-import DocCardList from "@theme/DocCardList";
-
 This section provides step-by-step instructions to help users complete specific tasks associated with developing on Stellar. These tasks can include instructions for goals related to writing contracts, interacting with contracts, building applications, using Stellar operations, setting up infrastructure, and more.
-
-<DocCardList />


### PR DESCRIPTION
We're already injecting the list of doccards elsewhere.

Closes #779 