### PR TITLE
extend ttl should use readOnly 

### DIFF
--- a/docs/build/guides/transactions/simulateTransaction-Deep-Dive.mdx
+++ b/docs/build/guides/transactions/simulateTransaction-Deep-Dive.mdx
@@ -269,7 +269,7 @@ export async function simulateRestorationIfNeeded(
           txParams.txBuilderOptions,
         )
           .setSorobanData(
-            new SorobanDataBuilder().setReadWrite([ledgerKey]).build(),
+            new SorobanDataBuilder().setReadOnly([ledgerKey]).build(),
           )
           .addOperation(
             Operation.extendFootprintTtl({


### PR DESCRIPTION
[the simulate deep dive](https://developers.stellar.org/docs/build/guides/transactions/simulateTransaction-Deep-Dive) example was using `setReadWrite` instead of `setReadOnly` for extend ttl operation ([sdk doc](https://stellar.github.io/js-stellar-sdk/Operation.html#.extendFootprintTtl))

> Builds an operation to bump the time-to-live (TTL) of the ledger keys. The keys for extension have to be provided in the **read-only** footprint of the transaction.