### PR TITLE
Add nightly rust requirement to fuzzing how-to guide

### DIFF
--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -15,7 +15,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 1. Install the nightly Rust toolchain. Nightly Rust is required to run cargo-fuzz.
 
-   ```shell
+   ```
    rustup install nightly
    ```
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -13,19 +13,25 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 ## How to Write Fuzz Tests
 
-1. Install `cargo-fuzz`.
+1. Install the nightly Rust toolchain. Nightly Rust is required to run cargo-fuzz.
+
+   ```shell
+   rustup install nightly
+   ```
+
+2. Install `cargo-fuzz`.
 
    ```shell
    cargo install --locked cargo-fuzz
    ```
 
-2. Initialize a fuzz project by running the following command inside your contract directory.
+3. Initialize a fuzz project by running the following command inside your contract directory.
 
    ```shell
    cargo fuzz init
    ```
 
-3. Open the contract's `Cargo.toml` file. Add `lib` as a `crate-type`.
+4. Open the contract's `Cargo.toml` file. Add `lib` as a `crate-type`.
 
    ```diff
     [lib]
@@ -33,7 +39,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
    +crate-type = ["lib", "cdylib"]
    ```
 
-4. Open the generated `fuzz/Cargo.toml` file. Add the `soroban-sdk` dependency.
+5. Open the generated `fuzz/Cargo.toml` file. Add the `soroban-sdk` dependency.
 
    ```diff
     [dependencies]
@@ -41,7 +47,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
    +soroban-sdk = { version = "*", features = ["testutils"] }
    ```
 
-5. Open the generated `fuzz/src/fuzz_target_1.rs` file. It will look like the below.
+6. Open the generated `fuzz/src/fuzz_target_1.rs` file. It will look like the below.
 
    ```rust
    #![no_main]
@@ -52,7 +58,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
    });
    ```
 
-6. Fill out the `fuzz_target!` call with test setup and assertions. For example, for the [increment example]:
+7. Fill out the `fuzz_target!` call with test setup and assertions. For example, for the [increment example]:
 
    ```rust
    #![no_main]
@@ -85,7 +91,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
    });
    ```
 
-7. Execute the fuzz target.
+8. Execute the fuzz target.
 
    ```shell
    cargo +nightly fuzz run --sanitizer=thread fuzz_target_1


### PR DESCRIPTION
### What
Update fuzzing how-to guide to include installation of the nightly Rust toolchain.

### Why
Cargo-fuzz requires the nightly Rust channel, so the documentation now explicitly guides users to install the nightly toolchain before setting up fuzzing. The documentation previously assumed it was already installed which would lead devs to see an error when first running the fuzzer.