### PR TITLE
better trustline description

### DIFF
--- a/docs/learn/fundamentals/stellar-data-structures/accounts.mdx
+++ b/docs/learn/fundamentals/stellar-data-structures/accounts.mdx
@@ -40,7 +40,7 @@ Account data is stored in subentries, each of which increases an account’s min
 
 ## Trustlines
 
-Trustlines are an explicit opt-in for an account to hold and trade a particular asset. To hold a specific asset, an account must establish a trustline with the issuing account using the change_trust operation. Trustlines track the balance of an asset and can also limit the amount of an asset that an account can hold.
+Trustlines are an explicit opt-in for an account to hold a particular asset. To hold a specific asset, an account must establish a trustline with the issuing account using the change_trust operation. Trustlines track the balance of an asset and can also limit the amount of an asset that an account can hold.
 
 A trustline must be established for an account to receive any asset except lumens (XLM). You can create a claimable balance to send assets to an account without a trustline, but the recipient has to create a trustline to claim that balance. Learn more here: [Claimable Balances Encyclopedia Entry](../../encyclopedia/transactions-specialized/claimable-balances.mdx)
 


### PR DESCRIPTION
remove the language about the relationship between trustlines and trading. In flight, as a hop in a path payment, an account can trade an asset that it does not have a trustline for