### PR TITLE
Update moneygram-access-integration-guide.mdx

### DIFF
--- a/docs/build/apps/moneygram-access-integration-guide.mdx
+++ b/docs/build/apps/moneygram-access-integration-guide.mdx
@@ -327,7 +327,7 @@ You will need the following information to do so.
 - The authentication token provided by MoneyGram
 - The transaction’s ID provided by MoneyGram
 - MoneyGram’s transaction’s endpoint (you don't need to worry about it if you are using the Wallet SDK)
-  - Testing: https://extmgxanchor.moneygram.com/stellaradapterservice/sep24/transaction
+  - Testing: https://extmgxanchor.moneygram.com/stellarsepservice/sep24/transaction
   - Production: https://stellar.moneygram.com/stellaradapterservice/sep24/transaction
 
 This code uses a simple watching (polling) mechanism with no bail-out condition. The application’s code should be more robust.

--- a/docs/build/apps/moneygram-access-integration-guide.mdx
+++ b/docs/build/apps/moneygram-access-integration-guide.mdx
@@ -136,10 +136,10 @@ This section encompasses steps 1 & 2 of the diagram displayed in the Architectur
 This section assumes that the application’s server has the following pieces of information:
 
 - The user’s integer ID (must be positive and represented using 64 bits or less) MoneyGram’s authentication endpoint
-  - Testing: https://extstellar.moneygram.com/stellaradapterservice/auth
+  - Testing: https://extmgxanchor.moneygram.com/stellarsepservice/auth
   - Production: https://stellar.moneygram.com/stellaradapterservice/auth
 - MoneyGram’s authentication public key
-  - Testing: `GCSESAP5ILVM6CWIEGK2SDOCQU7PHVFYYT7JNKRDAQNVQWKD5YEE5ZJ4`
+  - Testing: `GCUZ6YLL5RQBTYLTTQLPCM73C5XAIUGK2TIMWQH7HPSGWVS2KJ2F3CHS`
   - Production: `GD5NUMEX7LYHXGXCAD4PGW7JDMOUY2DKRGY5XZHJS5IONVHDKCJYGVCL`
 - The application’s authentication public and secret key
 
@@ -163,7 +163,7 @@ import { Wallet, SigningKeypair } from "@stellar/typescript-wallet-sdk";
 const wallet = Wallet.TestNet();
 
 // Testnet
-const MGI_ACCESS_HOST = "extstellar.moneygram.com";
+const MGI_ACCESS_HOST = "extmgxanchor.moneygram.com";
 // Pubnet
 // const MGI_ACCESS_HOST = "stellar.moneygram.com";
 
@@ -184,7 +184,7 @@ from stellar_sdk import Network
 from stellar_sdk.sep.stellar_web_authentication import read_challenge_transaction
 
 # Testnet
-MGI_ACCESS_HOST = "extstellar.moneygram.com"
+MGI_ACCESS_HOST = "extmgxanchor.moneygram.com"
 # Pubnet
 # MGI_ACCESS_HOST = "stellar.moneygram.com"
 
@@ -327,7 +327,7 @@ You will need the following information to do so.
 - The authentication token provided by MoneyGram
 - The transaction’s ID provided by MoneyGram
 - MoneyGram’s transaction’s endpoint (you don't need to worry about it if you are using the Wallet SDK)
-  - Testing: https://extstellar.moneygram.com/stellaradapterservice/sep24/transaction
+  - Testing: https://extmgxanchor.moneygram.com/stellaradapterservice/sep24/transaction
   - Production: https://stellar.moneygram.com/stellaradapterservice/sep24/transaction
 
 This code uses a simple watching (polling) mechanism with no bail-out condition. The application’s code should be more robust.


### PR DESCRIPTION
Updates all references to MoneyGram's 'external' testing environment. The URLs have changed in addition to the Stellar public key used to verify signatures on authentication challenges.