### PR TITLE
use 'stellar network container start'

### DIFF
--- a/docs/tools/developer-tools/lab/quickstart-with-lab.mdx
+++ b/docs/tools/developer-tools/lab/quickstart-with-lab.mdx
@@ -14,7 +14,7 @@
 Quickstart can be started for different networks. In this example, we will start Quickstart for `testnet`. Start Quickstart with the Stellar CLI using the following command:
 
 ```sh
-stellar network start testnet
+stellar network container start testnet
 ```
 
 Quickstart will usually start on `http://localhost:8000`. With this information, we can now configure Stellar Lab to use the local network.


### PR DESCRIPTION
use `stellar network container start` instead of `stellar network start`

https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli#stellar-network-container