### PR TITLE
Add Obsrvr as RPC and Horizon provider

### DIFF
--- a/docs/data/horizon/horizon-providers.mdx
+++ b/docs/data/horizon/horizon-providers.mdx
@@ -21,6 +21,7 @@ These providers allow access to the Testnet and Mainnet networks.
 | [QuickNode\*](https://www.quicknode.com/docs/stellar) | [Access](https://www.quicknode.com/chains/stellar) | Not available | Available | Available |
 | [Ankr](https://www.ankr.com/rpc/advanced-api/) | [Access](https://www.ankr.com/rpc/advanced-api/) | Not available | Available | Available |
 | [Validation Cloud\*†](https://www.validationcloud.io/) | [Access](https://app.validationcloud.io/) | Not available | Available | Available |
+| [Obsrvr](https://www.withObsrvr.com/) | [Access](https://console.withobsrvr.com/) | Not available | Available | Available |
 
 \*_Please note that Blockdaemon, Validation Cloud, and Quicknode combine Horizon and RPC in the same endpoint._
 

--- a/docs/data/rpc/rpc-providers.mdx
+++ b/docs/data/rpc/rpc-providers.mdx
@@ -18,6 +18,7 @@ These providers allow access to the Testnet and Mainnet networks.
 | [Gateway](https://gateway.fm/) | [Access](https://gateway.fm/public-rpc/) | Not available | Available | Available |
 | [Ankr](https://www.ankr.com/rpc/advanced-api/) | [Access](https://www.ankr.com/rpc/advanced-api/) | Not available | Available | Available |
 | [Infstones](https://infstones.com/) | [Access](https://cloud.infstones.com/login) | Not available | Not Available | Available |
+| [Obsrvr](https://www.withObsrvr.com/) | [Access](https://console.withobsrvr.com/) | Not available | Available | Available |
 
 \*_Blockdaemon, Validation Cloud, and Quicknode combine Horizon and RPC in the same endpoint._
 


### PR DESCRIPTION
This pull request adds Obsrvr to the official list of RPC and Horizon providers for the Stellar network. Obsrvr offers access to the Stellar network through its Obsrvr Gateway service.

**Details:**

- **Provider Name:** Obsrvr
- **Main Site URL:** https://www.withobsrvr.com/
- **Access URL for Console:** https://console.withobsrvr.com/

Developers can visit the main site for more information about Obsrvr’s offerings, and use the console access URL to create a subscription and manage their RPC and Horizon services.

**Authorization Header Example:** Currently, API keys are used in the authorization headers as follows:

`Authorization: Api-Key <API Key>`

**Future Update:** In a future update, API keys will also be supported in the URL, offering greater flexibility in how developers can authenticate their requests.

**History:** Horizon history is also set for a 30 day sliding window