### PR TITLE
Move RFC4506 reference in XDR documentation higher

### DIFF
--- a/docs/learn/encyclopedia/data-format/xdr.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr.mdx
@@ -4,7 +4,7 @@ title: XDR
 
 import { CodeExample } from "@site/src/components/CodeExample";
 
-Stellar stores and communicates ledger data, transactions, results, history, and messages in a binary format called External Data Representation (XDR). XDR is defined in [RFC4506](http://tools.ietf.org/html/rfc4506.html). XDR is optimized for network performance but not human readable. Horizon and the Stellar SDKs convert XDRs into friendlier formats.
+Stellar stores and communicates ledger data, transactions, results, history, and messages in a binary format called External Data Representation (XDR). XDR is defined in [RFC4506]. XDR is optimized for network performance but not human readable. Horizon and the Stellar SDKs convert XDRs into friendlier formats.
 
 ## .X files
 

--- a/docs/learn/encyclopedia/data-format/xdr.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr.mdx
@@ -4,7 +4,7 @@ title: XDR
 
 import { CodeExample } from "@site/src/components/CodeExample";
 
-Stellar stores and communicates ledger data, transactions, results, history, and messages in a binary format called External Data Representation (XDR). XDR is defined in [RFC4506]. XDR is optimized for network performance but not human readable. Horizon and the Stellar SDKs convert XDRs into friendlier formats.
+Stellar stores and communicates ledger data, transactions, results, history, and messages in a binary format called External Data Representation (XDR). XDR is defined in [RFC4506](http://tools.ietf.org/html/rfc4506.html). XDR is optimized for network performance but not human readable. Horizon and the Stellar SDKs convert XDRs into friendlier formats.
 
 ## .X files
 

--- a/docs/learn/encyclopedia/data-format/xdr.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr.mdx
@@ -32,8 +32,6 @@ The defined schema (linked above) is **not** backwards compatible between a give
 
 :::
 
-[RFC 4506]: http://tools.ietf.org/html/rfc4506.html
-
 ## More About XDR
 
 XDR is similar to tools like Protocol Buffers or Thrift. XDR provides a few important features:
@@ -237,3 +235,5 @@ There are many cases in which the different union arms share structure, and `.va
 This overview should give you a strong baseline on understanding how to inspect XDR in your respective SDK to dig into the fields that you're interested in. Specifics will, of course, be language dependent, but if you start at the foundation--that being the raw [.x files](#.x-files) themselves--you will get an understanding of the structure itself and should be able to access that same structure directly in your language of choice, as we've outlined here.
 
 {/* TODO: Room to expand much more: Tools -> CLI Visualization, JSON Visualization, Stellar Lab */}
+
+[RFC 4506]: http://tools.ietf.org/html/rfc4506.html

--- a/docs/learn/encyclopedia/data-format/xdr.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr.mdx
@@ -4,7 +4,7 @@ title: XDR
 
 import { CodeExample } from "@site/src/components/CodeExample";
 
-Stellar stores and communicates ledger data, transactions, results, history, and messages in a binary format called External Data Representation (XDR). XDR is optimized for network performance but not human readable. Horizon and the Stellar SDKs convert XDRs into friendlier formats.
+Stellar stores and communicates ledger data, transactions, results, history, and messages in a binary format called External Data Representation (XDR). XDR is defined in [RFC4506]. XDR is optimized for network performance but not human readable. Horizon and the Stellar SDKs convert XDRs into friendlier formats.
 
 ## .X files
 
@@ -32,9 +32,11 @@ The defined schema (linked above) is **not** backwards compatible between a give
 
 :::
 
+[RFC 4506]: http://tools.ietf.org/html/rfc4506.html
+
 ## More About XDR
 
-XDR is specified in [RFC 4506](http://tools.ietf.org/html/rfc4506.html) and is similar to tools like Protocol Buffers or Thrift. XDR provides a few important features:
+XDR is similar to tools like Protocol Buffers or Thrift. XDR provides a few important features:
 
 - It is very compact, so it can be transmitted quickly and stored with minimal disk space.
 - Data encoded in XDR is reliably and predictably stored. Fields are always in the same order, which makes cryptographically signing and verifying XDR messages simple.


### PR DESCRIPTION
### What
Move the RFC 4506 reference higher in the XDR doc.

### Why
For a lot of folks in the ecosystem who have only seen XDR used on Stellar and nowhere else, it's easy to think this is just some weird format that Stellar uses. But it's a well defined format in RFC4506, which is cheap to mention straight up at the top of the page. Mentioning it early helps to shape the context on what the format is.