### PR TITLE
[AP] Make `amount_out` optional for request funds

### DIFF
--- a/ap_versioned_docs/version-2.9.0/api-reference/platform/rpc/anchor-platform.openrpc.json
+++ b/ap_versioned_docs/version-2.9.0/api-reference/platform/rpc/anchor-platform.openrpc.json
@@ -13,7 +13,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.8.4"
+    "version": "2.9.0"
   },
   "servers": [
     {
@@ -76,11 +76,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -194,10 +190,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -446,19 +439,13 @@
           "required": false,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "amount_fee"
-            ],
+            "required": ["amount", "amount_fee"],
             "properties": {
               "amount": {
                 "title": "amount",
                 "description": "Amount to be refunded",
                 "type": "object",
-                "required": [
-                  "amount",
-                  "asset"
-                ],
+                "required": ["amount", "asset"],
                 "properties": {
                   "amount": {
                     "title": "amount",
@@ -476,10 +463,7 @@
                 "title": "amount_fee",
                 "description": "Amount of fee",
                 "type": "object",
-                "required": [
-                  "amount",
-                  "asset"
-                ],
+                "required": ["amount", "asset"],
                 "properties": {
                   "amount": {
                     "title": "amount",
@@ -512,11 +496,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -630,10 +610,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -892,10 +869,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -917,9 +891,7 @@
           "deprecated": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -937,10 +909,7 @@
             "title": "fee_details",
             "description": "Description of fee charged by the anchor.",
             "type": "object",
-            "required": [
-              "total",
-              "asset"
-            ],
+            "required": ["total", "asset"],
             "properties": {
               "total": {
                 "type": "number"
@@ -984,11 +953,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -1102,10 +1067,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -1370,11 +1332,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -1488,10 +1446,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -1734,10 +1689,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -1758,10 +1710,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -1783,9 +1732,7 @@
           "deprecated": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -1803,10 +1750,7 @@
             "title": "fee_details",
             "description": "Description of fee charged by the anchor.",
             "type": "object",
-            "required": [
-              "total",
-              "asset"
-            ],
+            "required": ["total", "asset"],
             "properties": {
               "total": {
                 "type": "number"
@@ -1840,9 +1784,7 @@
           "required": false,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -1868,11 +1810,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -1986,10 +1924,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -2283,11 +2218,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -2401,10 +2332,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -2678,11 +2606,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -2796,10 +2720,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -3070,10 +2991,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -3094,10 +3012,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -3119,9 +3034,7 @@
           "deprecated": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -3139,10 +3052,7 @@
             "title": "fee_details",
             "description": "Description of fee charged by the anchor.",
             "type": "object",
-            "required": [
-              "total",
-              "asset"
-            ],
+            "required": ["total", "asset"],
             "properties": {
               "total": {
                 "type": "number"
@@ -3186,11 +3096,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -3304,10 +3210,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -3619,11 +3522,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -3737,10 +3636,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -4008,10 +3904,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -4032,10 +3925,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -4057,9 +3947,7 @@
           "deprecated": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -4077,10 +3965,7 @@
             "title": "fee_details",
             "description": "Description of fee charged by the anchor.",
             "type": "object",
-            "required": [
-              "total",
-              "asset"
-            ],
+            "required": ["total", "asset"],
             "properties": {
               "total": {
                 "type": "number"
@@ -4124,11 +4009,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -4242,10 +4123,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -4522,11 +4400,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -4640,10 +4514,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -4891,20 +4762,13 @@
           "name": "refund",
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "amount_fee",
-              "id"
-            ],
+            "required": ["amount", "amount_fee", "id"],
             "properties": {
               "amount": {
                 "title": "amount",
                 "description": "Amount to be refunded",
                 "type": "object",
-                "required": [
-                  "amount",
-                  "asset"
-                ],
+                "required": ["amount", "asset"],
                 "properties": {
                   "amount": {
                     "title": "amount",
@@ -4922,10 +4786,7 @@
                 "title": "amount_fee",
                 "description": "Amount of fee",
                 "type": "object",
-                "required": [
-                  "amount",
-                  "asset"
-                ],
+                "required": ["amount", "asset"],
                 "properties": {
                   "amount": {
                     "title": "amount",
@@ -4963,11 +4824,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -5081,10 +4938,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -5345,20 +5199,13 @@
           "name": "refund",
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "amount_fee",
-              "id"
-            ],
+            "required": ["amount", "amount_fee", "id"],
             "properties": {
               "amount": {
                 "title": "amount",
                 "description": "Amount to be refunded",
                 "type": "object",
-                "required": [
-                  "amount",
-                  "asset"
-                ],
+                "required": ["amount", "asset"],
                 "properties": {
                   "amount": {
                     "title": "amount",
@@ -5376,10 +5223,7 @@
                 "title": "amount_fee",
                 "description": "Amount of fee",
                 "type": "object",
-                "required": [
-                  "amount",
-                  "asset"
-                ],
+                "required": ["amount", "asset"],
                 "properties": {
                   "amount": {
                     "title": "amount",
@@ -5417,11 +5261,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -5535,10 +5375,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -5811,11 +5648,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -5929,10 +5762,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -6191,11 +6021,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -6309,10 +6135,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -6578,11 +6401,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -6696,10 +6515,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -6958,11 +6774,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -7076,10 +6888,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -7343,11 +7152,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -7461,10 +7266,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -7720,11 +7522,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -7838,10 +7636,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -8087,10 +7882,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8111,10 +7903,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8136,9 +7925,7 @@
           "deprecated": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8156,10 +7943,7 @@
             "title": "fee_details",
             "description": "Description of fee charged by the anchor.",
             "type": "object",
-            "required": [
-              "total",
-              "asset"
-            ],
+            "required": ["total", "asset"],
             "properties": {
               "total": {
                 "type": "number"
@@ -8193,9 +7977,7 @@
           "required": false,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8221,11 +8003,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -8339,10 +8117,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -8615,10 +8390,7 @@
           "required": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8635,14 +8407,11 @@
         },
         {
           "name": "amount_out",
-          "description": "Amount sent by anchor to user",
-          "required": true,
+          "description": "Amount sent by anchor to user. This is required if the transaction is associated with a firm quote and for transactions where `amount_in.asset` and `amount_out.asset` are the same.",
+          "required": false,
           "schema": {
             "type": "object",
-            "required": [
-              "amount",
-              "asset"
-            ],
+            "required": ["amount", "asset"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8664,9 +8433,7 @@
           "deprecated": true,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8684,10 +8451,7 @@
             "title": "fee_details",
             "description": "Description of fee charged by the anchor.",
             "type": "object",
-            "required": [
-              "total",
-              "asset"
-            ],
+            "required": ["total", "asset"],
             "properties": {
               "total": {
                 "type": "number"
@@ -8721,9 +8485,7 @@
           "required": false,
           "schema": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "title": "amount",
@@ -8773,11 +8535,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -8891,10 +8649,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"
@@ -9177,11 +8932,7 @@
               "title": "sep",
               "description": "Protocol of the transaction.",
               "type": "integer",
-              "enum": [
-                6,
-                24,
-                31
-              ]
+              "enum": [6, 24, 31]
             },
             "kind": {
               "title": "kind",
@@ -9295,10 +9046,7 @@
               "title": "fee_details",
               "description": "Description of fee charged by the anchor.",
               "type": "object",
-              "required": [
-                "total",
-                "asset"
-              ],
+              "required": ["total", "asset"],
               "properties": {
                 "total": {
                   "type": "number"

--- a/openrpc/src/anchor-platform/methods/request_onchain_funds.json
+++ b/openrpc/src/anchor-platform/methods/request_onchain_funds.json
@@ -3,15 +3,29 @@
   "summary": "Request onchain funds",
   "description": "The user has to initiate transfer to the anchor",
   "paramStructure": "by-name",
-  "tags": [
-    { "name": "SEP-6" },
-    { "name": "SEP-24" }
-  ],
+  "tags": [{ "name": "SEP-6" }, { "name": "SEP-24" }],
   "params": [
     { "$ref": "#/components/contentDescriptors/transaction_id" },
     { "$ref": "#/components/contentDescriptors/message" },
     { "$ref": "#/components/contentDescriptors/amount_in" },
-    { "$ref": "#/components/contentDescriptors/amount_out" },
+    {
+      "name": "amount_out",
+      "description": " This is required if the transaction is associated with a firm quote and for transactions where `amount_in.asset` and `amount_out.asset` are the same.",
+      "required": false,
+      "schema": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "$ref": "#/components/schemas/AmountNumber"
+          },
+          "asset": {
+            "description": "The asset to be sent by anchor to user at end of transaction",
+            "$ref": "#/components/schemas/AmountAsset"
+          }
+        },
+        "required": ["amount", "asset"]
+      }
+    },
     { "$ref": "#/components/contentDescriptors/amount_fee" },
     { "$ref": "#/components/contentDescriptors/fee_details" },
     { "$ref": "#/components/contentDescriptors/amount_expected" },

--- a/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
+++ b/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
@@ -8635,8 +8635,8 @@
         },
         {
           "name": "amount_out",
-          "description": "Amount sent by anchor to user",
-          "required": true,
+          "description": " This is required if the transaction is associated with a firm quote and for transactions where `amount_in.asset` and `amount_out.asset` are the same.",
+          "required": false,
           "schema": {
             "type": "object",
             "required": [


### PR DESCRIPTION
A lot of the changes are from prettier formatting. The main change is in the `amount_out` description for the `request_onchain_funds` RPC.