### PR TITLE
Remove event topic limit docs

### DIFF
--- a/docs/build/guides/events/publish.mdx
+++ b/docs/build/guides/events/publish.mdx
@@ -4,12 +4,7 @@ hide_table_of_contents: true
 description: Publish events from a Rust contract
 ---
 
-An event can contain up to 4 topics, alongside the data it is publishing. The `data` can be any value or type you want. However, the topics must not contain:
-
-- `Vec`
-- `Map`
-- `Bytes` or `BytesN` longer than 32 bytes
-- `contracttype`
+An event can contain topics, alongside the data it is publishing. The topics data can be any value or type you want.
 
 ```rust
 // This function does nothing beside publishing events. Topics we are using are

--- a/docs/build/smart-contracts/example-contracts/events.mdx
+++ b/docs/build/smart-contracts/example-contracts/events.mdx
@@ -103,8 +103,6 @@ env.events().publish(topics, data);
 
 ### Event Topics
 
-An event may contain up to four topics.
-
 Topics are conveniently defined using a tuple. In the sample code two topics of `Symbol` type are used.
 
 ```rust
@@ -113,7 +111,7 @@ env.events().publish((COUNTER, symbol_short!("increment")), ...);
 
 :::tip
 
-The topics don't have to be made of the same type. You can mix different types as long as the total topic count stays below the limit.
+The topics don't have to be made of the same type.
 
 :::
 

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -33,7 +33,7 @@ Events are ephemeral, the data retention window is a maximum of 7 days. See the 
 
 ### ContractEvent
 
-An event may contain up to four topics. The topics don't have to be made of the same type. You can mix different types as long as the total topic count stays below the limit.
+An events topics don't have to be made of the same type. You can mix different types.
 
 An event also contains a data object of any value or type including types defined by contracts using `#[contracttype]`
 


### PR DESCRIPTION
We originally had a limit on the number of event topics, but this was removed during soroban development.