### PR TITLE
Reorder testing docs in docs sidebar

### DIFF
--- a/docs/build/guides/testing/code-coverage.mdx
+++ b/docs/build/guides/testing/code-coverage.mdx
@@ -2,7 +2,7 @@
 title: Code Coverage
 hide_table_of_contents: true
 description: Code coverage tools find code not tested.
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 Measuring code coverage uses tools to identify lines of code that are and aren't executed by tests. Code coverage stats can give us an idea of how much of a contract is actually tested by its tests.

--- a/docs/build/guides/testing/mutation-testing.mdx
+++ b/docs/build/guides/testing/mutation-testing.mdx
@@ -2,7 +2,7 @@
 title: Mutation Testing
 hide_table_of_contents: true
 description: Mutation testing finds code not tested.
-sidebar_position: 11
+sidebar_position: 10
 ---
 
 Mutation testing is making changes to a program, either manually or automatically, to identify changes that can be made that don't get caught by tests.


### PR DESCRIPTION
### What
Move the mutation testing guide before code coverage in the sidebar.

### Why
This reordering groups the mutation testing with the majority of the guides that describe how to test. The code coverage guide is more ancillarily and describes a way to measure how much code is tested.