### PR TITLE
fix fuzzing example

### DIFF
--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -59,7 +59,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
    use libfuzzer_sys::fuzz_target;
    use soroban_increment_with_fuzz_contract::{IncrementContract, IncrementContractClient};
    use soroban_sdk::{
-       testutils::arbitrary::{self, Arbitrary},
+       testutils::arbitrary::{arbitrary, Arbitrary},
        Env,
    };
 


### PR DESCRIPTION
### What
Import the arbitrary module in the fuzzing example test.

### Why
It's required because of how arbitrary depends on it being in scope. Somehow this was missed when the test was run, and I have no idea how it worked. I tested it, and must have changed it to self thinking it was fine just before merging it.