### PR TITLE
add an oracles page to dev tools

### DIFF
--- a/docs/tools/developer-tools/block-explorers.mdx
+++ b/docs/tools/developer-tools/block-explorers.mdx
@@ -7,7 +7,7 @@ sidebar_position: 40
 
 # Block Explorers
 
-Block explorers exist to publicly display blockchain data in an easily digestbible way. They can be browsed with an ordinary web browser, and do not require any special developer skills to use. The block explorers available for Soroban index data related to payments, accounts, deployed contracts, transaction history, and more.
+Block explorers exist to publicly display blockchain data in an easily digestible way. They can be browsed with an ordinary web browser, and do not require any special developer skills to use. The block explorers available for Soroban index data related to payments, accounts, deployed contracts, transaction history, and more.
 
 ### [StellarExpert](https://stellar.expert/explorer/public)
 

--- a/docs/tools/developer-tools/oracles.mdx
+++ b/docs/tools/developer-tools/oracles.mdx
@@ -11,6 +11,8 @@ Oracles exist on the Stellar network to bring off-chain data onto the blockchain
 
 The Reflector oracle protocol is a combination of specialized smart contracts and peer-to-peer consensus of data provider nodes maintained by trusted Stellar ecosystem organizations. Feeds include on-chain and off-chain asset prices, CEX & DEX exchange rates, stock indices, financial market APIs, etc. Reflector nodes process, normalize, aggregate, and store trades information from Stellar Classic DEX, Soroban DEX protocols, as well as external sources.
 
+Also available are Reflector Subscriptions: a service for user-defined customized triggers invoked automatically once the price change for the specified asset reaches a certain threshold. Users or Developers interested in creating subscriptions can [learn more here](https://reflector.network/subscription).
+
 Learn how to integrate Reflector feeds [in their documentation](https://reflector.network/docs).
 
 ### Deployed Reflector contracts
@@ -26,10 +28,12 @@ Learn how to integrate Reflector feeds [in their documentation](https://reflecto
 
 DIA is a cross-chain oracle provider that sources granular market data from diverse exchanges, including CEXs and DEXs. Its data sourcing is thorough, enabling unparalleled transparency and customizability for resilient price feeds for 20,000+ assets. Its versatile data processing and delivery ensures adaptability and reliability for any decentralized application.
 
-Learn more about DIA's [data sourcing](https://docs.diadata.org/use-nexus-product/nexus/data-sourcing) and [data computation](https://docs.diadata.org/use-nexus-product/nexus/data-computation) architecture.
+Dapps building on Soroban can utilize DIA oracles to obtain up-to-date asset price information. These deployed oracles are suitable for use in production environments. They come with a list of supported assets and settings. However, custom oracles with a different set of assets and configurations are available. If you need something that more closely fits your needs, you can [reach out to DIA](https://docs.diadata.org/introduction/request-an-oracle) to make a request.
 
 ### Deployed DIA contracts
 
 | Address | Data Source | Network |
 | --- | --- | --- |
 | [`CAEDPEZDRCEJCF73ASC5JGNKCIJDV2QJQSW6DJ6B74MYALBNKCJ5IFP4`](https://stellar.expert/explorer/testnet/contract/CAEDPEZDRCEJCF73ASC5JGNKCIJDV2QJQSW6DJ6B74MYALBNKCJ5IFP4) | External CEXs & DEXs | Testnet |
+
+Learn more about DIA's [data sourcing](https://docs.diadata.org/use-nexus-product/nexus/data-sourcing) and [data computation](https://docs.diadata.org/use-nexus-product/nexus/data-computation) architecture.

--- a/docs/tools/developer-tools/oracles.mdx
+++ b/docs/tools/developer-tools/oracles.mdx
@@ -7,23 +7,6 @@ sidebar_position: 62
 
 Oracles exist on the Stellar network to bring off-chain data onto the blockchain. For example, a popular use-case of oracles is the inclusion of token pricing into smart contract logic. Since a smart contract can't access data from outside the Stellar network, oracles provide a means by which the data can be accessed on-chain.
 
-## [Reflector Network](https://reflector.network)
-
-The Reflector oracle protocol is a combination of specialized smart contracts and peer-to-peer consensus of data provider nodes maintained by trusted Stellar ecosystem organizations. Feeds include on-chain and off-chain asset prices, CEX & DEX exchange rates, stock indices, financial market APIs, etc. Reflector nodes process, normalize, aggregate, and store trades information from Stellar Classic DEX, Soroban DEX protocols, as well as external sources.
-
-Also available are Reflector Subscriptions: a service for user-defined customized triggers invoked automatically once the price change for the specified asset reaches a certain threshold. Users or Developers interested in creating subscriptions can [learn more here](https://reflector.network/subscription).
-
-Learn how to integrate Reflector feeds [in their documentation](https://reflector.network/docs).
-
-### Deployed Reflector contracts
-
-| Address | Data Source | Network |
-| --- | --- | --- |
-| [`CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M`](https://stellar.expert/explorer/public/contract/CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M) | Stellar DEX | Mainnet |
-| [`CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN`](https://stellar.expert/explorer/public/contract/CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN) | External CEXs & DEXs | Mainnet |
-| [`CAVLP5DH2GJPZMVO7IJY4CVOD5MWEFTJFVPD2YY2FQXOQHRGHK4D6HLP`](https://stellar.expert/explorer/testnet/contract/CAVLP5DH2GJPZMVO7IJY4CVOD5MWEFTJFVPD2YY2FQXOQHRGHK4D6HLP) | Stellar DEX | Testnet |
-| [`CCYOZJCOPG34LLQQ7N24YXBM7LL62R7ONMZ3G6WZAAYPB5OYKOMJRN63`](https://stellar.expert/explorer/testnet/contract/CCYOZJCOPG34LLQQ7N24YXBM7LL62R7ONMZ3G6WZAAYPB5OYKOMJRN63) | External CEXs & DEXs | Testnet |
-
 ## [DIA Oracles](https://www.diadata.org/)
 
 DIA is a cross-chain oracle provider that sources granular market data from diverse exchanges, including CEXs and DEXs. Its data sourcing is thorough, enabling unparalleled transparency and customizability for resilient price feeds for 20,000+ assets. Its versatile data processing and delivery ensures adaptability and reliability for any decentralized application.
@@ -53,3 +36,20 @@ The DIA oracle on Stellar includes price feeds for the following assets:
 #### Pricing methodology
 
 The final price point for each asset is calculated by computing the assets' trade information across multiple DEXs and CEXs. This is done using a Volume Weighted Average Price with Interquartile Range (VWAPIR) methodology. [Learn more about VWAPIR](https://docs.diadata.org/products/token-price-feeds/exchangeprices/vwapir-volume-weighted-average-price-with-interquartile-range-filter).
+
+## [Reflector Network](https://reflector.network)
+
+The Reflector oracle protocol is a combination of specialized smart contracts and peer-to-peer consensus of data provider nodes maintained by trusted Stellar ecosystem organizations. Feeds include on-chain and off-chain asset prices, CEX & DEX exchange rates, stock indices, financial market APIs, etc. Reflector nodes process, normalize, aggregate, and store trades information from Stellar Classic DEX, Soroban DEX protocols, as well as external sources.
+
+Also available are Reflector Subscriptions: a service for user-defined customized triggers invoked automatically once the price change for the specified asset reaches a certain threshold. Users or Developers interested in creating subscriptions can [learn more here](https://reflector.network/subscription).
+
+Learn how to integrate Reflector feeds [in their documentation](https://reflector.network/docs).
+
+### Deployed Reflector contracts
+
+| Address | Data Source | Network |
+| --- | --- | --- |
+| [`CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M`](https://stellar.expert/explorer/public/contract/CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M) | Stellar DEX | Mainnet |
+| [`CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN`](https://stellar.expert/explorer/public/contract/CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN) | External CEXs & DEXs | Mainnet |
+| [`CAVLP5DH2GJPZMVO7IJY4CVOD5MWEFTJFVPD2YY2FQXOQHRGHK4D6HLP`](https://stellar.expert/explorer/testnet/contract/CAVLP5DH2GJPZMVO7IJY4CVOD5MWEFTJFVPD2YY2FQXOQHRGHK4D6HLP) | Stellar DEX | Testnet |
+| [`CCYOZJCOPG34LLQQ7N24YXBM7LL62R7ONMZ3G6WZAAYPB5OYKOMJRN63`](https://stellar.expert/explorer/testnet/contract/CCYOZJCOPG34LLQQ7N24YXBM7LL62R7ONMZ3G6WZAAYPB5OYKOMJRN63) | External CEXs & DEXs | Testnet |

--- a/docs/tools/developer-tools/oracles.mdx
+++ b/docs/tools/developer-tools/oracles.mdx
@@ -37,3 +37,19 @@ Dapps building on Soroban can utilize DIA oracles to obtain up-to-date asset pri
 | [`CAEDPEZDRCEJCF73ASC5JGNKCIJDV2QJQSW6DJ6B74MYALBNKCJ5IFP4`](https://stellar.expert/explorer/testnet/contract/CAEDPEZDRCEJCF73ASC5JGNKCIJDV2QJQSW6DJ6B74MYALBNKCJ5IFP4) | External CEXs & DEXs | Testnet |
 
 Learn more about DIA's [data sourcing](https://docs.diadata.org/use-nexus-product/nexus/data-sourcing) and [data computation](https://docs.diadata.org/use-nexus-product/nexus/data-computation) architecture.
+
+### Oracle specification
+
+#### Included price feeds
+
+The DIA oracle on Stellar includes price feeds for the following assets:
+
+| Asset | Blockchain | Address | Markets Overview |
+| --- | --- | --- | --- |
+| USDC | Ethereum | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 | [USDC Information](https://www.diadata.org/app/price/asset/Ethereum/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/) |
+| BTC | Bitcoin | 0x0000000000000000000000000000000000000000 | [BTC Information](https://www.diadata.org/app/price/asset/Bitcoin/0x0000000000000000000000000000000000000000/) |
+| DIA | Ethereum | 0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419 | [DIA Information](https://www.diadata.org/app/price/asset/Ethereum/0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419/) |
+
+#### Pricing methodology
+
+The final price point for each asset is calculated by computing the assets' trade information across multiple DEXs and CEXs. This is done using a Volume Weighted Average Price with Interquartile Range (VWAPIR) methodology. [Learn more about VWAPIR](https://docs.diadata.org/products/token-price-feeds/exchangeprices/vwapir-volume-weighted-average-price-with-interquartile-range-filter).

--- a/docs/tools/developer-tools/oracles.mdx
+++ b/docs/tools/developer-tools/oracles.mdx
@@ -1,0 +1,35 @@
+---
+title: Oracles
+description: Explore on-chain data and prices feeds using oracles.
+sidebar_label: Oracles
+sidebar_position: 62
+---
+
+Oracles exist on the Stellar network to bring off-chain data onto the blockchain. For example, a popular use-case of oracles is the inclusion of token pricing into smart contract logic. Since a smart contract can't access data from outside the Stellar network, oracles provide a means by which the data can be accessed on-chain.
+
+## [Reflector Network](https://reflector.network)
+
+The Reflector oracle protocol is a combination of specialized smart contracts and peer-to-peer consensus of data provider nodes maintained by trusted Stellar ecosystem organizations. Feeds include on-chain and off-chain asset prices, CEX & DEX exchange rates, stock indices, financial market APIs, etc. Reflector nodes process, normalize, aggregate, and store trades information from Stellar Classic DEX, Soroban DEX protocols, as well as external sources.
+
+Learn how to integrate Reflector feeds [in their documentation](https://reflector.network/docs).
+
+### Deployed Reflector contracts
+
+| Address | Data Source | Network |
+| --- | --- | --- |
+| [`CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M`](https://stellar.expert/explorer/public/contract/CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M) | Stellar DEX | Mainnet |
+| [`CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN`](https://stellar.expert/explorer/public/contract/CAFJZQWSED6YAWZU3GWRTOCNPPCGBN32L7QV43XX5LZLFTK6JLN34DLN) | External CEXs & DEXs | Mainnet |
+| [`CAVLP5DH2GJPZMVO7IJY4CVOD5MWEFTJFVPD2YY2FQXOQHRGHK4D6HLP`](https://stellar.expert/explorer/testnet/contract/CAVLP5DH2GJPZMVO7IJY4CVOD5MWEFTJFVPD2YY2FQXOQHRGHK4D6HLP) | Stellar DEX | Testnet |
+| [`CCYOZJCOPG34LLQQ7N24YXBM7LL62R7ONMZ3G6WZAAYPB5OYKOMJRN63`](https://stellar.expert/explorer/testnet/contract/CCYOZJCOPG34LLQQ7N24YXBM7LL62R7ONMZ3G6WZAAYPB5OYKOMJRN63) | External CEXs & DEXs | Testnet |
+
+## [DIA Oracles](https://www.diadata.org/)
+
+DIA is a cross-chain oracle provider that sources granular market data from diverse exchanges, including CEXs and DEXs. Its data sourcing is thorough, enabling unparalleled transparency and customizability for resilient price feeds for 20,000+ assets. Its versatile data processing and delivery ensures adaptability and reliability for any decentralized application.
+
+Learn more about DIA's [data sourcing](https://docs.diadata.org/use-nexus-product/nexus/data-sourcing) and [data computation](https://docs.diadata.org/use-nexus-product/nexus/data-computation) architecture.
+
+### Deployed DIA contracts
+
+| Address | Data Source | Network |
+| --- | --- | --- |
+| [`CAEDPEZDRCEJCF73ASC5JGNKCIJDV2QJQSW6DJ6B74MYALBNKCJ5IFP4`](https://stellar.expert/explorer/testnet/contract/CAEDPEZDRCEJCF73ASC5JGNKCIJDV2QJQSW6DJ6B74MYALBNKCJ5IFP4) | External CEXs & DEXs | Testnet |


### PR DESCRIPTION
With the launch of DIA, I realized we don't have any content in the dev tools section concerning oracles. This creates that page, and adds information about the [Reflector Network](https://reflector.network/) and [DIA](https://www.diadata.org/) to start with.

Relevant preview page: https://developers-pr1124.previews.kube001.services.stellar-ops.com/docs/tools/developer-tools/oracles