### PR TITLE
AP: Remove callback_url from client config

### DIFF
--- a/platforms/anchor-platform/admin-guide/sep10/README.mdx
+++ b/platforms/anchor-platform/admin-guide/sep10/README.mdx
@@ -60,30 +60,28 @@ clients:
   #
   #   If the type is `custodial`,
   #   - signing_keys: (required) the custodial SEP-10 signing key of the client.
-  #   - callback_url: (optional) the URL of the client's callback API endpoint.
-  #                   If one of SEP-specific URLs is also provided, then this URL will be used as a fallback.
-  #                   For example, if `callback_url_sep6` is not provided, but `callback_url_sep24` is,
-  #                   SEP-6 transactions will use the `callback_url` as the callback URL. This field is
-  #                   deprecated and will be removed in 3.0.
-  #   - callback_url_sep6: (optional) the URL of the client's SEP-6 callback API endpoint.
-  #   - callback_url_sep24: (optional) the URL of the client's SEP-24 callback API endpoint.
-  #   - callback_url_sep31: (optional) the URL of the client's SEP-31 callback API endpoint.
-  #   - callback_url_sep12: (optional) the URL of the client's SEP-10 callback API endpoint.
+  #   - callback_urls.sep6: (optional) the URL of the client's SEP-6 callback API endpoint.
+  #   - callback_urls.sep24: (optional) the URL of the client's SEP-24 callback API endpoint.
+  #   - callback_urls.sep31: (optional) the URL of the client's SEP-31 callback API endpoint.
+  #   - callback_urls.sep12: (optional) the URL of the client's SEP-10 callback API endpoint.
   #   - allow_any_destination: (optional) default to false. If set to true, allows any destination for deposits.
   #   - destination_accounts: (optional) list of accounts allowed to be used for the deposit.
   #                           If allows_any_destinations set to true, this configuration option is ignored.
   #
   #   If the type is `noncustodial`,
   #   - domains: (required) the domains of the client.
-  #   - callback_url: (optional) the URL of the client's callback API endpoint
+  #   - callback_urls.sep6: (optional) the URL of the client's SEP-6 callback API endpoint.
+  #   - callback_urls.sep24: (optional) the URL of the client's SEP-24 callback API endpoint.
+  #   - callback_urls.sep31: (optional) the URL of the client's SEP-31 callback API endpoint.
+  #   - callback_urls.sep12: (optional) the URL of the client's SEP-10 callback API endpoint.
 
   # custodial client
   - name: custodial-client1
     type: custodial
     signing_keys: "the signing key 1 of the client1","the signing key 2 of the client1"
-    callback_url: https://callback.custodial-client1.com/api/v1/anchor/callback
-    callback_url_sep6: https://callback.custodial-client1.com/api/v1/anchor/callback/sep6
-    callback_url_sep12: https://callback.custodial-client1.com/api/v1/anchor/callback/sep12
+    callback_urls:
+      sep6: https://callback.custodial-client1.com/api/v1/anchor/callback/sep6
+      sep12: https://callback.custodial-client1.com/api/v1/anchor/callback/sep12
     allow_any_destination: false
     destination_accounts: destAccount1,destAccount2
   - name: custodial-client2
@@ -94,9 +92,9 @@ clients:
   - name: noncustodial-client1
     type: noncustodial
     domains: noncustodial-client1.co,noncustodial-client1.com
-    callback_url: https://callback.noncustodial-client1.co/api/v2/anchor/callback
-    callback_url_sep6: https://callback.noncustodial-client1.co/api/v2/anchor/callback/sep6
-    callback_url_sep12: https://callback.noncustodial-client1.co/api/v2/anchor/callback/sep12
+    callback_urls:
+      sep6: https://callback.noncustodial-client1.co/api/v2/anchor/callback/sep6
+      sep12: https://callback.noncustodial-client1.co/api/v2/anchor/callback/sep12
   - name: noncustodial-client2
     type: noncustodial
     domains: noncustodial-client2.com
@@ -108,7 +106,6 @@ clients:
 CLIENTS[0]_NAME=custodial-client1
 CLIENTS[0]_TYPE=custodial
 CLIENTS[0]_SIGNING_KEYS="the signing key 1 of the client1","the signing key 2 of the client1"
-CLIENTS[0]_CALLBACK_URL=https://callback.custodial-client1.com/api/v1/anchor/callback
 CLIENTS[0]_ALLOW_ANY_DESTINATION=false
 CLIENTS[0]_DESTINATION_ACCOUNTS=destAccount1,destAccount2
 CLIENTS[1]_NAME=custodial-client2
@@ -119,7 +116,6 @@ CLIENTS[1]_SIGNING_KEYS="the signing key of the client2"
 CLIENTS[2]_NAME=noncustodial-client1
 CLIENTS[2]_TYPE=noncustodial
 CLIENTS[2]_DOMAINS=noncustodial-client1.co,noncustodial-client1.com
-CLIENTS[2]_CALLBACK_URL=https://callback.noncustodial-client1.co/api/v2/anchor/callback
 CLIENTS[3]_NAME=noncustodial-client2
 CLIENTS[3]_TYPE=noncustodial
 CLIENTS[3]_DOMAINS=noncustodial-client2.com


### PR DESCRIPTION
`callback_url` has been deprecated in favor of SEP-specific URLs.