### PR TITLE
Fix fuzzing guide code block formatting

### DIFF
--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -15,13 +15,13 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 1. Install `cargo-fuzz`.
 
-   ```
+   ```text
    cargo install --locked cargo-fuzz
    ```
 
 2. Initialize a fuzz project by running the following command inside your contract directory.
 
-   ```
+   ```text
    cargo fuzz init
    ```
 
@@ -87,7 +87,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 7. Execute the fuzz target.
 
-   ```
+   ```text
    cargo +nightly fuzz run --sanitizer=thread fuzz_target_1
    ```
 
@@ -122,19 +122,19 @@ Getting code coverage data for fuzz tests requires some different tooling than w
 
 1. Run the fuzz tests until it has produced a corpus, just as in step 7 above.
 
-   ```
+   ```text
    cargo +nightly fuzz run --sanitizer thread fuzz_target_1
    ```
 
 2. Install the llvm-tools for the nightly compiler.
 
-   ```
+   ```text
    rustup component add --toolchain nightly llvm-tools-preview
    ```
 
 3. Run the fuzz coverage command that'll execute the corpus and write coverage data to the coverage directory in the `profdata` format.
 
-   ```
+   ```text
    cargo +nightly fuzz coverage --sanitizer thread fuzz_target_1
    ```
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -15,13 +15,13 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 1. Install `cargo-fuzz`.
 
-   ```shell
+   ```
    cargo install --locked cargo-fuzz
    ```
 
 2. Initialize a fuzz project by running the following command inside your contract directory.
 
-   ```shell
+   ```
    cargo fuzz init
    ```
 
@@ -87,7 +87,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 7. Execute the fuzz target.
 
-   ```shell
+   ```
    cargo +nightly fuzz run --sanitizer=thread fuzz_target_1
    ```
 


### PR DESCRIPTION
### What
Change the formatting of the code blocks on the fuzzing guide from 'shell' to nothing.

### Why
Shell formatting shouldn't be used for simple commands, otherwise the formatter will highly random arguments that happen to fit shell keywords.