### PR TITLE
FIX - Update bindings.mdx

### DIFF
--- a/docs/build/apps/guestbook/bindings.mdx
+++ b/docs/build/apps/guestbook/bindings.mdx
@@ -29,7 +29,7 @@ The smart contract code needs to be installed to the network first. This uploads
 
 ```shell
 stellar contract install \
-    --source S...ECRETKEY \
+    --source <identity or secret key> \
     --network testnet \
     --wasm ./target/wasm32-unknown-unknown/release/ye_olde_guestbook.wasm
 ```
@@ -40,7 +40,7 @@ This will return a hexadecimal hash corresponding to the uploaded Wasm executabl
 
 ```shell
 stellar contract deploy \
-    --source S...ECRETKEY \
+    --source <identity or secret key> \
     --network testnet \
     --wasm-hash <wasm_hash_from_install_step>
 ```
@@ -51,7 +51,6 @@ Now we can (again) use the Stellar CLI to generate bindings from the contract we
 
 ```shell
 stellar contract bindings typescript \
-    --source S...ECRETKEY \
     --network testnet \
     --id <contract_address_from_deploy_step> \
     --output-dir ./packages/ye_olde_guestbook \


### PR DESCRIPTION
there's an error when generating the typescript bindings, source is not needed to generate them. also made the secret-key clearer and made it clear you can also use a stored identity which is safer