### PR TITLE
Reference correct diagram in scaling documentation

### DIFF
--- a/docs/data/horizon/admin-guide/scaling.mdx
+++ b/docs/data/horizon/admin-guide/scaling.mdx
@@ -54,4 +54,4 @@ In the above example, ingestion is safely isolated from most API traffic, which 
 
 The below diagram illustrates how we could further isolate (and scale) transaction submission, by way of using core watcher instances, rather than Horizon instances running captive core. This allows us to further protect ingestion, preventing downtime and ingestion lag. It also makes it possible to horizontally scale transaction submission itself, independent of the rest of the API traffic.
 
-![](/assets/horizon-scaling/Topology-ingestion-isolation.png)
+![](/assets/horizon-scaling/Topology-txsub.png)


### PR DESCRIPTION
Just noticed this when referring someone to this documentation. I think the wrong diagram reference has been there since the rewrite of this page