### PR TITLE
Mention that Soroban Strings are not encoded or validated

### DIFF
--- a/docs/learn/encyclopedia/contract-development/types/built-in-types.mdx
+++ b/docs/learn/encyclopedia/contract-development/types/built-in-types.mdx
@@ -52,11 +52,13 @@ Symbols are small efficient strings up to 32 characters in length and limited to
 
 Symbols are primarily used for function names and other identifiers that are exported in the public API of a contract. They can also be used wherever short strings are needed to keep resource costs down.
 
-## Bytes, Strings (`Bytes`, `BytesN`)
+## Bytes, Strings (`Bytes`, `BytesN`, `String`)
 
 Byte arrays and strings can be passed to contracts and stores using the `Bytes` type.
 
 For byte arrays of fixed length, `BytesN` can be used. For example, contract IDs are fixed 32-byte byte arrays, and are represented as `BytesN<32>`.
+
+Note that the bytes contained in `String`s are not encoded or validated.
 
 ## Vec (`Vec`)
 

--- a/docs/learn/encyclopedia/contract-development/types/built-in-types.mdx
+++ b/docs/learn/encyclopedia/contract-development/types/built-in-types.mdx
@@ -58,7 +58,7 @@ Byte arrays and strings can be passed to contracts and stores using the `Bytes` 
 
 For byte arrays of fixed length, `BytesN` can be used. For example, contract IDs are fixed 32-byte byte arrays, and are represented as `BytesN<32>`.
 
-Note that the bytes contained in `String`s are not encoded or validated.
+Note that the bytes contained in `String`s do not necessarily conform to any standard text encoding such as ASCII or Unicode UTF-8. They are plain uninterpreted byes, and users expecting a particular encoding need to enforce that encoding manually.
 
 ## Vec (`Vec`)
 

--- a/docs/learn/encyclopedia/contract-development/types/built-in-types.mdx
+++ b/docs/learn/encyclopedia/contract-development/types/built-in-types.mdx
@@ -58,7 +58,7 @@ Byte arrays and strings can be passed to contracts and stores using the `Bytes` 
 
 For byte arrays of fixed length, `BytesN` can be used. For example, contract IDs are fixed 32-byte byte arrays, and are represented as `BytesN<32>`.
 
-Note that the bytes contained in `String`s do not necessarily conform to any standard text encoding such as ASCII or Unicode UTF-8. They are plain uninterpreted byes, and users expecting a particular encoding need to enforce that encoding manually.
+Note that the bytes contained in `String`s do not necessarily conform to any standard text encoding such as ASCII or Unicode UTF-8. They are plain uninterpreted bytes, and users expecting a particular encoding need to enforce that encoding manually.
 
 ## Vec (`Vec`)
 


### PR DESCRIPTION
Someone from the ecosystem asked us this question recently. 