### PR TITLE
update the translations fix script to include MDX comments

### DIFF
--- a/scripts/fix_translations.sh
+++ b/scripts/fix_translations.sh
@@ -2,3 +2,5 @@
 
 perl -i -pe's/\s\{/ \\{/g' i18n/es/docusaurus-plugin-content-docs/current/learn/fundamentals/transactions/list-of-operations.mdx
 perl -i -pe's/<\s(.*\.mdx)>/\1/' i18n/es/docusaurus-plugin-content-docs-ap/**/admin-guide/component/observer/observer.mdx
+find i18n/es/docusaurus-plugin-content-docs/current -type f -print0 | xargs -0 perl -i -pe's/{\/_/{\/\*/'
+find i18n/es/docusaurus-plugin-content-docs/current -type f -print0 | xargs -0 perl -i -pe's/_\/}/\*\/}/'


### PR DESCRIPTION
Crowdin does some kind of "processing" or "parsing" to MDX files, when we use the `crowdin download` command. This replaces any occurence of MDX comments like `{/* ... */}` with `{/_ ... _/}`. I think this is because it assumes the single-`*` asterisks are meant to denote underline syntax, so it replaces them with the configured underline character, `_`.

Anyway, this changes our fixup script to account for that. It uses find and xargs to replace any instances of those errant non-comment strings, and replaces them with valid MDX comments, resulting in builds that actually build.