### PR TITLE
use contract.Client.from instead of just contract.Client

### DIFF
--- a/docs/learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx
+++ b/docs/learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx
@@ -80,7 +80,7 @@ To create a contract client for the same contract as shown for `contract invoke`
 
 ```js
 import { contract } from "@stellar/stellar-sdk";
-const xlm = contract.Client({
+const xlm = contract.Client.from({
   contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
   networkPassphrase: "Test SDF Network ; September 2015",
   rpcUrl: "https://soroban-testnet.stellar.org",


### PR DESCRIPTION
I think it meant to use `contract.Client.from` since its example doesn't include spec as the first argument.

[js-stellar-sdk doc](https://stellar.github.io/js-stellar-sdk/module-contract.Client.html) as a reference