### PR TITLE
Add JSON RPC Request and Response Examples

### DIFF
--- a/docs/data/rpc/api-reference/json-rpc.mdx
+++ b/docs/data/rpc/api-reference/json-rpc.mdx
@@ -17,6 +17,32 @@ Please note that parameter structure must contain named parameters as a by-name 
 
 :::
 
+## Example Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "method": "getTransaction",
+  "params": {
+    "hash": "5ee7e055afb3b0b13fd6ac6d8adb11f799df8593448e23ad93454fefc387bbfa"
+  }
+}
+```
+
+## Example Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "status": "SUCCESS",
+    // ...
+  }
+}
+```
+
 ## Open-RPC Specification
 
 Stellar-RPC provides an [OpenRPC] specification document that can be used to mock, build, and/or validate both server and client software implementations. This document is used to generate all of our [methods] documentation pages. You can view the full [specification document here]. Additionally, you can experiment with this specificaiton document in the [OpenRPC Playground].

--- a/docs/data/rpc/api-reference/json-rpc.mdx
+++ b/docs/data/rpc/api-reference/json-rpc.mdx
@@ -32,7 +32,7 @@ Please note that parameter structure must contain named parameters as a by-name 
 
 ## Example Response
 
-```json
+```js
 {
   "jsonrpc": "2.0",
   "id": "1",


### PR DESCRIPTION
### What
Add example JSON RPC request and response on the page that discusses JSON-RPC.

### Why
For readers who are visual it is helpful to illustrate what the format is. While this is no replacement for reading the spec and understanding it in greater detail, it's helps to quickly demystify it.