### PR TITLE
Update install instructions of the stellar-cli

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -85,23 +85,16 @@ The [Stellar CLI](https://github.com/stellar/stellar-cli) can execute smart cont
 
 There are a few ways to install the [latest released version](https://github.com/stellar/stellar-cli/releases) of Stellar CLI.
 
-Install with cargo from source:
-
-```sh
-cargo install --locked stellar-cli --features opt
-```
-
-Install with `cargo-binstall`:
-
-```sh
-cargo install --locked cargo-binstall
-cargo binstall -y stellar-cli
-```
-
 Install with Homebrew (macOS, Linux):
 
 ```sh
 brew install stellar-cli
+```
+
+Install with cargo from source:
+
+```sh
+cargo install --locked stellar-cli --features opt
 ```
 
 :::info

--- a/docs/tools/developer-tools/cli/install-cli.mdx
+++ b/docs/tools/developer-tools/cli/install-cli.mdx
@@ -10,38 +10,23 @@ sidebar_position: 50
 
 There are a few ways to install the latest released version of Stellar CLI.
 
-Install the latest version from source:
-
-```
-cargo install --locked stellar-cli --features opt
-```
-
-Install with `cargo-binstall`:
-
-```
-cargo install --locked cargo-binstall
-cargo binstall -y stellar-cli
-```
-
 Install with Homebrew (macOS, Linux):
 
-```
+```sh
 brew install stellar-cli
 ```
 
-## Installation with Experimental Features
+Install with cargo from source:
 
-To use the potentially unreleased bleeding edge CLI functionalities, install from git:
-
-```
-cargo install --locked stellar-cli --features opt --git https://github.com/stellar/stellar-cli.git
+```sh
+cargo install --locked stellar-cli --features opt
 ```
 
 ## Set up Autocomplete
 
 The Stellar CLI supports some autocompletion. To set up, run the following commands:
 
-```
+```sh
 stellar completion --shell <SHELL>
 ```
 
@@ -49,13 +34,13 @@ Possible SHELL values are `bash`, `elvish`, `fish`, `powershell`, `zsh`, etc.
 
 To enable autocomplete in the current bash shell, run:
 
-```
+```sh
 source <(stellar completion --shell bash)
 ```
 
 To enable autocomplete permanently, run:
 
-```
+```sh
 echo "source <(stellar completion --shell bash)" >> ~/.bashrc
 ```
 


### PR DESCRIPTION
### What

Update install instructions of the stellar-cli:

- Remove cargo-binstall instructions
- Elevate binary installs over source
- Remove instructions for installing from the repo

### Why

> - Remove cargo-binstall instructions

- It breaks from time to time.
- It's broken right now.
- It installs from source without `--locked` which is not secure.
- The tool doesn't verify github attestations, vs brew that does.
- Issues about improving supply chain vulnerability are getting little attention.

> - Elevate binary installs over source

- Building from source is time consuming and requires more than the rust compiler to be installed.
- Building from source requires a significant amount of system resources.
- Most folks will have a better experience installing a precompiled binary.

> - Remove instructions for installing from the repo

- 99% of devs should be installing the latest release.
- We're releasing more frequently lately and getting features out fast.

---

_We still have a gap installing binaries for Windows, but we're on it and that is being tracked in:_
- _https://github.com/stellar/stellar-cli/issues/1446_

---

_Note that related to this, I've opened an issue on the stellar-cli repo to fix the issues above that are within our control. The change to the docs is because I don't think we should be pushing it as a preferred way to install ahead of other things like homebrew which has more attention to supply chain security._
- _https://github.com/stellar/stellar-cli/issues/1678_
