### PR TITLE
Restore Missed Changes from `ap-v3` branch

### DIFF
--- a/openapi/anchor-platform/main-callbacks.yaml
+++ b/openapi/anchor-platform/main-callbacks.yaml
@@ -25,7 +25,6 @@ x-tagGroups:
   - name: "Callbacks Server"
     tags:
       - Unique Address
-      - Fees
       - Rates
       - Customers
 paths:

--- a/platforms/anchor-platform/admin-guide/sep31/configuration.mdx
+++ b/platforms/anchor-platform/admin-guide/sep31/configuration.mdx
@@ -368,12 +368,6 @@ SECRET_CALLBACK_API_AUTH_SECRET=<your jwt encryption key>
 
 We'll define the server that implements the endpoints defined in the Callback API in the following section.
 
-:::caution
-
-Note that as of 2.x path segments are not supported in `CALLBACK_API_BASE_URL` (such as `http://server:8081/myPath`).
-
-:::
-
 [sep31-get-info]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md#get-info
 [sep1-ap]: ../sep1/README.mdx
 [get-rates-api]: ../../api-reference/callbacks/get-rates.api.mdx


### PR DESCRIPTION
We had this [ap-v3](https://github.com/stellar/stellar-docs/compare/main...ap-v3) branch prior to the version documentation, and some changes were missed during the refactor. This PR reintroduces those changes.