### PR TITLE
[ANCHOR-647] Add more_info_url section to SEP-6

### DIFF
--- a/platforms/anchor-platform/admin-guide/sep24/faq.mdx
+++ b/platforms/anchor-platform/admin-guide/sep24/faq.mdx
@@ -3,9 +3,9 @@ title: "FAQ"
 sidebar_position: 50
 ---
 
-### How To Use Interactive JWTs?
+### How To Use JWTs?
 
-As part of the flow, once a user makes an interactive withdrawal/deposit request, it will be processed by the Anchor Platform and forwarded to your service. The Anchor Platform will make a `GET` call to `<configured interactive url>?token=<jwt token>`.
+As part of the flow, once a user makes a request, i.e. an interactive withdrawal/deposit request, it will be processed by the Anchor Platform and forwarded to your service. The Anchor Platform will make a `GET` call to `<configured url>?token=<jwt token>`.
 
 This JWT token will contain:
 

--- a/platforms/anchor-platform/admin-guide/sep24/faq.mdx
+++ b/platforms/anchor-platform/admin-guide/sep24/faq.mdx
@@ -12,7 +12,7 @@ This JWT token will contain:
 1. `exp` is the expiration time of the token. You should check that the provided token has not expired.
 2. `sub` is the account associated with this transaction. It can be used to identify the user account. Note that this value may be different from the account that will be used to receive/send funds.
 3. `jti` is the hash of the transaction.
-4. `data` is the extra payload that has been set by the user. It will always contain the Stellar `asset` wants to deposit or withdraw. If provided by the client, it will also contain the `amount` the user wants to transact, the `client_domain` of the wallet verified during SEP-10 authentication, and the `lang` (language) preference of the user, and `client_name` (defined as 'name' in [clients] configuration if provided).
+4. `data` is the extra payload that has been set by the user. It will always contain the Stellar `asset` wants to deposit or withdraw. If provided by the client, it will also contain the `amount` the user wants to transact, the `client_domain` of the wallet verified during SEP-10 authentication, and `client_name` (defined as 'name' in [clients] configuration if provided), and the `lang` (language) preference of the user.
 
 ### How To Provide Fees?
 

--- a/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
+++ b/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
@@ -164,7 +164,7 @@ SECRET_CALLBACK_API_AUTH_SECRET="a secret used to sign JWTs"
 
 The above tells the Anchor Platform to include a [JWT][how-to-use-jwt], signed with the configured secret, in the `Authorization` header of requests made to `/callbacks/<callback endpoint>` so your server can authenticate the Anchor Platform before processing requests.
 
-`more_info_url` is an optional URL provided by the Business for wallet applications to display information about previously initiated transactions. This URL is typically used by wallets in their transaction history views, and your business can specify the information to be displayed about the transaction.
+`more_info_url` is an optional URL provided by your business server for wallet applications to display information about previously initiated transactions. This URL is typically used by wallets in their transaction history views, and your business can specify the information to be displayed about the transaction.
 
 <CodeExample>
 
@@ -176,7 +176,7 @@ SECRET_SEP6_MORE_INFO_URL_JWT_SECRET="your encryption key shared with your busin
 
 </CodeExample>
 
-See the [KYC API][platform-api-kyc] and [Rates API][sep38] for details on the endpoints that must be implemented on your business' server.
+See the [KYC API][platform-api-kyc] and [Rates API][sep38] for details on the endpoints that must be implemented on your business's server.
 
 ## Test With the Demo Wallet
 

--- a/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
+++ b/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
@@ -176,7 +176,7 @@ SECRET_SEP6_MORE_INFO_URL_JWT_SECRET="your encryption key shared with your busin
 
 </CodeExample>
 
-See the [KYC API][platform-api-kyc] and [Rates API][sep38] for details on the endpoints that must be implemented on your business's server.
+See the [KYC API][platform-api-kyc] and [Rates API][sep38] for details on the endpoints that must be implemented on your business server.
 
 ## Test With the Demo Wallet
 

--- a/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
+++ b/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
@@ -162,7 +162,7 @@ SECRET_CALLBACK_API_AUTH_SECRET="a secret used to sign JWTs"
 
 </CodeExample>
 
-The above tells the Anchor Platform to include a [JWT](jwt), signed with the configured secret, in the `Authorization` header of requests made to `/callbacks/<callback endpoint>` so your server can authenticate the Anchor Platform before processing requests.
+The above tells the Anchor Platform to include a [JWT][how-to-use-jwt], signed with the configured secret, in the `Authorization` header of requests made to `/callbacks/<callback endpoint>` so your server can authenticate the Anchor Platform before processing requests.
 
 `more_info_url` is an optional URL provided by the Business for wallet applications to display information about previously initiated transactions. This URL is typically used by wallets in their transaction history views, and your business can specify the information to be displayed about the transaction.
 
@@ -249,4 +249,4 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 [sep38]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
 [platform-api-kyc]: ../../api-reference/callbacks/customer/README.mdx
 [request-onchain-funds]: ../../api-reference/rpc/methods/request_onchain_funds/README.mdx
-[jwt]:../sep24/faq.mdx
+[how-to-use-jwt]:../sep24/faq.mdx

--- a/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
+++ b/platforms/anchor-platform/admin-guide/sep6/configuration.mdx
@@ -162,7 +162,19 @@ SECRET_CALLBACK_API_AUTH_SECRET="a secret used to sign JWTs"
 
 </CodeExample>
 
-The above tells the Anchor Platform to include a JWT, signed with the configured secret, in the `Authorization` header of requests made to `/callbacks/<callback endpoint>` so your server can authenticate the Anchor Platform before processing requests.
+The above tells the Anchor Platform to include a [JWT](jwt), signed with the configured secret, in the `Authorization` header of requests made to `/callbacks/<callback endpoint>` so your server can authenticate the Anchor Platform before processing requests.
+
+`more_info_url` is an optional URL provided by the Business for wallet applications to display information about previously initiated transactions. This URL is typically used by wallets in their transaction history views, and your business can specify the information to be displayed about the transaction.
+
+<CodeExample>
+
+```bash
+# dev.env
+SEP6_MORE_INFO_URL_BASE_URL=http://example.com
+SECRET_SEP6_MORE_INFO_URL_JWT_SECRET="your encryption key shared with your business server"
+```
+
+</CodeExample>
 
 See the [KYC API][platform-api-kyc] and [Rates API][sep38] for details on the endpoints that must be implemented on your business' server.
 
@@ -197,6 +209,8 @@ SEP1_TOML_VALUE=/home/dev.stellar.toml
 
 SEP6_ENABLED=true
 SEP6_DEPOSIT_INFO_GENERATOR_TYPE=none
+SEP6_MORE_INFO_URL_BASE_URL=http://example.com
+SECRET_SEP6_MORE_INFO_URL_JWT_SECRET="your encryption key shared with your business server"
 
 SEP10_ENABLED=true
 SEP10_HOME_DOMAIN=localhost:8080
@@ -235,3 +249,4 @@ The demo wallet should be able to find your `stellar.toml` file, authenticate us
 [sep38]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
 [platform-api-kyc]: ../../api-reference/callbacks/customer/README.mdx
 [request-onchain-funds]: ../../api-reference/rpc/methods/request_onchain_funds/README.mdx
+[jwt]:../sep24/faq.mdx


### PR DESCRIPTION
1. Add instruction for config more_info_url in SEP-6. Details about `txn_fields` can be found in `anchor-config-default-values.yaml`
2. Remove the term "interactive" from "How To Use Interactive JWTs" as it is a  general explanation of jwt.