### PR TITLE
Add section on supercluster / theoretical max TPS tests

### DIFF
--- a/docs/validators/admin-guide/advanced.mdx
+++ b/docs/validators/admin-guide/advanced.mdx
@@ -26,7 +26,7 @@ The [stellar-core GitHub repository] also contains [the `architecture.md` file],
 [Stellar Supercluster] is a tool that enables running simulated networks of stellar-core nodes on Kubernetes clusters. One use case for Supercluster is running reproducible performance tests. The Supercluster GitHub repository contains a few documents to help users run theoretical maximum Transaction Per Second (TPS) tests:
 
 - [`doc/getting-started.md`] details dependencies for building and running Supercluster.
-- [`doc/eks.md`] details how to build a supercluster compatible EKS cluster on AWS.
+- [`doc/eks.md`] details how to build a supercluster-compatible EKS cluster on AWS.
 - [`doc/theoretical-max-tps.md`] explains how to run the theoretical max TPS test on an EKS cluster. It also contains a table of results from SDF's own theoretical max TPS runs, as well as the configurations used to achieve those results.
 
 ### Other Supercluster Resources

--- a/docs/validators/admin-guide/advanced.mdx
+++ b/docs/validators/admin-guide/advanced.mdx
@@ -21,7 +21,28 @@ Stellar-core can also be packaged in a container system such as Docker, so long 
 
 The [stellar-core GitHub repository] also contains [the `architecture.md` file], which describes how stellar-core is structured internally, how it is intended to be deployed, and the collection of servers and services needed to get the full functionality and performance.
 
+## Reproducible Performance Testing With Stellar Supercluster
+
+[Stellar Supercluster] is a tool that enables running simulated networks of stellar-core nodes on Kubernetes clusters. One use case for Supercluster is running reproducible performance tests. The Supercluster GitHub repository contains a few documents to help users run theoretical maximum Transaction Per Second (TPS) tests:
+
+- [`doc/getting-started.md`] details dependencies for building and running Supercluster.
+- [`doc/eks.md`] details how to build a supercluster compatible EKS cluster on AWS.
+- [`doc/theoretical-max-tps.md`] explains how to run the theoretical max TPS test on an EKS cluster. It also contains a table of results from SDF's own theoretical max TPS runs, as well as the configurations used to achieve those results.
+
+### Other Supercluster Resources
+
+Supercluster is useful beyond reproducible performance testing. Some helpful resources to learn more about Supercluster include:
+
+- [`doc/measuring-transaction-throughput.md`] details additional maximum TPS tests beyond the theoretical max TPS test.
+- [`doc/missions.md`] lists all tests (referred to as "missions") that Supercluster supports.
+
 [stellar-core github repository]: https://github.com/stellar/stellar-core
 [a `testnet.md` file]: https://github.com/stellar/stellar-core/blob/master/docs/software/testnet.md
 [`stellar/quickstart`]: https://github.com/stellar/quickstart
 [the `architecture.md` file]: https://github.com/stellar/stellar-core/blob/master/docs/architecture.md
+[Stellar Supercluster]: https://github.com/stellar/supercluster/tree/main
+[`doc/getting-started.md`]: https://github.com/stellar/supercluster/blob/main/doc/getting-started.md
+[`doc/eks.md`]: https://github.com/stellar/supercluster/blob/main/doc/eks.md
+[`doc/theoretical-max-tps.md`]: https://github.com/stellar/supercluster/blob/main/doc/theoretical-max-tps.md
+[`doc/measuring-transaction-throughput.md`]: https://github.com/stellar/supercluster/blob/main/doc/measuring-transaction-throughput.md
+[`doc/missions.md`]: https://github.com/stellar/supercluster/blob/main/doc/missions.md


### PR DESCRIPTION
This change adds links to our supercluster documentation on running reproducible theoretical max TPS tests.