### PR TITLE
add SEP-7 support to Flutter Wallet SDK

### DIFF
--- a/docs/build/apps/wallet/component/dart/install.mdx
+++ b/docs/build/apps/wallet/component/dart/install.mdx
@@ -4,8 +4,8 @@ import { CodeExample } from "@site/src/components/CodeExample";
 
 ```dart
 // pubspec.yaml
-stellar_wallet_flutter_sdk: ^0.3.6
-stellar_flutter_sdk: ^1.8.6
+stellar_wallet_flutter_sdk: ^1.0.0
+stellar_flutter_sdk: ^1.8.8
 ```
 
 </CodeExample>

--- a/docs/build/apps/wallet/sep7.mdx
+++ b/docs/build/apps/wallet/sep7.mdx
@@ -30,6 +30,18 @@ const uri = wallet.parseSep7Uri(txUri);
 // uri can be parsed and transaction can be signed/submitted by an application that implements Sep-7
 ```
 
+```dart
+final sourceAccountKeyPair = PublicKeyPair.fromAccountId('G...');
+final destinationAccountKeyPair = PublicKeyPair.fromAccountId('G...');
+var txBuilder = await stellar.transaction(sourceAccountKeyPair);
+final tx = txBuilder.createAccount(destinationAccountKeyPair).build();
+final xdr = Uri.encodeComponent(tx.toEnvelopeXdrBase64());
+final callback = Uri.encodeComponent('https://example.com/callback');
+final txUri = 'web+stellar:tx?xdr=$xdr&callback=$callback';
+final uri = wallet.parseSep7Uri(txUri);
+// uri can be parsed and transaction can be signed/submitted by an application that implements Sep-7
+```
+
 </CodeExample>
 
 You can set replacements to be made in the xdr for specific fields by the application, these will be added in the [Sep-11 transaction representation format] to the URI.
@@ -43,6 +55,17 @@ uri.addReplacement({
   path: "sourceAccount",
   hint: "account from where you want to pay fees",
 });
+```
+
+```dart
+final uri = wallet.parseSep7Uri(txUri);
+
+if (uri is Sep7Tx) {
+    uri.addReplacement(Sep7Replacement(
+        id: 'X',
+        path: 'sourceAccount',
+        hint: 'account from where you want to pay fees'));
+}
 ```
 
 </CodeExample>
@@ -61,6 +84,18 @@ const tx = txBuilder.createAccount(destinationAccountKeyPair).build();
 const uri = wallet.Sep7Tx.forTransaction(tx);
 uri.callback = "https://example.com/callback";
 uri.msg = "here goes a message";
+uri.toString(); // encodes everything and converts to a uri string
+```
+
+```dart
+final sourceAccountKeyPair = PublicKeyPair.fromAccountId('G...');
+final destinationAccountKeyPair = PublicKeyPair.fromAccountId('G...');
+var txBuilder = await stellar.transaction(sourceAccountKeyPair);
+final tx = txBuilder.createAccount(destinationAccountKeyPair).build();
+
+final uri = Sep7Tx.forTransaction(tx);
+uri.setCallback('https://example.com/callback');
+uri.setMsg('here goes a message');
 uri.toString(); // encodes everything and converts to a uri string
 ```
 
@@ -85,6 +120,19 @@ const uri = parseSep7Uri(payUri);
 // uri can be parsed and transaction can be built/signed/submitted by an application that implements Sep-7
 ```
 
+```dart
+const destination = 'G...';
+const assetIssuer = 'G...';
+const assetCode = 'USDC';
+const amount = '120.1234567';
+const memo = 'memo';
+final message = Uri.encodeComponent('pay me with lumens');
+const originDomain = 'example.com';
+final payUri = 'web+stellar:pay?destination=$destination&amount=$amount&memo=$memo&msg=$message&origin_domain=$originDomain&asset_issuer=$assetIssuer&asset_code=$assetCode';
+final uri = Sep7.parseSep7Uri(payUri);
+// uri can be parsed and transaction can be built/signed/submitted by an application that implements Sep-7
+```
+
 </CodeExample>
 
 You can assign parameters after creating the initial instance using the appropriate setter for the parameter.
@@ -98,6 +146,16 @@ uri.msg = "here goes a message";
 uri.assetCode = "USDC";
 uri.assetIssuer = "G...";
 uri.amount = "10";
+uri.toString(); // encodes everything and converts to a uri string
+```
+
+```dart
+final uri = Sep7Pay.forDestination('G...');
+uri.setCallback('https://example.com/callback');
+uri.setMsg('here goes a message');
+uri.setAssetCode('USDC');
+uri.setAssetIssuer('G...');
+uri.setAmount('10');
 uri.toString(); // encodes everything and converts to a uri string
 ```
 
@@ -115,6 +173,14 @@ uri.addSignature(Keypair.fromSecret(keypair.secretKey));
 console.log(uri.signature); // signed uri payload
 ```
 
+```dart
+final uri = Sep7Pay.forDestination('G...');
+uri.setOriginDomain('example.com');
+final keypair = wallet.stellar().account().createKeyPair();
+uri.addSignature(keypair);
+print(uri.getSignature()); // signed uri payload
+```
+
 </CodeExample>
 
 The signature can then be verified by fetching the [Stellar toml file] from the origin domain in the uri, and using the included signing key to verify the uri signature. This is all done as part of the `verifySignature` method.
@@ -123,6 +189,10 @@ The signature can then be verified by fetching the [Stellar toml file] from the 
 
 ```typescript
 const passesVerification = await uri.verifySignature(); // true or false
+```
+
+```dart
+final passesVerification = await uri.verifySignature(); // true or false
 ```
 
 </CodeExample>


### PR DESCRIPTION
SEP-7 support has been added to the Flutter Wallet SDK. This PR adds the Flutter Wallet SDK SEP-7 code examples to the Wallet SDK's docs section. 