### PR TITLE
Fix `sendTransaction` example by simulating the transaction prior to submission

### DIFF
--- a/docs/data/rpc/api-reference/methods/sendTransaction.mdx
+++ b/docs/data/rpc/api-reference/methods/sendTransaction.mdx
@@ -76,7 +76,7 @@ async function sendTransaction() {
     const sourceKeypair = StellarSdk.Keypair.fromSecret(sourceSecretKey);
     server.prepareTransaction(tx).then((result) => {
       result.sign(sourceKeypair);
-      return sendTransaction(transaction);
+      return sendTransaction(result);
     }).then((result) => {
       console.log("hash:", result.hash);
       console.log("status:", result.status);

--- a/docs/data/rpc/api-reference/methods/sendTransaction.mdx
+++ b/docs/data/rpc/api-reference/methods/sendTransaction.mdx
@@ -74,9 +74,10 @@ async function sendTransaction() {
       .build();
 
     const sourceKeypair = StellarSdk.Keypair.fromSecret(sourceSecretKey);
-    transaction.sign(sourceKeypair);
-
-    server.sendTransaction(transaction).then((result) => {
+    server.prepareTransaction(tx).then((result) => {
+      result.sign(sourceKeypair);
+      return sendTransaction(transaction);
+    }).then((result) => {
       console.log("hash:", result.hash);
       console.log("status:", result.status);
       console.log("errorResultXdr:", result.errorResultXdr);

--- a/docs/data/rpc/api-reference/methods/sendTransaction.mdx
+++ b/docs/data/rpc/api-reference/methods/sendTransaction.mdx
@@ -74,14 +74,17 @@ async function sendTransaction() {
       .build();
 
     const sourceKeypair = StellarSdk.Keypair.fromSecret(sourceSecretKey);
-    server.prepareTransaction(tx).then((result) => {
-      result.sign(sourceKeypair);
-      return sendTransaction(result);
-    }).then((result) => {
-      console.log("hash:", result.hash);
-      console.log("status:", result.status);
-      console.log("errorResultXdr:", result.errorResultXdr);
-    });
+    server
+      .prepareTransaction(tx)
+      .then((result) => {
+        result.sign(sourceKeypair);
+        return sendTransaction(result);
+      })
+      .then((result) => {
+        console.log("hash:", result.hash);
+        console.log("status:", result.status);
+        console.log("errorResultXdr:", result.errorResultXdr);
+      });
   } catch (error) {
     console.error("Error fetching transaction:", error);
   }


### PR DESCRIPTION
Soroban transactions need to be simulated prior to submission, so we need a `prepareTransaction` call which will simulate and assemble for us. 

Closes https://github.com/stellar/stellar-docs/issues/837