### PR TITLE
Add Rust Libraries to SDKs Documentation

### DIFF
--- a/docs/tools/sdks/library.mdx
+++ b/docs/tools/sdks/library.mdx
@@ -61,7 +61,7 @@ It provides:
 
 ### Rust
 
-Some of the functionality found in Stellar SDK's is found in the following Rust crates:
+Functionality for interacting with Stellar data can found in the following Rust crates:
 
 - `stellar-xdr` – [Code](https://github.com/stellar/rs-stellar-xdr) | [Docs](https://docs.rs/stellar-xdr)
 

--- a/docs/tools/sdks/library.mdx
+++ b/docs/tools/sdks/library.mdx
@@ -59,6 +59,22 @@ It provides:
 - A networking layer API for Horizon endpoints.
 - Facilities for building and signing transactions, for communicating with a Stellar Horizon instance, and for submitting transactions or querying network history.
 
+### Rust
+
+Some of the functionality found in Stellar SDK's is found in the following Rust crates:
+
+- `stellar-xdr` – [Code](https://github.com/stellar/rs-stellar-xdr) | [Docs](https://docs.rs/stellar-xdr)
+
+   Provides [XDR] encode/decode and the reference implementation of [XDR-JSON].
+
+- `stellar-strkey` – [Code](https://github.com/stellar/rs-stellar-strkey) | [Docs](https://docs.rs/stellar-strkey)
+
+   Provides Stellar Strkey (Address) [SEP-23] encoding/decoding.
+
+[XDR]: ../../learn/encyclopedia/data-format/xdr
+[XDR-JSON]: ../../learn/encyclopedia/data-format/xdr#json-and-xdr-conversion-schema
+[SEP-23]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md
+
 ### iOS SDK
 
 [iOS SDK](https://github.com/Soneso/stellar-ios-mac-sdk) | [Docs](https://github.com/Soneso/stellar-ios-mac-sdk/tree/master/docs) | [Smart Contract Docs](https://github.com/Soneso/stellar-ios-mac-sdk/blob/master/soroban.md)

--- a/docs/tools/sdks/library.mdx
+++ b/docs/tools/sdks/library.mdx
@@ -65,11 +65,11 @@ Functionality for interacting with Stellar data can found in the following Rust 
 
 - `stellar-xdr` – [Code](https://github.com/stellar/rs-stellar-xdr) | [Docs](https://docs.rs/stellar-xdr)
 
-   Provides [XDR] encode/decode and the reference implementation of [XDR-JSON].
+  Provides [XDR] encode/decode and the reference implementation of [XDR-JSON].
 
 - `stellar-strkey` – [Code](https://github.com/stellar/rs-stellar-strkey) | [Docs](https://docs.rs/stellar-strkey)
 
-   Provides Stellar Strkey (Address) [SEP-23] encoding/decoding.
+  Provides Stellar Strkey (Address) [SEP-23] encoding/decoding.
 
 [XDR]: ../../learn/encyclopedia/data-format/xdr
 [XDR-JSON]: ../../learn/encyclopedia/data-format/xdr#json-and-xdr-conversion-schema

--- a/docs/tools/sdks/library.mdx
+++ b/docs/tools/sdks/library.mdx
@@ -61,7 +61,7 @@ It provides:
 
 ### Rust
 
-Functionality for interacting with Stellar data can found in the following Rust crates:
+Functionality for interacting with Stellar data can be found in the following Rust crates:
 
 - `stellar-xdr` – [Code](https://github.com/stellar/rs-stellar-xdr) | [Docs](https://docs.rs/stellar-xdr)
 


### PR DESCRIPTION
### What
Add Stellar Rust libraries stellar-xdr and stellar-strkey to the SDKs page.

### Why
Rust libraries are absent from the SDKs page in the docs. The stellar-xdr crate is one of the earliest available XDR libs because it's a dependency of Core, and is used in Soroban, the Contract SDK, Lab, CLI, meaning it's available early in releases, and reliable, and tested across multiple products.