### PR TITLE
Fix test steps #1104

### DIFF
--- a/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
+++ b/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
@@ -46,10 +46,17 @@ git clone -b v22.0.1 https://github.com/stellar/soroban-examples
 
 Or, skip the development environment setup and open this example in [Gitpod][oigp].
 
-To run the tests for the example, navigate to the `cross_contract/contract_b` directory, and use `cargo test`.
+To run the tests for the example, first build Contract A (the contract to be called) and then run `cargo test` from Contract B's directory. Build Contract A by navigating to the `cross_contract/contract_a` directory and use the `stellar contract build` build command:
 
 ```
-cd cross_contract/contract_b
+cd cross_contract/contract_a
+stellar contract build
+```
+
+When Contract A has been built, navigate to the `cross_contract/contract_b` directory, and use `cargo test`.
+
+```
+cd ../contract_b
 cargo test
 ```
 


### PR DESCRIPTION
It's necessary to build Contract A before running the test, otherwise Contract A cannot be called from Contract B.