### PR TITLE
[Wallet SDK] Mention Sep-7 support on Getting Started section

### DIFF
--- a/docs/build/apps/wallet/intro.mdx
+++ b/docs/build/apps/wallet/intro.mdx
@@ -158,9 +158,12 @@ Below you can find all the SEPs the anchor class currently supports:
 - [SEP-12]: explored on [Providing KYC info] subsection
 - [SEP-38]: explored on [Quote] section
 
+Besides the SEPs supported by the anchor class the wallet SDK also has support for the [SEP-7] protocol which is explored on [URI Scheme to facilitate delegated signing] section.
+
 [horizon sdk]: /docs/tools/sdks
 [sep-1]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
 [sep-6]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md
+[sep-7]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md
 [sep-10]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md
 [sep-12]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md
 [sep-24]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
@@ -170,3 +173,4 @@ Below you can find all the SEPs the anchor class currently supports:
 [programmatic deposit and withdrawal]: /docs/build/apps/wallet/sep6
 [providing kyc info]: /docs/build/apps/wallet/sep6#providing-kyc-info
 [quote]: /docs/build/apps/wallet/sep38
+[uri scheme to facilitate delegated signing]: /docs/build/apps/wallet/sep7


### PR DESCRIPTION
We've [recently merged](https://github.com/stellar/stellar-docs/pull/926) documentation for `Sep-7`, so let's mention it on the `Getting Started` section together with the other supported SEPs.