### PR TITLE
Anchor Platform: Remove warning on event handling page

### DIFF
--- a/platforms/anchor-platform/admin-guide/events/integration.mdx
+++ b/platforms/anchor-platform/admin-guide/events/integration.mdx
@@ -151,14 +151,6 @@ callback_api:
 
 </CodeExample>
 
-:::caution
-
-The `http_header` is not configurable as of version `2.5.2` and earlier. The default value is `Authorization` for JWT and `X-Api-Key` for API key.
-
-Tracking issue: https://github.com/stellar/java-stellar-anchor-sdk/issues/1272
-
-:::
-
 This configures the event service's callback API that will be used to send events to client and business server callback endpoints. The following are the supported configuration options:
 
 - `base_url`: The base URL of the business server's callback endpoint.


### PR DESCRIPTION
This has been fixed.