### PR TITLE
Update brew install instructions for stellar-cli

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -98,10 +98,10 @@ cargo install --locked cargo-binstall
 cargo binstall -y stellar-cli
 ```
 
-Install with Homebrew:
+Install with Homebrew (macOS, Linux):
 
 ```sh
-brew install stellar/tap/stellar-cli
+brew install stellar-cli
 ```
 
 :::info

--- a/docs/tools/developer-tools/cli/install-cli.mdx
+++ b/docs/tools/developer-tools/cli/install-cli.mdx
@@ -23,10 +23,10 @@ cargo install --locked cargo-binstall
 cargo binstall -y stellar-cli
 ```
 
-Install with Homebrew:
+Install with Homebrew (macOS, Linux):
 
 ```
-brew install stellar/tap/stellar-cli
+brew install stellar-cli
 ```
 
 ## Installation with Experimental Features

--- a/docs/validators/admin-guide/soroban-settings.mdx
+++ b/docs/validators/admin-guide/soroban-settings.mdx
@@ -19,10 +19,10 @@ If you are being asked to vote for an upgrade, please move on to the [Examine a 
 
 ### 1. Create an Upgrade Set
 
-The `stellar-xdr` rust tool allows for the use of a JSON input file to encode a collection of Soroban settings into an base64-encoded string representing the XDR type `ConfigUpgradeSet`. You can use the [`pubnet_phase1.json`] and [`pubnet_phase2.json`] files as a starting point to formulate your upgrade proposal. Use the following command to create the required upgrade set XDR:
+The `stellar` CLI tool allows for the use of a JSON input file to encode a collection of Soroban settings into an base64-encoded string representing the XDR type `ConfigUpgradeSet`. You can use the [`pubnet_phase1.json`] and [`pubnet_phase2.json`] files as a starting point to formulate your upgrade proposal. Use the following command to create the required upgrade set XDR:
 
 ```bash
-stellar-xdr encode --type ConfigUpgradeSet path/to/upgrade.json
+stellar xdr encode --type ConfigUpgradeSet path/to/upgrade.json
 ```
 
 The output of the phase 2 JSON file, for example, would look like:
@@ -33,12 +33,12 @@ AAAAAgAAAAEAAAAAHc1lAAAAAAAF9eEAAAAAAAAAABkCgAAAAAAAAgAAAMgAB6EgAAAAfQABEXAAAAAo
 
 <Alert>
 
-`stellar-xdr` can be installed using brew or cargo:
+`stellar` CLI can be installed using brew or cargo:
 
 ```bash
-brew install stellar/tap/stellar-xdr
+brew install stellar-cli
 # OR
-cargo install --locked stellar-xdr --features cli
+cargo install --locked stellar-cli --features opt
 ```
 
 You can also download a [precompiled binary] of the latest release for your system from GitHub.
@@ -165,7 +165,7 @@ curl -G 'http://localhost:11626/sorobaninfo' --data-urlencode 'format=detailed'
 
 [`pubnet_phase1.json`]: https://github.com/stellar/stellar-core/blob/master/soroban-settings/pubnet_phase1.json
 [`pubnet_phase2.json`]: https://github.com/stellar/stellar-core/blob/master/soroban-settings/pubnet_phase2.json
-[precompiled binary]: https://github.com/stellar/rs-stellar-xdr/releases/latest
+[precompiled binary]: https://github.com/stellar/stellar-cli/releases/latest
 [protocol history page]: https://stellar.expert/explorer/pubnet/protocol-history
 [stellar.expert]: https://stellar.expert
 [this repository]: https://github.com/stellar-expert/staged-soroban-upgrades


### PR DESCRIPTION
### What
Update brew install instructions for stellar-cli. Also use stellar-cli for config updates instead fo stellar-xdr.

### Why
The stellar-cli is now available in the core homebrew tap and is the best place to install the CLI from instead of from the SDF tap.

The stellar-xdr tool is a standalone CLI, but it is embedded in the stellar-cli. The stellar-cli is installable from more places.
