### PR TITLE
updates software versions table for protocol 22

### DIFF
--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -20,15 +20,15 @@ Release candidates are software releases that are also released to the [Testnet]
 | --- | --- |
 | XDR | `v22.0` |
 | Rust XDR | `v22.0.0` |
-| Soroban Environment | `v22.0.0` |
+| Soroban Environment | `v22.1.0` |
 | Stellar Core | `v22.0.0` |
-| Soroban Rust SDK | `v22.0.0-rc.2.1` |
-| Stellar CLI | `TBD` |
-| Soroban RPC | `TBD` |
-| Stellar Horizon | `TBD` |
-| Stellar Quickstart | `TBD` |
-| Stellar JS Stellar Base | `TBD` |
-| Stellar JS Stellar SDK | `TBD` |
+| Soroban Rust SDK | `v22.0.0-rc.3.2` |
+| Stellar CLI | `v22.0.1` |
+| Stellar RPC | `v22.1.0` |
+| Stellar Horizon | `v22.0.1` |
+| Stellar Quickstart | `docker.io/stellar/quickstart:latest@sha256:e85ab6ebaea56af7437a48d923128228d9dcdfd4b63902a462aa3676b5a75453` |
+| Stellar JS Stellar Base | `v13.0.1` |
+| Stellar JS Stellar SDK | `v13.0.0` |
 | Freighter |  |
 | Laboratory |  |
 | Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -22,7 +22,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | Rust XDR | `v22.0.0` |
 | Soroban Environment | `v22.1.0` |
 | Stellar Core | `v22.0.0` |
-| Soroban Rust SDK | `v22.0.0` |
+| Soroban Rust SDK | `v22.0.1` |
 | Stellar CLI | `v22.0.1` |
 | Stellar RPC | `v22.1.0` |
 | Stellar Horizon | `v22.0.1` |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -22,11 +22,11 @@ Release candidates are software releases that are also released to the [Testnet]
 | Rust XDR | `v22.0.0` |
 | Soroban Environment | `v22.1.0` |
 | Stellar Core | `v22.0.0` |
-| Soroban Rust SDK | `v22.0.0-rc.3.2` |
+| Soroban Rust SDK | `v22.0.0` |
 | Stellar CLI | `v22.0.1` |
 | Stellar RPC | `v22.1.0` |
 | Stellar Horizon | `v22.0.1` |
-| Stellar Quickstart | `docker.io/stellar/quickstart:latest@sha256:e85ab6ebaea56af7437a48d923128228d9dcdfd4b63902a462aa3676b5a75453` |
+| Stellar Quickstart | `stellar/quickstart:v455-latest@sha256:bbd4cea64c5428381ac5ace7c380ed7c3b72f12488aeb1f1bf19c48e74244af8` |
 | Stellar JS Stellar Base | `v13.0.1` |
 | Stellar JS Stellar SDK | `v13.0.0` |
 | Freighter |  |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -26,7 +26,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | Stellar CLI | `v22.0.1` |
 | Stellar RPC | `v22.1.0` |
 | Stellar Horizon | `v22.0.1` |
-| Stellar Quickstart | `stellar/quickstart:v455-latest@sha256:bbd4cea64c5428381ac5ace7c380ed7c3b72f12488aeb1f1bf19c48e74244af8` |
+| Stellar Quickstart | `docker.io/stellar/quickstart:v455-latest@sha256:bbd4cea64c5428381ac5ace7c380ed7c3b72f12488aeb1f1bf19c48e74244af8` |
 | Stellar JS Stellar Base | `v13.0.1` |
 | Stellar JS Stellar SDK | `v13.0.0` |
 | Freighter |  |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -22,7 +22,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | Rust XDR | `v22.0.0` |
 | Soroban Environment | `v22.1.2` |
 | Stellar Core | `v22.0.0` |
-| Soroban Rust SDK | `v22.0.1` |
+| Soroban Rust SDK | `v22.0.3` |
 | Stellar CLI | `v22.0.1` |
 | Stellar RPC | `v22.1.0` |
 | Stellar Horizon | `v22.0.1` |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -20,7 +20,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | --- | --- |
 | XDR | `v22.0` |
 | Rust XDR | `v22.0.0` |
-| Soroban Environment | `v22.1.0` |
+| Soroban Environment | `v22.1.2` |
 | Stellar Core | `v22.0.0` |
 | Soroban Rust SDK | `v22.0.1` |
 | Stellar CLI | `v22.0.1` |


### PR DESCRIPTION
I'm pretty sure I got the most current versions of everything.

Could use some help confirming the correct SHA hash for the `stellar/quickstart:latest` container. @sisuresh or @leighmcculloch maybe?