### PR TITLE
Remove incorrect stellar-cli instructions

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -134,12 +134,6 @@ Install with cargo from source:
 
 <StellarCliVersion />
 
-Install with cargo to get the unreleased features from the `main` branch:
-
-```sh
-cargo install --locked stellar-cli --features opt
-```
-
 </TabItem>
 
 </Tabs>

--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -116,12 +116,6 @@ Install with cargo from source:
 
 <StellarCliVersion />
 
-Install with cargo to get the unreleased features from the `main` branch:
-
-```sh
-cargo install --locked stellar-cli --features opt
-```
-
 </TabItem>
 
 <TabItem value="windows" label="Windows">


### PR DESCRIPTION
### What
Remove incorrect stellar-cli instructions.

### Why
The instructions say to use the cargo install command to install from the main branch, but the command won't do that, it'll install the latest released version. We already show a similar command above that for how to install the latest version (with the version specified), so we don't need to show it a second time without the version specified.

I also don't think we should promote how folks can install from the main branch. The main branch is unreleased and unstable. If folks really want to they can go and install from the main branch, but we don't need to place it front and centre as a recommended way to go.

The idea of building the main branch came about when the cli was releasing too infrequently. We're trying to, and are, releasing more frequently now.