### PR TITLE
Fix stellar-cli version

### DIFF
--- a/src/components/StellarCliVersion.tsx
+++ b/src/components/StellarCliVersion.tsx
@@ -3,7 +3,7 @@ import CodeBlock from "@theme/CodeBlock";
 import { latestVersion } from "@site/src/helpers/stellarCli";
 
 export function StellarCliVersion() {
-  const command = `cargo install --locked stellar-cli --version v${latestVersion} --features opt`;
+  const command = `cargo install --locked stellar-cli@${latestVersion} --features opt`;
 
   return <CodeBlock language="sh">{command}</CodeBlock>;
 }


### PR DESCRIPTION
### What
Remove the `v` from the beginning of the version number when using cargo to install the stellar-cli from source.

### Why
Cargo accepts versions without a v prefix, and errors if you provide the v.

The change also uses the abbreviated version selection by specifying the version with the `@` instead of with `--version`. This isn't required, but it's a bit shorter.

Close https://github.com/stellar/stellar-cli/issues/1782