### PR TITLE
Refresh admin guide

### DIFF
--- a/docs/validators/admin-guide/commands.mdx
+++ b/docs/validators/admin-guide/commands.mdx
@@ -46,10 +46,9 @@ The **`run`** command will run the `stellar-core` node.
 
 - `--disable-bucket-gc`: Keeps all, even old, buckets on disk.
 - `--metadata-output-stream <STREAM>`: Filename or file-descriptor number `fd:N` to stream metadata to.
-- `--in-memory`: Stores working ledger in memory rather than database.
 - `--wait-for-consensus`: Wait to hear from the network before voting, for validating nodes only.
-- `--start-at-ledger <LEDGER>`: Start in-memory run with replay from historical ledger number.
-- `--start-at-hash <HASH>`: Start in-memory run with replay from historical ledger hash.
+
+Certain features, such as `in-memory` mode options, have been deprecated, so they aren't listed here.
 
 ### `catchup`
 
@@ -63,7 +62,6 @@ The **`catchup`** command will execute a catchup from history archives without c
 - `--output-file <FILE-NAME>`: Output file.
 - `--disable-bucket-gc`: Keeps all, even old, buckets on disk.
 - `--extra-verification`: Verify all files from the archive for the catchup range.
-- `--in-memory`: Store working ledger in memory rather than database.
 - `--trusted-hash <HASH>`: Hash of the ledger to catchup to.
 - `--force-untrusted-catchup`: Force unverified catchup.
 - `--metadata-output-stream <STREAM>`: Filename or file-descriptor number `fd:N` to stream metadata to.

--- a/docs/validators/admin-guide/configuring.mdx
+++ b/docs/validators/admin-guide/configuring.mdx
@@ -58,7 +58,7 @@ You specify your node's database by using the aptly named `DATABASE` field of yo
 
 ### Buckets
 
-The flat XDR files of Stellar Core (the duplicate copy of the ledger) are placed in a directory specified in the config file as `BUCKET_DIR_PATH`, which defaults to `buckets`.
+The flat XDR files of Stellar Core are placed in a directory specified in the config file as `BUCKET_DIR_PATH`, which defaults to `buckets`.
 
 ## Validating Node
 
@@ -249,7 +249,7 @@ _Diagram: Depiction of the nested quality levels and how they interact._
 
 ### Quorum and Overlay Network
 
-It can be beneficial to give information to your validator on other validators that you rely on. This is achieved by configuring the optional `KNOWN_PEERS` and `PREFERRED_PEERS` fields with the addresses of nodes you depend on. Most often, it is reasonable to depend on your node's default peer discovery. These settings, however, can be very useful for troubleshooting.
+In order to get in sync and run consensus, your validator needs to be able to connect to the Stellar Network. In most cases, it is sufficient to simply rely on node's built-in peer discovery. However, your validator can be configured to connect to specific peers via `KNOWN_PEERS` and `PREFERRED_PEERS` in the config file. These can be either domain names or IPs. This can be useful for troubleshooting.
 
 Additionally, configuring `PREFERRED_PEER_KEYS` with the keys from your quorum set might be a good idea to give priority to the nodes that allow you to reach consensus.
 

--- a/docs/validators/admin-guide/environment-preparation.mdx
+++ b/docs/validators/admin-guide/environment-preparation.mdx
@@ -15,17 +15,16 @@ stellar-core new-db
 
 This command will initialize the database, as well as the bucket directory, and then exit. You can also use this command if your database gets corrupted and you want to restart it from scratch.
 
-### Cursors and Automatic Maintenance
+### Automatic Maintenance
 
-Some tables in the database act as a publishing queue for external systems such as Horizon and generate **metadata** for changes happening to the distributed ledger.
+Some tables in stellar-core are used to publish ledger data to history archives.
 
-If not managed properly, those tables will grow without bounds. To avoid this, a built-in scheduler will delete data from old ledgers that are not used anymore by other parts of the system (external systems included).
+If not managed properly, those tables will grow without bounds. To avoid this, a built-in scheduler will delete data from old ledgers that are not used anymore by other parts of the system.
 
 By default, stellar-core will perform this automatic maintenance. The configuration fields that control the automatic maintenance behavior are:
 
 - `AUTOMATIC_MAINTENANCE_PERIOD`,
-- `AUTOMATIC_MAINTENANCE_COUNT`, and
-- `KNOWN_CURSORS`.
+- `AUTOMATIC_MAINTENANCE_COUNT`
 
 If you need to regenerate the metadata, the simplest way is to replay ledgers for the range you're interested in after (optionally) clearing the database with the `new-db` command [referenced earlier](#initialize-the-database-and-local-state).
 

--- a/docs/validators/admin-guide/logging.mdx
+++ b/docs/validators/admin-guide/logging.mdx
@@ -7,11 +7,11 @@ import { Alert } from "@site/src/components/Alert";
 
 Stellar Core sends logs to standard error and `stellar-core.log` by default, configurable with the `LOG_FILE_PATH` field.
 
-Log messages are classified by progressive _priority levels_: `TRACE`, `VERBOSE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `FATAL`. The logging system only emits those messages at or above its configured logging level.
+Log messages are classified by progressive _priority levels_: `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR`, and `FATAL`. The logging system only emits those messages at or above its configured logging level.
 
 Log messages at different priority levels can be color-coded on standard error by setting `LOG_COLOR=true` in the config file. By default they are not color-coded.
 
-The log level can be controlled by configuration, the `-ll` command-line flag, or adjusted dynamically by administrative (HTTP) commands. To do so, run:
+The log level can be controlled by configuration, the `--ll` command-line flag, or adjusted dynamically by administrative (HTTP) commands. To do so, run:
 
 ```bash
 $ stellar-core http-command "ll?level=debug"

--- a/docs/validators/admin-guide/monitoring.mdx
+++ b/docs/validators/admin-guide/monitoring.mdx
@@ -33,7 +33,7 @@ If you run `$ stellar-core http-command 'info'`, the output will look something 
       "hash": "39c2a3cd4141b2853e70d84601faa44744660334b48f3228e0309342e3f4eb48",
       "maxTxSetSize": 100,
       "num": 1,
-      "version": 0
+      "version": 20
     },
     "network": "Public Global Stellar Network ; September 2015",
     "peers": {
@@ -63,8 +63,7 @@ If you run `$ stellar-core http-command 'info'`, the output will look something 
       }
     },
     "startedOn": "2024-04-15T16:16:25Z",
-    "state": "Catching up",
-    "status": "Synced!"
+    "state": "Synced!"
   }
 }
 ```
@@ -75,7 +74,7 @@ Some notable fields from this `info` endpoint are:
 - `ledger`: a representation of the local state of your node, which may be different from the network state if your node was disconnected from the network for example. Some important sub-fields:
   - `age`: time elapsed since this ledger closed (during normal operation less than 10 seconds)
   - `num`: ledger number
-  - `version`: protocol version supported by this ledger
+  - `version`: protocol version of this ledger
 - `network` the [network passphrase](../../learn/encyclopedia/network-configuration/network-passphrases.mdx) for the network this core instance is using
 - `peers`: information on the connectivity to the network
   - `authenticated_count`: the number of live connections

--- a/docs/validators/admin-guide/network-upgrades.mdx
+++ b/docs/validators/admin-guide/network-upgrades.mdx
@@ -12,7 +12,7 @@ A node can be configured to vote for upgrades using the `upgrades` endpoint . Se
 The network settings are:
 
 - the version of the protocol used to process transactions;
-- the maximum number of transactions that can be included in a given ledger close;
+- the maximum number of transactions that can be included in a given ledger close. Separate setting for Soroban and classic transactions;
 - the cost (fee) associated with processing operations;
 - the base reserve used to calculate the lumen balance needed to store non-Soroban data in the ledger; and
 - generalized Soroban network settings stored in `ConfigSettingsEntries`.

--- a/docs/validators/admin-guide/prerequisites.mdx
+++ b/docs/validators/admin-guide/prerequisites.mdx
@@ -55,18 +55,18 @@ If you need to expose this endpoint to other hosts in your local network, we str
 
 ### Outbound
 
-- Stellar Core requires access to a database (PostgreSQL for example). If that database resides on a different machine on your network, you'll need to allow that connection. You'll specify the database when you [configure] Stellar Core.
+- Stellar Core requires access to a database (PostgreSQL, for example). If that database resides on a different machine on your network, you'll need to allow that connection. You'll specify the database when you [configure] Stellar Core.
 - You can safely block all other connections.
 
 ## Storage
 
-Stellar Core stores two copies of the ledger: one in a SQL [database](#database) and one in XDR files on local disk called [buckets](#buckets). For the most part, the contents of both the database and buckets directories can be ignored, since they are completely managed by Stellar Core. In terms of storage space, 100 GB is enough (as of April 2024).
+Most storage needs come from stellar-core's database backend, which needs to store the entire ledger state. For the most part, the contents of both the database and related directories (such as `buckets`) can be ignored, since they are completely managed by Stellar Core. In terms of storage space, 100 GB is enough (as of April 2024).
 
 ### Database
 
 The database is consulted during consensus, and modified atomically when a transaction set is applied to the ledger. It's random access, fine-grained, and fast.
 
-While a SQLite database works with Stellar Core, we generally recommend using a separate PostgreSQL server. A Postgres database is the bread and butter of Stellar Core.
+As of August 2024, Stellar Core officially switched to BucketListDB as its primary database backend. Note that BucketListDB still requires SQL database, either SQLite or Postgres (recommended).
 
 If you're using PostgreSQL, we recommend you configure your local database to be accessed over a Unix domain socket, as well as updating the below PostgreSQL configuration parameters:
 
@@ -80,7 +80,7 @@ If you're using PostgreSQL, we recommend you configure your local database to be
 
 ### Buckets
 
-In addition to the SQL database, Stellar Core stores a duplicate copy of the ledger in the form of flat XDR files called "buckets." The bucket files are used for hashing and transmission of ledger differences to history archives.
+Stellar-core stores ledger state in the form of flat XDR files called "buckets." The bucket files are used for hashing and transmission of ledger differences to history archives. If BucketListDB is used, the `buckets` directory is also used as a primary database backend. If SQL is used, the `buckets` directory is only used for hashing and history archives, and simply represents a copy of the ledger state stored in SQL.
 
 Buckets should be stored on a fast, local disk with sufficient space to store several times the size of the current ledger. Current ledger size is approximately 10 GB (as of April 2024), so please plan accordingly.
 

--- a/docs/validators/admin-guide/running-node.mdx
+++ b/docs/validators/admin-guide/running-node.mdx
@@ -93,7 +93,7 @@ And will then move through the various phases of downloading and applying state,
 "status" : [ "Catching up: downloading ledger files 20094/119803 (16%)" ]
 ```
 
-You can specify how far back in time your node goes to catch up in your config file. If you set the `CATCHUP_COMPLETE` field to `true`, your node will replay the _entire history_ of the network, which can take a long time. Weeks. You can speed up the process by copying existing archives from another full validator, but you only need to replay the complete network history if you're setting up a Full Validator (or possibly if you need to reingest Horizon state). Otherwise, you can specify a starting point for catchup using the `CATCHUP_RECENT` field. See the [complete example configuration] for more details.
+You can specify how far back in time your node goes to catch up in your config file. If you set the `CATCHUP_COMPLETE` field to `true`, your node will replay the _entire history_ of the network, which can take a long time. Weeks. You can speed up the process by copying existing archives from another full validator, using [`archivist` tool](./publishing-history-archives.mdx#complete-history-archive). Note that you only need to replay the complete network history if you're setting up a Full Validator (or possibly if you need to reingest Horizon state). Otherwise, you can specify a starting point for catchup using the `CATCHUP_RECENT` field. To get in sync as fast as possible, simply use configuration defaults for `CATCHUP_RECENT` and `CATCHUP_COMPLETE`. See the [complete example configuration] for more details.
 
 :::info
 


### PR DESCRIPTION
- Update expectations regarding database backend (BucketListDB is the default)
- Remove mentions of deprecated features (in-memory mode, cursors)
- Clarify catchup instructions, link to archivist
- Various typo fixes and clarifications