### PR TITLE
Two not three typo

### DIFF
--- a/docs/learn/fundamentals/fees-resource-limits-metering.mdx
+++ b/docs/learn/fundamentals/fees-resource-limits-metering.mdx
@@ -175,7 +175,7 @@ For the past three hours, inclusion fee statistics on the Mainnet network can be
 
 <CanvasFeeGraphs />
 
-There are three primary methods to deal with inclusion fee fluctuations and surge pricing:
+There are two primary methods to deal with inclusion fee fluctuations and surge pricing:
 
 - [**Method 1:**](#set-the-highest-fee-youre-comfortable-paying) set the highest fee you’re comfortable paying. This does not mean that you’ll pay that amount on every transaction — you will only pay what’s necessary to get into the ledger. Under normal (non-surge) circumstances, you will only pay the standard fee even with a higher maximum fee set. This method is simple, convenient, and efficient but can still potentially fail.
 - [**Method 2:**](#fee-bumps-on-past-transactions) resubmit a transaction with a higher fee using a fee-bump transaction


### PR DESCRIPTION
only two methods are listed for handling inclusion fee fluctuations and surge pricing. So someone accidentally must have wrote as 'three' methods