### PR TITLE
Incorporate the new transaction polling utility into the tutorials

### DIFF
--- a/docs/build/guides/archival/restore-contract-js.mdx
+++ b/docs/build/guides/archival/restore-contract-js.mdx
@@ -19,7 +19,7 @@ Unfortunately, we still need simulation to figure out the _fees_ for our restora
 
 :::info
 
-This guide makes use of the (aptly named) `yeetTx` function we created in [another guide](../transactions/submit-transaction-wait-js.mdx).
+This guide makes use of the (aptly named) `submitTx` function we created in [another guide](../transactions/submit-transaction-wait-js.mdx).
 
 :::
 
@@ -63,7 +63,7 @@ async function restoreContract(
 
   const preppedTx = await server.prepareTransaction(restoreTx);
   preppedTx.sign(signer);
-  return yeetTx(preppedTx);
+  return submitTx(preppedTx);
 }
 
 function getWasmLedgerKey(entry: xdr.ContractDataEntry):  {

--- a/docs/build/guides/archival/restore-data-js.mdx
+++ b/docs/build/guides/archival/restore-data-js.mdx
@@ -21,7 +21,7 @@ Here's a function called `submitOrRestoreAndRetry()` that will take care of all 
 
 :::info
 
-This guide makes use of the (aptly named) `yeetTx` function we created in [another guide](../transactions/submit-transaction-wait-js.mdx).
+This guide makes use of the (aptly named) `submitTx` function we created in [another guide](../transactions/submit-transaction-wait-js.mdx).
 
 :::
 
@@ -34,10 +34,10 @@ import {
   SorobanDataBuilder,
   SorobanRpc,
   xdr,
-} from "@stellar/stellar-sdk"; // add'l imports to yeetTx
+} from "@stellar/stellar-sdk"; // add'l imports to submitTx
 const { Api, assembleTransaction } = SorobanRpc;
 
-// assume that `server` is the Server() instance from the yeetTx
+// assume that `server` is the Server() instance from the submitTx
 
 async function submitOrRestoreAndRetry(
   signer: Keypair,
@@ -56,7 +56,7 @@ async function submitOrRestoreAndRetry(
   if (!Api.isSimulationRestore(sim)) {
     const prepTx = assembleTransaction(tx, sim);
     prepTx.sign(signer);
-    return yeetTx(prepTx);
+    return submitTx(prepTx);
   }
 
   // Build the restoration operation using the RPC server's hints.
@@ -72,7 +72,7 @@ async function submitOrRestoreAndRetry(
 
   restoreTx.sign(signer);
 
-  const resp = await yeetTx(restoreTx);
+  const resp = await submitTx(restoreTx);
   if (resp.status !== Api.GetTransactionStatus.SUCCESS) {
     throw resp;
   }
@@ -91,6 +91,6 @@ async function submitOrRestoreAndRetry(
   const retryTx = retryTxBuilder.build();
   retryTx.sign(signer);
 
-  return yeetTx(retryTx);
+  return submitTx(retryTx);
 }
 ```

--- a/docs/build/guides/basics/automate-reset-data.mdx
+++ b/docs/build/guides/basics/automate-reset-data.mdx
@@ -60,7 +60,7 @@ import {
   LiquidityPoolFeeV18,
   BASE_FEE,
 } from "@stellar/stellar-sdk";
-import { Server } from "@stellar/stellar-sdk/rpc";
+import { Server, Api } from "@stellar/stellar-sdk/rpc";
 import fs from "fs";
 
 // const networkRPC = "USE EITHER FUTERNET OR TESTNET RPC"
@@ -125,8 +125,10 @@ async function issueAsset(issuerKeys, receivingKeys, customAsset) {
       .setTimeout(100)
       .build();
     transaction.sign(receivingKeys);
-    const result = await server.sendTransaction(transaction);
-    await submitTx(result);
+    const status = await submitTx(transaction);
+    if (status !== Api.GetTransactionStatus.SUCCESS) {
+      throw status;
+    }
     console.log(`Receiver Trusting ${customAsset.code} Asset......`);
 
     // Second, the issuing account actually sends a payment using the asset
@@ -146,8 +148,10 @@ async function issueAsset(issuerKeys, receivingKeys, customAsset) {
       .setTimeout(100)
       .build();
     transaction.sign(issuerKeys);
-    const resultFeeback = await server.sendTransaction(transaction);
-    await submitTx(resultFeeback);
+    const status = await submitTx(transaction);
+    if (status !== Api.GetTransactionStatus.SUCCESS) {
+      throw status;
+    }
     console.log(
       `Issuer Payment using ${
         customAsset.code
@@ -193,9 +197,10 @@ async function createLiquidityPool(accountKeypair, nativeAsset, customAsset) {
       .setTimeout(30)
       .build();
     transaction.sign(accountKeypair);
-    const resultFeeback = await server.sendTransaction(transaction);
-
-    await submitTx(resultFeeback);
+    const status = await submitTx(transaction);
+    if (status !== Api.GetTransactionStatus.SUCCESS) {
+      throw status;
+    }
     console.log(
       `Creating Liquidity Pool for ${nativeAsset.code} and ${customAsset.code}`,
     );
@@ -223,13 +228,15 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
     uploadTx.sign(deployer);
 
     console.log("Submitting WASM upload transaction...");
-    let uploadResponse = await server.sendTransaction(uploadTx);
-    const result = await submitTx(uploadResponse, `WASM upload transaction...`);
-    const wasmHash = result.returnValue._value;
+    let status = await submitTx(uploadTx);
+    if (status !== Api.GetTransactionStatus.SUCCESS) {
+      throw status;
+    }
+    const wasmHash = status.returnValue.bytes();
 
     const deployerAddress = new Address(deployer.publicKey());
 
-    //  Deploy the Contract
+    // Deploy the Contract
     const createContractTransaction = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase,
@@ -237,7 +244,7 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
       .addOperation(
         Operation.createCustomContract({
           address: deployerAddress,
-          wasmHash: wasmHash,
+          wasmHash,
         }),
       )
       .setTimeout(30)
@@ -247,11 +254,16 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
       createContractTransaction,
     );
     createContractTx.sign(deployer);
-    let createContractResponse = await server.sendTransaction(createContractTx);
-    const returnContractResponse = await submitTx(createContractResponse);
+    status = await submitTx(createContractTx);
+    if (status !== Api.GetTransactionStatus.SUCCESS) {
+      throw status;
+    }
     console.log(`Contract Deployed...`);
-    const contractBuffer = returnContractResponse.returnValue?._value?._value;
-    const contractId = StrKey.encodeContract(contractBuffer);
+
+    const contractAddr = Address.fromScAddress(
+      returnContractResponse.returnValue.address(),
+    );
+    const contractId = contractAddr.toString();
     const contract = new Contract(contractId);
 
     // Invoke Contract
@@ -269,13 +281,12 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
       invokeContractTransaction,
     );
     invokeContractTx.sign(deployer);
-    let invokeContractResponse = await server.sendTransaction(invokeContractTx);
-    const returnInvokeContractResponse = await submitTx(invokeContractResponse);
+    const returnInvokeContractResponse = await submitTx(invokeContractTx);
     console.log(`Invoke Contract.`);
 
-    const returnValues = scValToNative(returnInvokeContractResponse).filter(
-      Boolean,
-    );
+    const returnValues = scValToNative(
+      returnInvokeContractResponse.returnValue,
+    ).filter(Boolean);
 
     return { contractId, returnValues };
   } catch (error) {
@@ -313,7 +324,7 @@ async function automateSetup() {
     // Ensure you have the contract Wasm file compiled and saved in the specified path.
     // Adjust this path as necessary
     const contractWasmFilePath =
-      "./target/wasm32-unknown-unknown/release/hello_world.wasm"; // This is Wasmfile for an Hello World Contract.
+      "./target/wasm32-unknown-unknown/release/hello_world.wasm";
     const ContractData = await deployAndInvokeContract(
       accountOne,
       contractWasmFilePath,
@@ -355,7 +366,7 @@ Initializes the Stellar server connection, Creates two accounts, Issues a custom
 
 `sleep(ms)`: A utility function to introduce delays in asynchronous operations.
 
-`submitTx(feedback, message)`: provides more detailed logging of transaction results.
+`submitTx(tx)`: a retry-enabled transaction submission function `submitTx` outlined in [another guide](../transactions/submit-transaction-wait-js.mdx)
 
 ### Conclusion
 

--- a/docs/build/guides/basics/automate-reset-data.mdx
+++ b/docs/build/guides/basics/automate-reset-data.mdx
@@ -43,7 +43,7 @@ Automating blockchain state on Stellar's Testnet and Futurenet can streamline de
 
 - [Node.js](https://nodejs.org/en) and `npm` installed.
 - Stellar SDK for [JavaScript](https://www.npmjs.com/package/@stellar/stellar-sdk) and `fs` installed
-- An understanding of the rudimentary, retry-enabled transaction polling function `yeetTx` which we outlined in [another guide](../transactions/submit-transaction-wait-js.mdx)
+- An understanding of the rudimentary, retry-enabled transaction polling function `submitTx` which we outlined in [another guide](../transactions/submit-transaction-wait-js.mdx)
 
 ### Code
 
@@ -126,7 +126,7 @@ async function issueAsset(issuerKeys, receivingKeys, customAsset) {
       .build();
     transaction.sign(receivingKeys);
     const result = await server.sendTransaction(transaction);
-    await yeetTx(result);
+    await submitTx(result);
     console.log(`Receiver Trusting ${customAsset.code} Asset......`);
 
     // Second, the issuing account actually sends a payment using the asset
@@ -147,7 +147,7 @@ async function issueAsset(issuerKeys, receivingKeys, customAsset) {
       .build();
     transaction.sign(issuerKeys);
     const resultFeeback = await server.sendTransaction(transaction);
-    await yeetTx(resultFeeback);
+    await submitTx(resultFeeback);
     console.log(
       `Issuer Payment using ${
         customAsset.code
@@ -195,7 +195,7 @@ async function createLiquidityPool(accountKeypair, nativeAsset, customAsset) {
     transaction.sign(accountKeypair);
     const resultFeeback = await server.sendTransaction(transaction);
 
-    await yeetTx(resultFeeback);
+    await submitTx(resultFeeback);
     console.log(
       `Creating Liquidity Pool for ${nativeAsset.code} and ${customAsset.code}`,
     );
@@ -224,7 +224,7 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
 
     console.log("Submitting WASM upload transaction...");
     let uploadResponse = await server.sendTransaction(uploadTx);
-    const result = await yeetTx(uploadResponse, `WASM upload transaction...`);
+    const result = await submitTx(uploadResponse, `WASM upload transaction...`);
     const wasmHash = result.returnValue._value;
 
     const deployerAddress = new Address(deployer.publicKey());
@@ -248,7 +248,7 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
     );
     createContractTx.sign(deployer);
     let createContractResponse = await server.sendTransaction(createContractTx);
-    const returnContractResponse = await yeetTx(createContractResponse);
+    const returnContractResponse = await submitTx(createContractResponse);
     console.log(`Contract Deployed...`);
     const contractBuffer = returnContractResponse.returnValue?._value?._value;
     const contractId = StrKey.encodeContract(contractBuffer);
@@ -270,7 +270,7 @@ async function deployAndInvokeContract(deployer, contractWasmFilePath) {
     );
     invokeContractTx.sign(deployer);
     let invokeContractResponse = await server.sendTransaction(invokeContractTx);
-    const returnInvokeContractResponse = await yeetTx(invokeContractResponse);
+    const returnInvokeContractResponse = await submitTx(invokeContractResponse);
     console.log(`Invoke Contract.`);
 
     const returnValues = scValToNative(returnInvokeContractResponse).filter(
@@ -355,7 +355,7 @@ Initializes the Stellar server connection, Creates two accounts, Issues a custom
 
 `sleep(ms)`: A utility function to introduce delays in asynchronous operations.
 
-`yeetTx(feedback, message)`: provides more detailed logging of transaction results.
+`submitTx(feedback, message)`: provides more detailed logging of transaction results.
 
 ### Conclusion
 

--- a/docs/build/guides/conventions/deploy-sac-with-code.mdx
+++ b/docs/build/guides/conventions/deploy-sac-with-code.mdx
@@ -37,7 +37,7 @@ import { Server } from "@stellar/stellar-sdk/rpc";
 
 const networkRPC = "https://soroban-testnet.stellar.org";
 const server = new Server(networkRPC);
-const network_passphrase = StellarSdk.Networks.TESTNET;
+const networkPassphrase = StellarSdk.Networks.TESTNET;
 
 const deployStellarAssetContract = async () => {
   const sourceSecrets =
@@ -52,7 +52,7 @@ const deployStellarAssetContract = async () => {
 
     const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
       fee: StellarSdk.BASE_FEE,
-      networkPassphrase: network_passphrase,
+      networkPassphrase,
     })
       .addOperation(
         StellarSdk.Operation.createStellarAssetContract({
@@ -65,11 +65,14 @@ const deployStellarAssetContract = async () => {
     const uploadTx = await server.prepareTransaction(transaction);
     uploadTx.sign(sourceKeypair);
 
-    const result = await server.sendTransaction(uploadTx);
-    const feedback = await submitTx(result);
-    const contractBuffer = feedback.returnValue._value._value;
-    const contractID = StellarSdk.StrKey.encodeContract(contractBuffer);
-    console.log(`ContractID of Our ${customAsset.code} Asset`, contractID);
+    const feedback = await submitTx(uploadTx);
+    const contract = StellarSdk.Address.fromScAddress(
+      feedback.returnValue.address(),
+    );
+    console.log(
+      `ContractID of Our ${customAsset.code} Asset`,
+      contract.toString(),
+    );
   } catch (e) {
     console.error("An error occurred while Deploying assets:", e);
   }
@@ -100,7 +103,7 @@ const network_passphrase = StellarSdk.Networks.TESTNET;
 const deployStellarAssetContract = async () => {
   const sourceSecrets =
     "SASI6PA4K52GQJF6BC263GLYOADVKFJ4SZ7TFX4QQF2U76T3EJ54DT7Y"; // Replace with your Secret Key
-  const network_passphrase = StellarSdk.Networks.TESTNET;
+  const networkPassphrase = StellarSdk.Networks.TESTNET;
   const sourceKeypair = StellarSdk.Keypair.fromSecret(sourceSecrets);
   const sourceAccount = await server.getAccount(sourceKeypair.publicKey());
 
@@ -111,7 +114,7 @@ const deployStellarAssetContract = async () => {
 
     const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
       fee: StellarSdk.BASE_FEE,
-      networkPassphrase: network_passphrase,
+      networkPassphrase,
     })
       .addOperation(
         StellarSdk.Operation.createStellarAssetContract({
@@ -124,11 +127,14 @@ const deployStellarAssetContract = async () => {
     const uploadTx = await server.prepareTransaction(transaction);
     uploadTx.sign(sourceKeypair);
 
-    const result = await server.sendTransaction(uploadTx);
-    const feedback = await submitTx(result);
-    const contractBuffer = feedback.returnValue._value._value;
-    const contractID = StellarSdk.StrKey.encodeContract(contractBuffer);
-    console.log(`ContractID of Our ${customAsset.code} Asset`, contractID);
+    const feedback = await submitTx(uploadTx);
+    const contract = StellarSdk.Address.fromScAddress(
+      feedback.returnValue.address(),
+    );
+    console.log(
+      `ContractID of Our ${customAsset.code} Asset`,
+      contract.toString(),
+    );
   } catch (e) {
     console.error("An error occurred while Deploying assets:", e);
   }
@@ -144,4 +150,4 @@ This function is designed to deploy a Stellar Asset Contract (SAC) on the Soroba
 - **Custom Asset**: Defines a custom asset with the code `JOEBOY` and the issuer's public key.
 - **Transaction Building**: A transaction is built using the `TransactionBuilder`, which includes the `createStellarAssetContract` operation for the custom asset. The transaction is then prepared and signed.
 - **Send Transaction**: The signed transaction is sent to the network using `server.sendTransaction`.
-- **Feedback Handling**: It waits for the transaction feedback using the `submitTx` function to ensure it has succeeded. extracts the contract buffer from the feedback and converts it to a contract ID using `StellarSdk.StrKey.encodeContract`. finally, it logs the contract ID for the deployed asset.
+- **Feedback Handling**: It waits for the transaction feedback using the `submitTx` function to ensure it has succeeded. extracts the contract buffer from the feedback and converts it to a contract ID using `StellarSdk.Address`. finally, it logs the contract ID for the deployed asset.

--- a/docs/build/guides/conventions/deploy-sac-with-code.mdx
+++ b/docs/build/guides/conventions/deploy-sac-with-code.mdx
@@ -27,7 +27,7 @@ In this guide, you'll learn how to deploy a [Stellar Asset Contract (SAC)](../..
 - [Node.js ](https://nodejs.org/en) and npm installed.
 - Stellar SDK for [JavaScript](https://www.npmjs.com/package/@stellar/stellar-sdk) installed
 - [Knowledge about Issuing an Asset on Stellar](https://developers.stellar.org/docs/tokens/how-to-issue-an-asset)
-- An understanding of the rudimentary, retry-enabled transaction polling function `yeetTx` which we outlined in [another guide](../transactions/submit-transaction-wait-js.mdx)
+- An understanding of the rudimentary, retry-enabled transaction polling function `submitTx` which we outlined in [another guide](../transactions/submit-transaction-wait-js.mdx)
 
 ## Code overview
 
@@ -66,7 +66,7 @@ const deployStellarAssetContract = async () => {
     uploadTx.sign(sourceKeypair);
 
     const result = await server.sendTransaction(uploadTx);
-    const feedback = await yeetTx(result);
+    const feedback = await submitTx(result);
     const contractBuffer = feedback.returnValue._value._value;
     const contractID = StellarSdk.StrKey.encodeContract(contractBuffer);
     console.log(`ContractID of Our ${customAsset.code} Asset`, contractID);
@@ -125,7 +125,7 @@ const deployStellarAssetContract = async () => {
     uploadTx.sign(sourceKeypair);
 
     const result = await server.sendTransaction(uploadTx);
-    const feedback = await yeetTx(result);
+    const feedback = await submitTx(result);
     const contractBuffer = feedback.returnValue._value._value;
     const contractID = StellarSdk.StrKey.encodeContract(contractBuffer);
     console.log(`ContractID of Our ${customAsset.code} Asset`, contractID);
@@ -144,4 +144,4 @@ This function is designed to deploy a Stellar Asset Contract (SAC) on the Soroba
 - **Custom Asset**: Defines a custom asset with the code `JOEBOY` and the issuer's public key.
 - **Transaction Building**: A transaction is built using the `TransactionBuilder`, which includes the `createStellarAssetContract` operation for the custom asset. The transaction is then prepared and signed.
 - **Send Transaction**: The signed transaction is sent to the network using `server.sendTransaction`.
-- **Feedback Handling**: It waits for the transaction feedback using the `yeetTx` function to ensure it has succeeded. extracts the contract buffer from the feedback and converts it to a contract ID using `StellarSdk.StrKey.encodeContract`. finally, it logs the contract ID for the deployed asset.
+- **Feedback Handling**: It waits for the transaction feedback using the `submitTx` function to ensure it has succeeded. extracts the contract buffer from the feedback and converts it to a contract ID using `StellarSdk.StrKey.encodeContract`. finally, it logs the contract ID for the deployed asset.

--- a/docs/build/guides/transactions/submit-transaction-wait-js.mdx
+++ b/docs/build/guides/transactions/submit-transaction-wait-js.mdx
@@ -7,51 +7,37 @@ description: Use a looping mechanism to submit a transaction to the RPC
 Here is a simple, rudimentary looping mechanism to submit a transaction to Soroban RPC and wait for a result.
 
 ```typescript
-import {
-  Transaction,
-  FeeBumpTransaction,
-  SorobanRpc,
-} from "@stellar/stellar-sdk";
+import { Transaction, FeeBumpTransaction } from "@stellar/stellar-sdk";
 import { Server, Api } from "@stellar/stellar-sdk/rpc";
 
 const RPC_SERVER = "https://soroban-testnet.stellar.org/";
 const server = new Server(RPC_SERVER);
 
 // Submits a tx and then polls for its status until a timeout is reached.
-async function yeetTx(
+async function submitTx(
   tx: Transaction | FeeBumpTransaction,
 ): Promise<Api.GetTransactionResponse> {
-  return server.sendTransaction(tx).then(async (reply) => {
-    if (reply.status !== "PENDING") {
-      throw reply;
-    }
-
-    let status;
-    let attempts = 0;
-    while (attempts++ < 5) {
-      const tmpStatus = await server.getTransaction(reply.hash);
-      switch (tmpStatus.status) {
-        case Api.GetTransactionStatus.FAILED:
-          throw tmpStatus;
-        case Api.GetTransactionStatus.NOT_FOUND:
-          await sleep(500);
-          continue;
-        case Api.GetTransactionStatus.SUCCESS:
-          status = tmpStatus;
-          break;
+  return server
+    .sendTransaction(tx)
+    .then(async (reply) => {
+      if (reply.status !== "PENDING") {
+        throw reply;
       }
-    }
 
-    if (attempts >= 5 || !status) {
-      throw new Error(`Failed to find transaction ${reply.hash} in time.`);
-    }
-
-    return status;
-  });
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+      return server.pollTransaction(reply.hash, {
+        sleepStrategy: (_iter: number) => 500,
+        attempts: 5,
+      });
+    })
+    .then((finalStatus) => {
+      switch (finalStatus.status) {
+        case Api.GetTransactionStatus.FAILED:
+        case Api.GetTransactionStatus.NOT_FOUND:
+          throw tmpStatus;
+        case Api.GetTransactionStatus.SUCCESS:
+          return status;
+      }
+    });
 }
 ```
 

--- a/docs/learn/encyclopedia/storage/state-archival.mdx
+++ b/docs/learn/encyclopedia/storage/state-archival.mdx
@@ -197,7 +197,7 @@ Remember, though, that any combination of these scenarios can occur in reality.
 
 ### Preparation
 
-In order to help the scaffolding of the code, we'll reuse the rudimentary, retry-enabled transaction polling function `yeetTx` which we outlined in [another guide](/build/guides/transactions/submit-transaction-wait-js.mdx).
+In order to help the scaffolding of the code, we'll reuse the rudimentary, retry-enabled transaction polling function `submitTx` which we outlined in [another guide](/build/guides/transactions/submit-transaction-wait-js.mdx).
 
 In the following code, we will also leverage [`Server.prepareTransaction`](https://stellar.github.io/js-soroban-client/Server.html#prepareTransaction). This is a helpful method that, given a transaction, will simulate it, then amend the transaction with the simulation results (fees, etc.) and return that. Then, it can just be signed and submitted. We will also use [`SorobanDataBuilder`](https://stellar.github.io/js-stellar-sdk/SorobanDataBuilder.html), a convenient abstraction that lets us use a [builder pattern](https://en.wikipedia.org/wiki/Builder_pattern) to set the appropriate storage footprints for a transaction.
 
@@ -244,7 +244,7 @@ async function submitOrRestoreAndRetry(
   if (!Api.isSimulationRestore(sim)) {
     const prepTx = assembleTransaction(tx, sim);
     prepTx.sign(signer);
-    return yeetTx(prepTx);
+    return submitTx(prepTx);
   }
 
   //
@@ -262,7 +262,7 @@ async function submitOrRestoreAndRetry(
 
   restoreTx.sign(signer);
 
-  const resp = await yeetTx(restoreTx);
+  const resp = await submitTx(restoreTx);
   if (resp.status !== Api.GetTransactionStatus.SUCCESS) {
     throw resp;
   }
@@ -283,7 +283,7 @@ async function submitOrRestoreAndRetry(
   const retryTx = retryTxBuilder.build();
   retryTx.sign(signer);
 
-  return yeetTx(retryTx);
+  return submitTx(retryTx);
 }
 ```
 
@@ -344,7 +344,7 @@ async function restoreContract(
 
   const preppedTx = await server.prepareTransaction(restoreTx);
   preppedTx.sign(signer);
-  return yeetTx(preppedTx);
+  return submitTx(preppedTx);
 }
 
 function getWasmLedgerKey(entry: xdr.ContractDataEntry):  {


### PR DESCRIPTION
With the addition of https://github.com/stellar/js-stellar-sdk/pull/1092, people don't need to write their own polling code. We should incorporate that into the tutorials and also probably rename the gen-z asf `yeetTx` to something more readable :crying_cat_face: 