### PR TITLE
Add Nodies as part of RPC Providers

### DIFF
--- a/docs/data/rpc/rpc-providers.mdx
+++ b/docs/data/rpc/rpc-providers.mdx
@@ -12,6 +12,7 @@ These providers allow access to the Testnet network and Mainnet network.
 | Provider | Access | Futurenet | Testnet | Mainnet |
 | --- | --- | --- | --- | --- |
 | [Blockdaemon\*](https://docs.blockdaemon.com/reference/how-to-access-soroban-api) | [Access](https://www.blockdaemon.com/apply/soroban) | Not available | Available | Available |
+| [Nodies](https://nodies.org) | [Access](https://nodies.org/) | Not available | Available | Available |
 | [Validation Cloud\*](https://validationcloud.io/) | [Access](https://app.validationcloud.io/) | Not available | Available | Available |
 | [QuickNode\*](https://www.quicknode.com/docs/stellar) | [Access](https://www.quicknode.com/chains/stellar) | Not available | Available | Available |
 | [NowNodes](https://nownodes.io/nodes/stellar-xlm) | [Access](https://nownodes.io/nodes/stellar-xlm) | Available | Available | Available |
@@ -27,6 +28,7 @@ These providers allow access to the Testnet network and Mainnet network.
 
 | Provider | Mainnet RPC Endpoint | Testnet RPC Endpoint | Futurenet RPC Endpoint |
 | --- | --- | --- | --- |
+| [Nodies](https://nodies.org) | `https://stellar-soroban.nodies.app` | `https://stellar-soroban-testnet.nodies.app` | N/A |
 | [Liquify](https://www.liquify.io/) | `https://stellar-mainnet.liquify.com/api=41EEWAH79Y5OCGI7/mainnet` | `https://stellar.liquify.com/api=41EEWAH79Y5OCGI7/testnet` | `https://stellar.liquify.com/api=41EEWAH79Y5OCGI7/futurenet` |
 | [Gateway](https://gateway.fm/) | `https://soroban-rpc.mainnet.stellar.gateway.fm` | `https://soroban-rpc.testnet.stellar.gateway.fm` | N/A |
 | [sorobanrpc.com](https://sorobanrpc.com/) | `https://mainnet.sorobanrpc.com` | N/A | N/A |


### PR DESCRIPTION
Nodies now supports both soroban and horizon endpoints. This PR aims to add us as a RPC provider for Stellar.