### PR TITLE
Fix/1138 followup

### DIFF
--- a/docs/build/apps/dapp-frontend.mdx
+++ b/docs/build/apps/dapp-frontend.mdx
@@ -79,7 +79,7 @@ stellar contract bindings typescript \
 
 :::tip
 
-Notice that we were able to use the contract alias, `hello-world`, in place of the contract id!
+Notice that we were able to use the contract alias, `hello_world`, in place of the contract id!
 
 :::
 

--- a/docs/build/apps/dapp-frontend.mdx
+++ b/docs/build/apps/dapp-frontend.mdx
@@ -19,11 +19,13 @@ Let's get started.
 
 You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) v18.14.1 or greater. If you haven't yet, install it now.
 
-We want to initialize our current project as an Astro project. To do this, we can clone a template. You can find Soroban templates on GitHub by [searching for repositories that start with "soroban-template-"](https://github.com/search?q=%22soroban-template-%22&type=repositories). For this tutorial, we'll use [stellar/soroban-template-astro](https://github.com/stellar/soroban-template-astro). We'll also use a tool called [degit](https://github.com/Rich-Harris/degit) to clone the template without its git history. This will allow us to set it up as our own git project.
+We want to create an Astro project with the contracts from the previous lesson. To do this, we can clone a template. You can find Soroban templates on GitHub by [searching for repositories that start with "soroban-template-"](https://github.com/search?q=%22soroban-template-%22&type=repositories). For this tutorial, we'll use [stellar/soroban-template-astro](https://github.com/stellar/soroban-template-astro). We'll also use a tool called [degit](https://github.com/Rich-Harris/degit) to clone the template without its git history. This will allow us to set it up as our own git project.
 
-Since you have `node` and its package manager `npm` installed, you also have `npx`. Make sure you're no longer in your `soroban-hello-world` directory and then run:
+Since you have `node` and its package manager `npm` installed, you also have `npx`.
 
-```
+We're going to create a new project directory with this template to make things easier in this tutorial, so make sure you're no longer in your `soroban-hello-world` directory and then run:
+
+```sh
 npx degit stellar/soroban-template-astro first-soroban-app
 cd first-soroban-app
 git init
@@ -56,7 +58,11 @@ This project has the following directory structure, which we'll go over in more 
 └── tsconfig.json
 ```
 
-The `contracts` are the same ones you walked through in the previous steps of the tutorial.
+The `contracts` are the same ones you walked through in the previous steps of the tutorial. Since we already deployed these contracts with aliases, we can reuse the generated contract ID files by copying them from the `soroban-hello-world/.stellar` directory into this project:
+
+```sh
+cp -R ../soroban-hello-world/.stellar/ .stellar
+```
 
 ## Generate an NPM package for the Hello World contract
 
@@ -67,9 +73,15 @@ This is going to use the CLI command `stellar contract bindings typescript`:
 ```bash
 stellar contract bindings typescript \
   --network testnet \
-  --contract-id $(cat .stellar/contract-ids/hello_world.txt) \
+  --contract-id hello_world \
   --output-dir packages/hello_world
 ```
+
+:::tip
+
+Notice that we were able to use the contract alias, `hello-world`, in place of the contract id!
+
+:::
 
 This project is set up as an NPM Workspace, and so the `hello_world` client library was generated in the `packages` directory at `packages/hello_world`.
 
@@ -77,7 +89,7 @@ We attempt to keep the code in these generated libraries readable, so go ahead a
 
 ## Generate an NPM package for the Increment contract
 
-Though we can run `soroban contract bindings typescript` for each of our contracts individually, the [soroban-template-astro](https://github.com/stellar/soroban-astro-template) that we used as our template includes a very handy `initialize.js` script that will handle this for all of the contracts in our `contracts` directory.
+Though we can run `soroban contract bindings typescript` for each of our contracts individually, the [soroban-template-astro](https://github.com/stellar/soroban-astro-template) project that we used as our template includes a very handy `initialize.js` script that will handle this for all of the contracts in our `contracts` directory.
 
 In addition to generating the NPM packages, `initialize.js` will also:
 
@@ -408,7 +420,7 @@ Now you're ready to sign the call to `increment`!
 
 ### Call `increment`
 
-Now we can import the `increment` contract client from `soroban_increment_contract` and start using it. We'll again create a new Astro component. Create a new file at `src/components/Counter.astro` with the following contents:
+Now we can import the `increment` contract client from `contracts/increment.ts` and start using it. We'll again create a new Astro component. Create a new file at `src/components/Counter.astro` with the following contents:
 
 ```html title="src/components/Counter.astro"
 <strong>Incrementor</strong><br />
@@ -417,8 +429,8 @@ Current value: <strong id="current-value" aria-live="polite">???</strong><br />
 <button data-increment aria-controls="current-value">Increment</button>
 
 <script>
-  import { getPublicKey, kit } from "../stellar-wallets-kit";
-  import incrementor from "../contracts/soroban_increment_contract";
+  import { getPublicKey, signTransaction } from "../stellar-wallets-kit";
+  import incrementor from "../contracts/increment";
   const button = document.querySelector(
     "[data-increment]",
   ) as HTMLButtonElement;

--- a/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
+++ b/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
@@ -67,7 +67,8 @@ This returns the hash of the Wasm bytes, like `6ddb28e0980f643bb97350f7e3bacb0ff
 stellar contract deploy \
   --wasm-hash 6ddb28e0980f643bb97350f7e3bacb0ff1fe74d846c6d4f2c625e766210fbb5b \
   --source alice \
-  --network testnet
+  --network testnet \
+  --alias increment
 ```
 
 </TabItem>
@@ -78,7 +79,8 @@ stellar contract deploy \
 stellar contract deploy `
   --wasm-hash 6ddb28e0980f643bb97350f7e3bacb0ff1fe74d846c6d4f2c625e766210fbb5b `
   --source alice `
-  --network testnet
+  --network testnet `
+  --alias increment
 ```
 
 </TabItem>

--- a/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
+++ b/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
@@ -39,7 +39,7 @@ You can run these two steps separately. Let's try it with the Increment contract
 stellar contract install \
   --network testnet \
   --source alice \
-  --wasm target/wasm32-unknown-unknown/release/soroban_increment_contract.wasm
+  --wasm target/wasm32-unknown-unknown/release/increment.wasm
 ```
 
 </TabItem>
@@ -57,7 +57,7 @@ stellar contract install `
 
 </Tabs>
 
-This returns the hash of the Wasm bytes, like `6ddb28e0980f643bb97350f7e3bacb0ff1fe74d846c6d4f2c625e766210fbb5b`. Now you can use `--wasm-hash` with `deploy` rather than `--wasm`:
+This returns the hash of the Wasm bytes, like `6ddb28e0980f643bb97350f7e3bacb0ff1fe74d846c6d4f2c625e766210fbb5b`. Now you can use `--wasm-hash` with `deploy` rather than `--wasm. Make sure to replace the example wasm hash with your own.
 
 <Tabs groupId="platform" defaultValue={getPlatform()}>
 

--- a/docs/build/smart-contracts/getting-started/deploy-to-testnet.mdx
+++ b/docs/build/smart-contracts/getting-started/deploy-to-testnet.mdx
@@ -41,7 +41,8 @@ To deploy your HelloWorld contract, run the following command:
 stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/hello_world.wasm \
   --source alice \
-  --network testnet
+  --network testnet \
+  --alias hello_world
 ```
 
 </TabItem>
@@ -52,7 +53,8 @@ stellar contract deploy \
 stellar contract deploy `
   --wasm target/wasm32-unknown-unknown/release/hello_world.wasm `
   --source alice `
-  --network testnet
+  --network testnet `
+  --alias hello_world
 ```
 
 </TabItem>
@@ -60,6 +62,12 @@ stellar contract deploy `
 </Tabs>
 
 This returns the contract's id, starting with a `C`. In this example, we're going to use `CACDYF3CYMJEJTIVFESQYZTN67GO2R5D5IUABTCUG3HXQSRXCSOROBAN`, so replace it with your actual contract id.
+
+:::tip
+
+We used the `--alias` flag in this deploy command which will create a `.stellar/contract-ids/hello_world.json` file that maps the alias `hello_world` to the contract id and network. This allows us to refer to this contract as its alias instead the contract id.
+
+:::
 
 ## Interact
 

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -37,11 +37,12 @@ The `init` command will create a Rust workspace project, using the recommended s
 ├── Cargo.toml
 ├── README.md
 └── contracts
-    └── hello_world
-        ├── Cargo.toml
-        └── src
-            ├── lib.rs
-            └── test.rs
+    ├── hello_world
+    │   ├── Cargo.toml
+    │   ├── Makefile
+    │   ├── src
+    │   │   ├── lib.rs
+    │   │   └── test.rs
 ```
 
 ### Cargo.toml
@@ -60,7 +61,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "20.3.2"
+soroban-sdk = "22"
 ```
 
 :::info
@@ -150,14 +151,14 @@ All contracts should begin with `#![no_std]` to ensure that the Rust standard li
 The contract imports the types and macros that it needs from the `soroban-sdk` crate.
 
 ```rust
-use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 ```
 
 Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
 
 Contract inputs must not be references.
 
-The `#[contract]` attribute designates the Contract struct as the type to which contract functions are associated. This implies that the struct will have contract functions implemented for it.
+The `#[contract]` attribute designates the `HelloContract` struct as the type to which contract functions are associated. This implies that the struct will have contract functions implemented for it.
 
 ```rust
 #[contract]
@@ -169,8 +170,8 @@ Contract functions are defined within an `impl` block for the struct, which is a
 ```rust
 #[contractimpl]
 impl HelloContract {
-    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol_short!("Hello"), to]
+    pub fn hello(env: Env, to: String) -> Vec<String> {
+        vec![&env, String::from_str(&env, "Hello"), to]
     }
 }
 ```
@@ -179,15 +180,15 @@ Putting those pieces together a simple contract looks like this.
 
 ```rust title="contracts/hello_world/src/lib.rs"
 #![no_std]
-use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
 pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
-    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol_short!("Hello"), to]
+    pub fn hello(env: Env, to: String) -> Vec<String> {
+        vec![&env, String::from_str(&env, "Hello"), to]
     }
 }
 
@@ -200,22 +201,22 @@ Note the `mod test` line at the bottom, this will tell Rust to compile and run t
 
 Writing tests for Soroban contracts involves writing Rust code using the test facilities and toolchain that you'd use for testing any Rust code.
 
-Given our HelloContract, a simple test will look like this.
+Given our `HelloContract`, a simple test will look like this.
 
 <Tabs>
 <TabItem value="lib.rs" label="contracts/hello_world/src/lib.rs">
 
 ```rust
 #![no_std]
-use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
 pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
-    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, symbol_short!("Hello"), to]
+    pub fn hello(env: Env, to: String) -> Vec<String> {
+        vec![&env, String::from_str(&env, "Hello"), to]
     }
 }
 
@@ -229,18 +230,22 @@ mod test;
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{symbol_short, vec, Env};
+use soroban_sdk::{vec, Env, String};
 
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, HelloContract);
+    let contract_id = env.register(HelloContract, ());
     let client = HelloContractClient::new(&env, &contract_id);
 
-    let words = client.hello(&symbol_short!("Dev"));
+    let words = client.hello(&String::from_str(&env, "Dev"));
     assert_eq!(
         words,
-        vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]
+        vec![
+            &env,
+            String::from_str(&env, "Hello"),
+            String::from_str(&env, "Dev"),
+        ]
     );
 }
 ```
@@ -264,16 +269,20 @@ All public functions within an `impl` block that is annotated with the `#[contra
 
 ```rust
 let client = HelloContractClient::new(&env, &contract_id);
-let words = client.hello(&symbol_short!("Dev"));
+let words = client.hello(&String::from_str(&env, "Dev"));
 ```
 
 The values returned by functions can be asserted on:
 
 ```rust
-assert_eq!(
-    words,
-    vec![&env, symbol_short!("Hello"), symbol_short!("Dev"),]
-);
+    assert_eq!(
+        words,
+        vec![
+            &env,
+            String::from_str(&env, "Hello"),
+            String::from_str(&env, "Dev"),
+        ]
+    );
 ```
 
 ## Run the Tests

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -262,7 +262,7 @@ let env = Env::default();
 The contract is registered with the environment using the contract type. Contracts can specify a fixed contract ID as the first argument, or provide `None` and one will be generated.
 
 ```rust
-let contract_id = env.register_contract(None, Contract);
+let contract_id = env.register(Contract, ());
 ```
 
 All public functions within an `impl` block that is annotated with the `#[contractimpl]` attribute have a corresponding function generated in a generated client type. The client type will be named the same as the contract type with `Client` appended. For example, in our contract the contract type is `Contract`, and the client is named `ContractClient`.

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -158,18 +158,18 @@ Many of the types available in typical Rust programs, such as `std::vec::Vec`, a
 
 Contract inputs must not be references.
 
-The `#[contract]` attribute designates the `HelloContract` struct as the type to which contract functions are associated. This implies that the struct will have contract functions implemented for it.
+The `#[contract]` attribute designates the `Contract` struct as the type to which contract functions are associated. This implies that the struct will have contract functions implemented for it.
 
 ```rust
 #[contract]
-pub struct HelloContract;
+pub struct Contract;
 ```
 
 Contract functions are defined within an `impl` block for the struct, which is annotated with `#[contractimpl]`. It is important to note that contract functions should have names with a maximum length of 32 characters. Additionally, if a function is intended to be invoked from outside the contract, it should be marked with the `pub` visibility modifier. It is common for the first argument of a contract function to be of type `Env`, allowing access to a copy of the Soroban environment, which is typically necessary for various operations within the contract.
 
 ```rust
 #[contractimpl]
-impl HelloContract {
+impl Contract {
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
     }
@@ -183,10 +183,10 @@ Putting those pieces together a simple contract looks like this.
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
-pub struct HelloContract;
+pub struct Contract;
 
 #[contractimpl]
-impl HelloContract {
+impl Contract {
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
     }
@@ -201,7 +201,7 @@ Note the `mod test` line at the bottom, this will tell Rust to compile and run t
 
 Writing tests for Soroban contracts involves writing Rust code using the test facilities and toolchain that you'd use for testing any Rust code.
 
-Given our `HelloContract`, a simple test will look like this.
+Given our `Contract`, a simple test will look like this.
 
 <Tabs>
 <TabItem value="lib.rs" label="contracts/hello_world/src/lib.rs">
@@ -211,10 +211,10 @@ Given our `HelloContract`, a simple test will look like this.
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 #[contract]
-pub struct HelloContract;
+pub struct Contract;
 
 #[contractimpl]
-impl HelloContract {
+impl Contract {
     pub fn hello(env: Env, to: String) -> Vec<String> {
         vec![&env, String::from_str(&env, "Hello"), to]
     }
@@ -235,8 +235,8 @@ use soroban_sdk::{vec, Env, String};
 #[test]
 fn test() {
     let env = Env::default();
-    let contract_id = env.register(HelloContract, ());
-    let client = HelloContractClient::new(&env, &contract_id);
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
 
     let words = client.hello(&String::from_str(&env, "Dev"));
     assert_eq!(
@@ -265,10 +265,10 @@ The contract is registered with the environment using the contract type. Contrac
 let contract_id = env.register_contract(None, Contract);
 ```
 
-All public functions within an `impl` block that is annotated with the `#[contractimpl]` attribute have a corresponding function generated in a generated client type. The client type will be named the same as the contract type with `Client` appended. For example, in our contract the contract type is `HelloContract`, and the client is named `HelloContractClient`.
+All public functions within an `impl` block that is annotated with the `#[contractimpl]` attribute have a corresponding function generated in a generated client type. The client type will be named the same as the contract type with `Client` appended. For example, in our contract the contract type is `Contract`, and the client is named `ContractClient`.
 
 ```rust
-let client = HelloContractClient::new(&env, &contract_id);
+let client = ContractClient::new(&env, &contract_id);
 let words = client.hello(&String::from_str(&env, "Dev"));
 ```
 

--- a/docs/build/smart-contracts/getting-started/storing-data.mdx
+++ b/docs/build/smart-contracts/getting-started/storing-data.mdx
@@ -27,27 +27,27 @@ This tutorial assumes that you've already completed the previous steps in Gettin
 
 ## Adding the increment contract
 
-The `stellar contract init` command allows us to initialize a new project with any of the example contracts from the [soroban-examples](https://github.com/stellar/soroban-examples) repo, using the `--name` flag, to specify a new contract's name.
+In addition to creating a new project, the `stellar contract init` command also allows us to initialize a new contract workspace within an existing project. In this example, we're going to initialize a new contract and use the `--name` flag to specify the name of our new contract, `increment`.
 
-It will not overwrite existing files unless we explicily pass in `--ovewrite` flag. Run the command with a `--name` flag to add an `increment` contract to our project. From inside our `soroban-hello-world` directory, run:
+This command will not overwrite existing files unless we explicitly pass in the `--overwrite` flag. From within our `soroban-hello-world` directory, run:
 
 ```sh
 stellar contract init . --name increment
 ```
 
-This will create a new `contracts/increment` directory with the following files:
+This creates a new `contracts/increment` directory with placeholder code in `src/lib.rs` and `src/test.rs`, which we'll replace with our new increment contract and corresponding tests.
 
 ```
 └── contracts
     ├── increment
-        ├── Cargo.lock
         ├── Cargo.toml
+        ├── Makefile
         └── src
             ├── lib.rs
             └── test.rs
 ```
 
-The following code was added to `contracts/increment/src/lib.rs`. We'll go over it in more detail below. However, in order to use the increment contract code, you will need to copy and paste the `lib.rs` and `test.rs` into `src`.
+We will go through the contract code in more detail below, but for now, replace the placeholder code in `contracts/increment/src/lib.rs` with the following.
 
 ```rust
 #![no_std]
@@ -56,13 +56,13 @@ use soroban_sdk::{contract, contractimpl, log, symbol_short, Env, Symbol};
 const COUNTER: Symbol = symbol_short!("COUNTER");
 
 #[contract]
-pub struct IncrementorContract;
+pub struct IncrementContract;
 
 #[contractimpl]
-impl IncrementorContract {
-    /// Increment an internal counter; return the new value.
+impl IncrementContract {
+    /// Increment increments an internal counter, and returns the value.
     pub fn increment(env: Env) -> u32 {
-        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0);
+        let mut count: u32 = env.storage().instance().get(&COUNTER).unwrap_or(0); // If no value set, assume 0.
 
         count += 1;
 
@@ -150,21 +150,22 @@ Check that it built:
 ls target/wasm32-unknown-unknown/release/*.wasm
 ```
 
-You should see both `hello_world.wasm` and `soroban_increment_contract.wasm`.
+You should see both `hello_world.wasm` and `increment.wasm`.
 
 ## Tests
 
-The following test has been added to the `contracts/increment/src/test.rs` file.
+Replace the placeholder code in `contracts/increment/src/test.rs` with the following increment test code.
 
-```rust title="contracts/incrementor/src/test.rs"
-use crate::{IncrementorContract, IncrementorContractClient};
+```rust title="contracts/increment/src/test.rs"
+#![cfg(test)]
+use crate::{IncrementContract, IncrementContractClient};
 use soroban_sdk::Env;
 
 #[test]
-fn increment() {
+fn test() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, IncrementorContract);
-    let client = IncrementorContractClient::new(&env, &contract_id);
+    let contract_id = env.register(IncrementContract, ());
+    let client = IncrementContractClient::new(&env, &contract_id);
 
     assert_eq!(client.increment(), 1);
     assert_eq!(client.increment(), 2);
@@ -188,14 +189,20 @@ If you want to see the output of the `log!` call, run the tests with `--nocaptur
 cargo test -- --nocapture
 ```
 
-You should see the output:
+You should see the the diagnostic log events with the count data in the output:
 
 ```
 running 1 test
-count: U32(0)
-count: U32(1)
-count: U32(2)
-test test::incrementor ... ok
+[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM,
+    topics:[log],
+    data:["count: {}", 1]
+[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM,
+    topics:[log],
+    data:["count: {}", 2]
+[Diagnostic Event] contract:CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM,
+    topics:[log],
+    data:["count: {}", 3]
+test test::test ... ok
 ```
 
 ## Take it further


### PR DESCRIPTION
Some additional fixes/updates that i noticed while looking into [1138](https://github.com/stellar/stellar-docs/issues/1138)

getting start
- updated hello world and increment contracts to be the same as they are in the examples repo
- use aliases when deploying so that our first `contract bindings` command works in dapp-frontend.mdx
- add a tip about the --alias flag
- update description of `init` command, and how the `--name` flag works

dapp-frontend.mdx
- have the user copy the contract ids from `.stellar` over into the `irst-soroban-app` directory so we can reuse the deployments from the first secions
- use alias for first `contract bindings` example
- small update to the Counter.astro code
