### PR TITLE
Change fuzzing guide section heading level

### DIFF
--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -116,7 +116,7 @@ There is another tool for fuzzing Rust code, `cargo-afl`. See the [Rust Fuzz boo
 
 :::
 
-### How to Get Code Coverage of Fuzz Tests
+## How to Get Code Coverage of Fuzz Tests
 
 Getting code coverage data for fuzz tests requires some different tooling than when doing the same for regular Rust tests.
 


### PR DESCRIPTION
### What
Change one of the headings in the fuzzing guide to match the level of the other heading.

### Why
The level of the heading was different, but should be the same as they are not intended to be nested, but sit at the same level.