### PR TITLE
Updates the soroban-example tag

### DIFF
--- a/docs/build/guides/conventions/deploy-contract.mdx
+++ b/docs/build/guides/conventions/deploy-contract.mdx
@@ -29,7 +29,7 @@ This guide walks through the process of deploying a smart contract from installe
 
 ### Setup environment
 
-The [deployer example](https://github.com/stellar/soroban-examples/tree/v21.4.0/deployer) demonstrates how to deploy contracts using a contract.
+The [deployer example](https://github.com/stellar/soroban-examples/tree/v21.4.1/deployer) demonstrates how to deploy contracts using a contract.
 
 1. Clone the Soroban Examples Repository:
 

--- a/docs/build/guides/conventions/upgrading-contracts.mdx
+++ b/docs/build/guides/conventions/upgrading-contracts.mdx
@@ -31,8 +31,8 @@ The [upgradeable contract example] demonstrates how to upgrade a Wasm contract.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[upgradeable contract example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/upgradeable_contract
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[upgradeable contract example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/upgradeable_contract
 [Rust programming language]: https://www.rust-lang.org/
 
 ### Code

--- a/docs/build/guides/conventions/wasm-metadata.mdx
+++ b/docs/build/guides/conventions/wasm-metadata.mdx
@@ -29,4 +29,4 @@ pub trait LiquidityPoolTrait {...
 ```
 
 [`contractmeta!`]: https://docs.rs/soroban-sdk/20.0.2/soroban_sdk/macro.contractmeta.html
-[liquidity pool example]: https://github.com/stellar/soroban-examples/blob/v21.4.0/liquidity_pool/src/lib.rs#L152-L155
+[liquidity pool example]: https://github.com/stellar/soroban-examples/blob/v21.4.1/liquidity_pool/src/lib.rs#L152-L155

--- a/docs/build/smart-contracts/example-contracts/TEMPLATE.mdx
+++ b/docs/build/smart-contracts/example-contracts/TEMPLATE.mdx
@@ -19,16 +19,16 @@ Place each link definition at the bottom of the section it first is used in.
 
 :::
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[example demonstrates]: https://github.com/stellar/soroban-examples/tree/v21.4.0/hello_world
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[example demonstrates]: https://github.com/stellar/soroban-examples/tree/v21.4.1/hello_world
 [other example]: ../getting-started/setup.mdx
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 ```sh
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -67,7 +67,7 @@ impl HelloContract {
 mod test;
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/hello_world
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/hello_world
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/alloc.mdx
+++ b/docs/build/smart-contracts/example-contracts/alloc.mdx
@@ -23,19 +23,19 @@ The [allocator example] demonstrates how to utilize the allocator feature when w
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[allocator example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/alloc
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
+[allocator example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/alloc
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
 
 The `soroban-sdk` crate provides a lightweight bump-pointer allocator which can be used to emulate heap memory allocation in a Wasm smart contract.
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -94,7 +94,7 @@ impl AllocContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/alloc
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/alloc
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/atomic-multi-swap.mdx
+++ b/docs/build/smart-contracts/example-contracts/atomic-multi-swap.mdx
@@ -25,6 +25,6 @@ Follow the comments in the code for more information.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
 [atomic swap]: atomic-swap.mdx
-[atomic swap batching example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/atomic_multiswap
+[atomic swap batching example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/atomic_multiswap

--- a/docs/build/smart-contracts/example-contracts/atomic-swap.mdx
+++ b/docs/build/smart-contracts/example-contracts/atomic-swap.mdx
@@ -23,17 +23,17 @@ This is example demonstrates advanced usage of Soroban auth framework and assume
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[atomic swap example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/atomic_swap
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[atomic swap example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/atomic_swap
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -123,7 +123,7 @@ fn move_token(
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/atomic_swap
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/atomic_swap
 
 ## How it Works
 
@@ -186,7 +186,7 @@ The swap itself is implemented via two token moves: from `a` to `b` and from `b`
 
 Open the [`atomic_swap/src/test.rs`] file to follow along.
 
-[`atomic_swap/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/atomic_swap/src/test.rs
+[`atomic_swap/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/atomic_swap/src/test.rs
 
 Refer to another examples for the general information on the test setup.
 

--- a/docs/build/smart-contracts/example-contracts/auth.mdx
+++ b/docs/build/smart-contracts/example-contracts/auth.mdx
@@ -27,18 +27,18 @@ This example is an extension of the [storing data example].
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
 [storing data example]: ../getting-started/storing-data.mdx
-[auth example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/auth
+[auth example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/auth
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -110,7 +110,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/auth
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/auth
 
 ## How it Works
 
@@ -166,7 +166,7 @@ user.require_auth_for_args((value,).into_val(&env));
 
 Open the [`auth/src/test.rs`] file to follow along.
 
-[`auth/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/auth/src/test.rs
+[`auth/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/auth/src/test.rs
 
 ```rust title="auth/src/test.rs"
 fn test() {

--- a/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
+++ b/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
@@ -31,17 +31,17 @@ In this example there are two contracts that are compiled separately, deployed s
 
 :::
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[cross contract call example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/cross_contract
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[cross contract call example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/cross_contract
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -93,7 +93,7 @@ impl ContractB {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/cross_contract
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/cross_contract
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/custom-account.mdx
+++ b/docs/build/smart-contracts/example-contracts/custom-account.mdx
@@ -38,17 +38,17 @@ While custom accounts are supported by the Stellar protocol and Soroban SDK, the
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[custom account example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/account
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[custom account example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/account
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -278,7 +278,7 @@ Then we check for the standard token function names and verify that for these fu
 
 Open the [`account/src/test.rs`] file to follow along.
 
-[`account/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/account/src/test.rs
+[`account/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/account/src/test.rs
 
 Refer to another examples for the general information on the test setup.
 

--- a/docs/build/smart-contracts/example-contracts/custom-types.mdx
+++ b/docs/build/smart-contracts/example-contracts/custom-types.mdx
@@ -25,18 +25,18 @@ The [custom types example] demonstrates how to define your own data structures t
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v20.0.0
-[custom types example]: https://github.com/stellar/soroban-examples/tree/v20.0.0/custom_types
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[custom types example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/custom_types
 [storing data example]: ../getting-started/storing-data.mdx
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v20.0.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v20.0.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -97,7 +97,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v20.0.0/custom_types
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/custom_types
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/deployer.mdx
+++ b/docs/build/smart-contracts/example-contracts/deployer.mdx
@@ -35,17 +35,17 @@ In this example there are two contracts that are compiled separately, and the te
 
 :::
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[deployer example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/deployer
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[deployer example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/deployer
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -108,7 +108,7 @@ impl Deployer {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/deployer
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/deployer
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/errors.mdx
+++ b/docs/build/smart-contracts/example-contracts/errors.mdx
@@ -25,18 +25,18 @@ The [errors example] demonstrates how to define and generate errors in a contrac
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[errors example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/errors
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[errors example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/errors
 [storing data example]: ../getting-started/storing-data.mdx
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -120,7 +120,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/errors
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/errors
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/events.mdx
+++ b/docs/build/smart-contracts/example-contracts/events.mdx
@@ -22,18 +22,18 @@ The [events example] demonstrates how to publish events from a contract. This ex
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[events example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/events
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[events example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/events
 [storing data example]: ../getting-started/storing-data.mdx
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -87,7 +87,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/events
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/events
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/fuzzing.mdx
+++ b/docs/build/smart-contracts/example-contracts/fuzzing.mdx
@@ -23,22 +23,22 @@ The [fuzzing example] demonstrates how to fuzz test Soroban contracts with [`car
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[fuzzing example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/fuzzing
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[fuzzing example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/fuzzing
 [`cargo-fuzz`]: https://docs.rs/cargo-fuzz
 [`arbitrary`]: https://docs.rs/arbitrary
 [`proptest`]: https://docs.rs/proptest
 [`proptest-arbitrary-interop`]: https://docs.rs/proptest-arbitrary-interop
-[timelock example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/timelock
+[timelock example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/timelock
 
 ## Run the Example
 
-First go through the [setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```sh
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 You will also need the `cargo-fuzz` tool, and to run `cargo-fuzz` you will need a nightly Rust toolchain:
@@ -112,7 +112,7 @@ In Rust, multiple fuzzers are maintained by the [`rust-fuzz`] GitHub organizatio
 
 The example used for this tutorial is based on the [`timelock`] example program, with some changes to demonstrate fuzzing.
 
-[`timelock`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/timelock
+[`timelock`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/timelock
 
 The contract, `ClaimableBalanceContract`, allows one party to deposit an arbitrary quantity of a token to the contract, specifying additionally: the `claimants`, addresses that may withdraw from the contract; and the `time_bound`, a specification of when those claimants may withdraw from the account.
 
@@ -182,8 +182,8 @@ Our `soroban-examples/fuzzing` directory looks like
 
 There are special considerations to note in the configuration of both the [contract's manifest] and the [fuzzing crate's manifest].
 
-[contract's manifest]: https://github.com/stellar/soroban-examples/tree/v21.4.0/fuzzing/Cargo.toml
-[fuzzing crate's manifest]: https://github.com/stellar/soroban-examples/tree/v21.4.0/fuzzing/fuzz/Cargo.toml
+[contract's manifest]: https://github.com/stellar/soroban-examples/tree/v21.4.1/fuzzing/Cargo.toml
+[fuzzing crate's manifest]: https://github.com/stellar/soroban-examples/tree/v21.4.1/fuzzing/fuzz/Cargo.toml
 
 Within the contract's manifest one must specificy the crate type as both "cdylib" and "rlib":
 
@@ -243,7 +243,7 @@ features = ["testutils"]
 
 First let's look at [`fuzz_target_1.rs`]. This fuzz test does two things: it first deposits an arbitrary amount, then it claims an arbitrary amount.
 
-[`fuzz_target_1.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/fuzzing/fuzz/fuzz_targets/fuzz_target_1.rs
+[`fuzz_target_1.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/fuzzing/fuzz/fuzz_targets/fuzz_target_1.rs
 
 Again, you can run this fuzzer from the `soroban-examples/fuzzing` directory with the following command:
 
@@ -662,7 +662,7 @@ All user-defined contract types, those with the [`contracttype`] attribute, auto
 
 The [`fuzz_target_2.rs`] example, demonstrates the use of `SorobanArbitrary`, the advancement of time, and more advanced fuzzing techniques.
 
-[`fuzz_target_2.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/fuzzing/fuzz/fuzz_targets/fuzz_target_2.rs
+[`fuzz_target_2.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/fuzzing/fuzz/fuzz_targets/fuzz_target_2.rs
 
 This fuzz test takes a much more complex input, where some of the values are user-defined types exported from the contract under test. This test is structured as a simple interpreter, where the fuzzing harness provides arbitrarily-generated "steps", where each step is either a `deposit` command or a `claim` command. The test then treats each of these steps as a separate transaction: it maintains a snapshot of the blockchain state, and for each step creates a fresh environment in which to execute the contract call, simulating the advancement of time between each step. As in the previous example, assertions are made after each step.
 
@@ -795,4 +795,4 @@ The great benefit of property tests though is that they can be included in stand
 
 The [`proptest.rs`] file is a translation of `fuzz_target_1.rs` to a property test.
 
-[`proptest.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.0/fuzzing/src/proptest.rs
+[`proptest.rs`]: https://github.com/stellar/soroban-examples/tree/v21.4.1/fuzzing/src/proptest.rs

--- a/docs/build/smart-contracts/example-contracts/liquidity-pool.mdx
+++ b/docs/build/smart-contracts/example-contracts/liquidity-pool.mdx
@@ -35,16 +35,16 @@ The Stellar network already has liquidity pool functionality built right in to t
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/liquidity_pool
-[source code]: https://github.com/stellar/soroban-examples/blob/v21.4.0/liquidity_pool/src/lib.rs#L143
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[liquidity pool example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/liquidity_pool
+[source code]: https://github.com/stellar/soroban-examples/blob/v21.4.1/liquidity_pool/src/lib.rs#L143
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 ```sh
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -467,7 +467,7 @@ pub fn create_contract(
 </TabItem>
 </Tabs>
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/liquidity_pool
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/liquidity_pool
 
 ## How it Works
 
@@ -829,7 +829,7 @@ fn test() {
 }
 ```
 
-[`liquidity_pool/src/test.rs`]: https://github.com/stellar/soroban-examples/blob/v21.4.0/liquidity_pool/src/test.rs
+[`liquidity_pool/src/test.rs`]: https://github.com/stellar/soroban-examples/blob/v21.4.1/liquidity_pool/src/test.rs
 
 In any test the first thing that is always required is an `Env`, which is the Soroban environment that the contract will run in.
 

--- a/docs/build/smart-contracts/example-contracts/logging.mdx
+++ b/docs/build/smart-contracts/example-contracts/logging.mdx
@@ -24,8 +24,8 @@ The [logging example] demonstrates how to log for the purpose of debugging.
 
 Logs in contracts are only visible in tests, or when executing contracts using [`stellar-cli`]. Logs are only compiled into the contract if the `debug-assertions` Rust compiler option is enabled.
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[logging example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/hello_world
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[logging example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/hello_world
 
 :::tip
 
@@ -44,12 +44,12 @@ Logs are not accessible by dapps and other applications. See the [events example
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -92,7 +92,7 @@ impl Contract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/logging
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/logging
 
 ## How it Works
 

--- a/docs/build/smart-contracts/example-contracts/mint-lock.mdx
+++ b/docs/build/smart-contracts/example-contracts/mint-lock.mdx
@@ -23,5 +23,5 @@ The admin of the token contracts used must be the mint-lock contract.
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[mint-lock example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/mint-lock
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[mint-lock example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/mint-lock

--- a/docs/build/smart-contracts/example-contracts/single-offer-sale.mdx
+++ b/docs/build/smart-contracts/example-contracts/single-offer-sale.mdx
@@ -23,6 +23,6 @@ The [single offer sale example] demonstrates how to write a contract that allows
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[single offer sale example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/single_offer
-[source code]: https://github.com/stellar/soroban-examples/blob/v21.4.0/single_offer/src/lib.rs
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[single offer sale example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/single_offer
+[source code]: https://github.com/stellar/soroban-examples/blob/v21.4.1/single_offer/src/lib.rs

--- a/docs/build/smart-contracts/example-contracts/timelock.mdx
+++ b/docs/build/smart-contracts/example-contracts/timelock.mdx
@@ -25,6 +25,6 @@ The [timelock example] demonstrates how to write a timelock and implements a gre
 
 The contract accepts deposits of an amount of a token, and allows other users to claim it before or after a time point.
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[timelock example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/timelock
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[timelock example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/timelock
 [claimable balance]: ../../../learn/encyclopedia/transactions-specialized/claimable-balances.mdx

--- a/docs/build/smart-contracts/example-contracts/tokens.mdx
+++ b/docs/build/smart-contracts/example-contracts/tokens.mdx
@@ -25,16 +25,16 @@ The [token example] demonstrates how to write a token contract that implements t
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
-[token example]: https://github.com/stellar/soroban-examples/tree/v21.4.0/token
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
+[token example]: https://github.com/stellar/soroban-examples/tree/v21.4.1/token
 [token interface]: ../../../tokens/token-interface.mdx
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v21.4.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `v21.4.1` tag of `soroban-examples` repository:
 
 ```sh
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
@@ -525,7 +525,7 @@ pub enum DataKey {
 </TabItem>
 </Tabs>
 
-Ref: https://github.com/stellar/soroban-examples/tree/v21.4.0/token
+Ref: https://github.com/stellar/soroban-examples/tree/v21.4.1/token
 
 ## How it Works
 

--- a/docs/build/smart-contracts/getting-started/storing-data.mdx
+++ b/docs/build/smart-contracts/getting-started/storing-data.mdx
@@ -21,7 +21,7 @@ import TabItem from "@theme/TabItem";
 
 Now that we've built a basic Hello World example contract, we'll write a simple contract that stores and retrieves data. This will help you see the basics of Soroban's storage system.
 
-This is going to follow along with the [increment example](https://github.com/stellar/soroban-examples/tree/v21.4.0/increment), which has a single function that increments an internal counter and returns the value. If you want to see a working example, [try it in GitPod](https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0).
+This is going to follow along with the [increment example](https://github.com/stellar/soroban-examples/tree/v21.4.1/increment), which has a single function that increments an internal counter and returns the value. If you want to see a working example, [try it in GitPod](https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1).
 
 This tutorial assumes that you've already completed the previous steps in Getting Started: [Setup](./setup.mdx), [Hello World](./hello-world.mdx), and [Deploy to Testnet](./deploy-to-testnet.mdx).
 

--- a/docs/data/rpc/admin-guide.mdx
+++ b/docs/data/rpc/admin-guide.mdx
@@ -565,7 +565,7 @@ docker.io/stellar/system-test:soroban-preview11 \
 --TargetNetworkPassphrase "Test SDF Network ; September 2015" \
 --TargetNetworkTestAccountSecret <your test account StrKey encoded key here > \
 --TargetNetworkTestAccountPublic <your test account StrKey encoded pubkey here> \
---SorobanExamplesGitHash v21.4.0
+--SorobanExamplesGitHash v21.4.1
 ```
 
 Make sure you configure the system test correctly:

--- a/docs/learn/migrate/evm/introduction-to-solidity-and-rust.mdx
+++ b/docs/learn/migrate/evm/introduction-to-solidity-and-rust.mdx
@@ -30,7 +30,7 @@ Or if you want to jump right in, you can open up our examples in a ready to go d
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)][oigp]
 
-[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.0
+[oigp]: https://gitpod.io/#https://github.com/stellar/soroban-examples/tree/v21.4.1
 
 # Summary
 

--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -189,10 +189,10 @@ If you haven't already setup up the dev environment for Soroban, you can get sta
 
 This project requires using the `soroban_token_contract.wasm` file which you will need to import manually.
 
-First, you will need to clone the `v21.4.0` tag of `soroban-examples` repository:
+First, you will need to clone the `v21.4.1` tag of `soroban-examples` repository:
 
 ```bash
-git clone -b v21.4.0 https://github.com/stellar/soroban-examples
+git clone -b v21.4.1 https://github.com/stellar/soroban-examples
 ```
 
 Then, navigate to the `soroban-examples/token` directory

--- a/src/pages/docs/learn/interactive/dapps/challenges/challenge-1-payment.mdx
+++ b/src/pages/docs/learn/interactive/dapps/challenges/challenge-1-payment.mdx
@@ -61,7 +61,7 @@ yarn
 
 ## Checkpoint 2: 🎬 Deploy Smart Contracts
 
-For this step you will need to clone and deploy the Soroban token smart contract from the [Soroban Examples repository](https://github.com/stellar/soroban-examples/tree/v21.4.0/token). This Soroban token smart contract, broken into several smaller modules (as is the custom for complex smart contracts like this one), enables you to create and manage tokens on Soroban.
+For this step you will need to clone and deploy the Soroban token smart contract from the [Soroban Examples repository](https://github.com/stellar/soroban-examples/tree/v21.4.1/token). This Soroban token smart contract, broken into several smaller modules (as is the custom for complex smart contracts like this one), enables you to create and manage tokens on Soroban.
 
 The Soroban token is a custom token that will be used to facilitate payments in the Payment Dapp. Tokens are essentially programmable assets on a blockchain, and smart contracts provide the automation and rules for these tokens. They allow for predefined conditions and actions related to the tokens, such as issuance, transfer, and more complex functions, ensuring the execution of these operations without the need for intermediaries. In the case of this Payment Dapp, you will use the Soroban token to initialize and mint "Demo Token" assets, or DT, that you can then use to make payments via the Payment Dapp.
 


### PR DESCRIPTION
The first commit bumps the custom_types example from a very outdated version. The second commit is just for consistency. 