### PR TITLE
Add note on setting `QUALITY` to tier 1 page

### DIFF
--- a/docs/validators/tier-1-orgs.mdx
+++ b/docs/validators/tier-1-orgs.mdx
@@ -33,7 +33,11 @@ To configure a quorum set for your validator, we recommend including several Tie
 
 To see what the current recommended quorum set looks like, check out the [example Full Validator config file](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg).
 
-**NOTE:** Be sure to properly add your own validators to your validators' quorum sets. As a Tier 1 organization with three validators and history archives, SDF recommend declaring your organization [`HIGH` quality](./admin-guide/configuring.mdx#validator-quality) in your quorum set configuration. Declaring your organization at a lower quality level [may limit its participation in consensus](./admin-guide/configuring.mdx#impact-of-validator-quality-on-nomination).
+:::note
+
+Be sure to properly add your own validators to your validators' quorum sets. As a Tier 1 organization with three validators and history archives, SDF recommends declaring your organization [`HIGH` quality](./admin-guide/configuring.mdx#validator-quality) in your quorum set configuration. Declaring your organization at a lower quality level [may limit its participation in consensus](./admin-guide/configuring.mdx#impact-of-validator-quality-on-nomination).
+
+:::
 
 ## Declare Your Node
 

--- a/docs/validators/tier-1-orgs.mdx
+++ b/docs/validators/tier-1-orgs.mdx
@@ -33,7 +33,7 @@ To configure a quorum set for your validator, we recommend including several Tie
 
 To see what the current recommended quorum set looks like, check out the [example Full Validator config file](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg).
 
-**NOTE:** Be sure to properly add your own validators to your validators' quorum sets. As a Tier 1 organization with three validators and history archives, we recommend declaring your organization [`HIGH` quality](admin-guide/configuring#validator-quality) in your quorum set configuration. Declaring your organization at a lower quality level [may limit its participation in consensus](admin-guide/configuring#impact-of-validator-quality-on-nomination).
+**NOTE:** Be sure to properly add your own validators to your validators' quorum sets. As a Tier 1 organization with three validators and history archives, SDF recommend declaring your organization [`HIGH` quality](./admin-guide/configuring.mdx#validator-quality) in your quorum set configuration. Declaring your organization at a lower quality level [may limit its participation in consensus](./admin-guide/configuring.mdx#impact-of-validator-quality-on-nomination).
 
 ## Declare Your Node
 

--- a/docs/validators/tier-1-orgs.mdx
+++ b/docs/validators/tier-1-orgs.mdx
@@ -33,6 +33,8 @@ To configure a quorum set for your validator, we recommend including several Tie
 
 To see what the current recommended quorum set looks like, check out the [example Full Validator config file](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg).
 
+**NOTE:** Be sure to properly add your own validators to your validators' quorum sets. As a Tier 1 organization with three validators and history archives, we recommend declaring your organization [`HIGH` quality](admin-guide/configuring#validator-quality) in your quorum set configuration. Declaring your organization at a lower quality level [may limit its participation in consensus](admin-guide/configuring#impact-of-validator-quality-on-nomination).
+
 ## Declare Your Node
 
 [SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md) is an open spec that explains how self-verification of validator nodes works. The fields it specifies are pretty simple: you set the home domain of your validator’s Stellar account to your website, where you publish information about your node and your organization in a stellar.toml file.


### PR DESCRIPTION
This change adds a note to the docs for tier 1 orgs to help them properly set their org's quality level.