### PR TITLE
Fix documentation signAndSend with kit.signTransaction

### DIFF
--- a/docs/build/apps/dapp-frontend.mdx
+++ b/docs/build/apps/dapp-frontend.mdx
@@ -392,8 +392,7 @@ Current value: <strong id="current-value" aria-live="polite">???</strong><br />
     try {
       const { result } = await tx.signAndSend({
         signTransaction: async (xdr) => {
-          const { signedTxXdr } = await kit.signTransaction(xdr);
-          return signedTxXdr;
+          return await kit.signTransaction(xdr);
         },
       });
 


### PR DESCRIPTION
See the following discussion https://discord.com/channels/897514728459468821/1315433251044724766

And I think linked to https://github.com/stellar/js-stellar-sdk/issues/1113

With new versions of the JS SDK, the parameter `signTransaction` of `signAndSend` does not accept a string anymore but an object with 2 properties `{ signedTxXdr, signerAddress }`.

This PR simplifies the example.