### PR TITLE
[Fix] Remove deprecated amount_fee schema and examples

### DIFF
--- a/openrpc/src/anchor-platform/contentDescriptors/fee.json
+++ b/openrpc/src/anchor-platform/contentDescriptors/fee.json
@@ -1,19 +1,4 @@
 {
-    "amount_fee": {
-        "name": "amount_fee",
-        "description": "DEPRECATED in favor of fee_details. Amount of fee charged by anchor",
-        "required": false,
-        "deprecated": true,
-        "schema": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "$ref": "#/components/schemas/AmountNumber"
-                }
-            },
-            "required": ["amount"]
-        }
-    },
     "fee_details": {
         "name": "fee_details",
         "description": "Description of fees charged by the anchor",

--- a/openrpc/src/anchor-platform/examples/fee.json
+++ b/openrpc/src/anchor-platform/examples/fee.json
@@ -1,1 +1,16 @@
-{}
+{
+  "FeeDetailsIsoAsset": {
+    "name": "fee_details",
+    "value": {
+      "total": 0.1,
+      "asset": "iso4217:USD"
+    }
+  },
+  "FeeDetailsStellarAsset": {
+    "name": "fee_details",
+    "value": {
+      "total": 0.1,
+      "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+    }
+  }
+}

--- a/openrpc/src/anchor-platform/methods/notify_amounts_updated.json
+++ b/openrpc/src/anchor-platform/methods/notify_amounts_updated.json
@@ -1,7 +1,7 @@
 {
   "name": "notify_amounts_updated",
   "summary": "Update transaction amounts",
-  "description": "Update amount_out and amount_fee values",
+  "description": "Update amount_out and fee_details values",
   "paramStructure": "by-name",
   "tags": [
     { "name": "SEP-6" },
@@ -27,7 +27,7 @@
         { "$ref": "#/components/examples/transaction_id" },
         { "$ref": "#/components/examples/notify_amounts_updated_message" },
         { "$ref": "#/components/examples/AmountOutNumberOnly" },
-        { "$ref": "#/components/examples/AmountFeeNumberOnly" }
+        { "$ref": "#/components/examples/FeeDetailsStellarAsset" }
       ],
       "result": { "$ref": "#/components/examples/AnchorPlatformResponse" }
     }

--- a/openrpc/src/anchor-platform/methods/notify_interactive_flow_completed.json
+++ b/openrpc/src/anchor-platform/methods/notify_interactive_flow_completed.json
@@ -30,7 +30,7 @@
         { "$ref": "#/components/examples/notify_interactive_flow_completed_message" },
         { "$ref": "#/components/examples/AmountInNumberIsoAsset" },
         { "$ref": "#/components/examples/AmountOutNumberStellarAsset" },
-        { "$ref": "#/components/examples/AmountFeeNumberIsoAsset" },
+        { "$ref": "#/components/examples/FeeDetailsIsoAsset" },
         { "$ref": "#/components/examples/AmountExpectedNumberOnly" }
       ],
       "result": { "$ref": "#/components/examples/AnchorPlatformResponse" }

--- a/openrpc/src/anchor-platform/methods/notify_offchain_funds_received.json
+++ b/openrpc/src/anchor-platform/methods/notify_offchain_funds_received.json
@@ -33,7 +33,7 @@
         { "$ref": "#/components/examples/external_transaction_id" },
         { "$ref": "#/components/examples/AmountInNumberOnly" },
         { "$ref": "#/components/examples/AmountOutPoint9NumberOnly" },
-        { "$ref": "#/components/examples/AmountFeeNumberOnly" },
+        { "$ref": "#/components/examples/FeeDetailsStellarAsset" },
         { "$ref": "#/components/examples/AmountExpectedNumberOnly" }
       ],
       "result": { "$ref": "#/components/examples/AnchorPlatformResponse" }

--- a/openrpc/src/anchor-platform/methods/notify_onchain_funds_received.json
+++ b/openrpc/src/anchor-platform/methods/notify_onchain_funds_received.json
@@ -1,7 +1,7 @@
 {
   "name": "notify_onchain_funds_received",
   "summary": "Onchain funds received",
-  "description": "Notify that the payment is being processed internally by anchor for SEP-6 or SEP-24. For SEP-31, notify that the payment is being processed by the Receiving Anchor. In the request, amount parameters are optional, but have a strict rule of how to set them. Either none, only `amount_in`, or all of fields (`amount_in`, `amount_out`, `amount_fee`) must be specified. ",
+  "description": "Notify that the payment is being processed internally by anchor for SEP-6 or SEP-24. For SEP-31, notify that the payment is being processed by the Receiving Anchor. In the request, amount parameters are optional, but have a strict rule of how to set them. Either none, only `amount_in`, or all of fields (`amount_in`, `amount_out`, `fee_details`) must be specified. ",
   "paramStructure": "by-name",
   "tags": [
     { "name": "SEP-6" },

--- a/openrpc/src/anchor-platform/methods/request_offchain_funds.json
+++ b/openrpc/src/anchor-platform/methods/request_offchain_funds.json
@@ -45,7 +45,7 @@
         { "$ref": "#/components/examples/request_offchain_funds_message" },
         { "$ref": "#/components/examples/AmountInNumberIsoAsset" },
         { "$ref": "#/components/examples/AmountOutNumberStellarAsset" },
-        { "$ref": "#/components/examples/AmountFeeNumberIsoAsset" },
+        { "$ref": "#/components/examples/FeeDetailsIsoAsset" },
         { "$ref": "#/components/examples/AmountExpectedNumberOnly" }
       ],
       "result": { "$ref": "#/components/examples/AnchorPlatformResponse" }

--- a/openrpc/src/anchor-platform/methods/request_onchain_funds.json
+++ b/openrpc/src/anchor-platform/methods/request_onchain_funds.json
@@ -49,7 +49,7 @@
         { "$ref": "#/components/examples/request_onchain_funds_message" },
         { "$ref": "#/components/examples/AmountInNumberStellarAsset" },
         { "$ref": "#/components/examples/AmountOutNumberIsoAsset" },
-        { "$ref": "#/components/examples/AmountFeeNumberStellarAsset" },
+        { "$ref": "#/components/examples/FeeDetailsStellarAsset" },
         { "$ref": "#/components/examples/AmountExpectedNumberOnly" }
       ],
       "result": { "$ref": "#/components/examples/AnchorPlatformResponse" }

--- a/openrpc/src/anchor-platform/schemas/response.json
+++ b/openrpc/src/anchor-platform/schemas/response.json
@@ -24,9 +24,6 @@
             "amount_out": {
                 "$ref": "#/components/schemas/amount_out"
             },
-            "amount_fee": {
-                "$ref": "#/components/schemas/amount_fee"
-            },
             "fee_details": {
                 "$ref": "#/components/schemas/fee_details"
             },

--- a/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
+++ b/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
@@ -1211,7 +1211,8 @@
             {
               "name": "fee_details",
               "value": {
-                "total": 0.1
+                "total": 0.1,
+                "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               }
             }
           ],
@@ -1768,6 +1769,16 @@
               }
             }
           }
+        },
+        {
+          "name": "user_action_required_by",
+          "description": "Time and date by which user action is required",
+          "required": false,
+          "schema": {
+            "title": "datetime",
+            "description": "A date and time.",
+            "type": "string"
+          }
         }
       ],
       "result": {
@@ -2165,6 +2176,16 @@
             "description": "A unique transaction identifier.",
             "type": "string"
           }
+        },
+        {
+          "name": "user_action_required_by",
+          "description": "Time and date by which user action is required",
+          "required": false,
+          "schema": {
+            "title": "datetime",
+            "description": "A date and time.",
+            "type": "string"
+          }
         }
       ],
       "result": {
@@ -2540,6 +2561,16 @@
           "schema": {
             "title": "transaction_id",
             "description": "A unique transaction identifier.",
+            "type": "string"
+          }
+        },
+        {
+          "name": "user_action_required_by",
+          "description": "Time and date by which user action is required",
+          "required": false,
+          "schema": {
+            "title": "datetime",
+            "description": "A date and time.",
             "type": "string"
           }
         }
@@ -3326,7 +3357,8 @@
             {
               "name": "fee_details",
               "value": {
-                "total": 0.1
+                "total": 0.1,
+                "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               }
             },
             {
@@ -7435,6 +7467,16 @@
               }
             }
           }
+        },
+        {
+          "name": "user_action_required_by",
+          "description": "Time and date by which user action is required",
+          "required": false,
+          "schema": {
+            "title": "datetime",
+            "description": "A date and time.",
+            "type": "string"
+          }
         }
       ],
       "result": {
@@ -7848,6 +7890,30 @@
         },
         {
           "name": "amount_out",
+          "description": "Amount sent by anchor to user",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "required": [
+              "amount",
+              "asset"
+            ],
+            "properties": {
+              "amount": {
+                "title": "amount",
+                "description": "A numerical representation of an amount of some asset.",
+                "type": "string"
+              },
+              "asset": {
+                "title": "asset",
+                "description": "The asset to be sent by anchor to user at end of transaction",
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "name": "amount_out",
           "description": "This is required if the transaction is associated with a firm quote and for transactions where `amount_in.asset` and `amount_out.asset` are the same.",
           "required": false,
           "schema": {
@@ -7948,6 +8014,16 @@
           "description": "Type of memo that anchor should attach to the transaction",
           "required": false,
           "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "user_action_required_by",
+          "description": "Time and date by which user action is required",
+          "required": false,
+          "schema": {
+            "title": "datetime",
+            "description": "A date and time.",
             "type": "string"
           }
         }
@@ -8334,6 +8410,16 @@
           "schema": {
             "title": "message",
             "description": "A human readable message.",
+            "type": "string"
+          }
+        },
+        {
+          "name": "user_action_required_by",
+          "description": "Time and date by which user action is required",
+          "required": false,
+          "schema": {
+            "title": "datetime",
+            "description": "A date and time.",
             "type": "string"
           }
         }


### PR DESCRIPTION
Remove more `amount_fee` usage, including schemas, examples, references

Verified by `yarn rpcspec:build` and no more `amount_fee` will be generated