### PR TITLE
Move XDR-JSON details into separate page

### DIFF
--- a/docs/learn/encyclopedia/data-format/xdr-json.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr-json.mdx
@@ -14,7 +14,7 @@ The JSON-Schema for the XDR-JSON format can be found using the [`stellar xdr typ
 ## Tools
 
 - [Stellar CLI > `stellar xdr`](../../../tools/developer-tools/cli/stellar-cli.mdx#stellar-xdr)
-- [Lab > View XDR](../../../tools/developer-tools/lab.mdx)
+- [Lab > View XDR](../../../tools/developer-tools/lab)
 
 ## Libraries
 

--- a/docs/learn/encyclopedia/data-format/xdr-json.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr-json.mdx
@@ -38,5 +38,5 @@ The defined schema (linked above) is **not** backwards compatible between a give
 
 :::
 
-[XDR]: /learn/encyclopedia/data-format/xdr
+[XDR]: xdr
 [`stellar xdr types schema`]: ../../../tools/developer-tools/cli/stellar-cli#stellar-xdr-types-schema

--- a/docs/learn/encyclopedia/data-format/xdr-json.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr-json.mdx
@@ -39,4 +39,4 @@ The defined schema (linked above) is **not** backwards compatible between a give
 :::
 
 [XDR]: xdr
-[`stellar xdr types schema`]: ../../../tools/developer-tools/cli/stellar-cli#stellar-xdr-types-schema
+[`stellar xdr types schema`]: ../../../tools/developer-tools/cli/stellar-cli.mdx#stellar-xdr-types-schema

--- a/docs/learn/encyclopedia/data-format/xdr-json.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr-json.mdx
@@ -13,8 +13,8 @@ The JSON-Schema for the XDR-JSON format can be found using the [`stellar xdr typ
 
 ## Tools
 
-- [Stellar CLI > `stellar xdr`](../../../tools/developer-tools/cli/stellar-cli#stellar-xdr)
-- [Lab > View XDR](../../../tools/developer-tools/lab)
+- [Stellar CLI > `stellar xdr`](../../../tools/developer-tools/cli/stellar-cli.mdx#stellar-xdr)
+- [Lab > View XDR](../../../tools/developer-tools/lab.mdx)
 
 ## Libraries
 

--- a/docs/learn/encyclopedia/data-format/xdr-json.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr-json.mdx
@@ -1,0 +1,42 @@
+---
+title: XDR-JSON
+sidebar_position: 2
+---
+
+import { CodeExample } from "@site/src/components/CodeExample";
+
+The XDR-JSON schema is defined by the [stellar-xdr crate](https://docs.rs/stellar-xdr) and provides a round-trippable means for converting Stellar [XDR] values to JSON and converting that JSON back to the identical XDR.
+
+Converting with the schema is also exposed by the following tools and libraries.
+
+The JSON-Schema for the XDR-JSON format can be found using the [`stellar xdr types schema`] command.
+
+## Tools
+
+- [Stellar CLI > `stellar xdr`](../../../tools/developer-tools/cli/stellar-cli#stellar-xdr)
+- [Lab > View XDR](../../../tools/developer-tools/lab)
+
+## Libraries
+- [stellar-xdr](https://docs.rs/stellar-xdr) rust crate
+- [@stellar/stellar-xdr-json](https://www.npmjs.com/package/@stellar/stellar-xdr-json) npm package
+- [github.com/stellar/go-stellar-xdr-json](https://github.com/stellar/go-stellar-xdr-json) go package
+
+## Key Characteristics of the JSON and XDR Conversion Schema
+
+- **Round-Trippable:** The JSON format allows for converting from XDR to JSON and back to XDR without loss of information.
+
+- **Self-Describing:** The JSON format describes the internals of the type but does not identify the type that is encoded. This is similar to XDR, which also does not identify the encoded type.
+
+- **64-bit Integers:** The JSON format includes integers up to 64-bit in size. JavaScript runtimes do not support 64-bit integers, so a custom decoder must be used, such as [lossless-json](https://www.npmjs.com/package/lossless-json).
+
+- **Escaped ASCII Strings:** The JSON format includes strings that are UTF-8 safe, escaped ASCII strings. This is because XDR strings are not UTF-8 encoded, but are instead byte streams that can contain any values. Non-ASCII characters are escaped.
+
+:::info[backwards-incompatible]
+
+The defined schema (linked above) is **not** backwards compatible between a given protocol version and prior versions. The best practice is to store required ledger data in XDR format, not in JSON format.
+
+:::
+
+[XDR]: /learn/encyclopedia/data-format/xdr
+[`stellar xdr types schema`]: ../../../tools/developer-tools/cli/stellar-cli#stellar-xdr-types-schema
+

--- a/docs/learn/encyclopedia/data-format/xdr-json.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr-json.mdx
@@ -17,6 +17,7 @@ The JSON-Schema for the XDR-JSON format can be found using the [`stellar xdr typ
 - [Lab > View XDR](../../../tools/developer-tools/lab)
 
 ## Libraries
+
 - [stellar-xdr](https://docs.rs/stellar-xdr) rust crate
 - [@stellar/stellar-xdr-json](https://www.npmjs.com/package/@stellar/stellar-xdr-json) npm package
 - [github.com/stellar/go-stellar-xdr-json](https://github.com/stellar/go-stellar-xdr-json) go package
@@ -39,4 +40,3 @@ The defined schema (linked above) is **not** backwards compatible between a give
 
 [XDR]: /learn/encyclopedia/data-format/xdr
 [`stellar xdr types schema`]: ../../../tools/developer-tools/cli/stellar-cli#stellar-xdr-types-schema
-

--- a/docs/learn/encyclopedia/data-format/xdr.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr.mdx
@@ -222,4 +222,4 @@ This overview should give you a strong baseline on understanding how to inspect 
 {/* TODO: Room to expand much more: Tools -> CLI Visualization, JSON Visualization, Stellar Lab */}
 
 [RFC4506]: http://tools.ietf.org/html/rfc4506.html
-[XDR-JSON]: xdr-json
+[XDR-JSON]: ./xdr-json.mdx

--- a/docs/learn/encyclopedia/data-format/xdr.mdx
+++ b/docs/learn/encyclopedia/data-format/xdr.mdx
@@ -1,5 +1,6 @@
 ---
 title: XDR
+sidebar_position: 1
 ---
 
 import { CodeExample } from "@site/src/components/CodeExample";
@@ -10,25 +11,9 @@ Stellar stores and communicates ledger data, transactions, results, history, and
 
 Data structures in XDR are specified in `.x` files. These files _only_ contain data structure definitions, no operations or executable code. The `.x` files for the XDR structures used on the Stellar Network are available on [GitHub](https://github.com/stellar/stellar-xdr).
 
-## JSON and XDR Conversion Schema
+:::tip
 
-The canonical JSON and XDR Schema is defined by the [stellar-xdr crate](https://docs.rs/stellar-xdr) and also exposed by the [@stellar/stellar-xdr-json npm package](https://www.npmjs.com/package/@stellar/stellar-xdr-json). The schema provides a round-trippable means for converting any Stellar XDR type to JSON and converting that JSON back to the identical XDR.
-
-This conversion is visible in the Stellar CLI, Lab View XDR, and Hubble events table.
-
-### Key Characteristics of the JSON and XDR Conversion Schema
-
-- **Round-Trippable:** The JSON format allows for converting from XDR to JSON and back to XDR without loss of information.
-
-- **Self-Describing:** The JSON format describes the internals of the type but does not identify the type that is encoded. This is similar to XDR, which also does not identify the encoded type.
-
-- **64-bit Integers:** The JSON format includes integers up to 64-bit in size. JavaScript runtimes do not support 64-bit integers, so a custom decoder must be used, such as [lossless-json](https://www.npmjs.com/package/lossless-json).
-
-- **Escaped ASCII Strings:** The JSON format includes strings that UTF-8 safe, escaped ASCII strings. This is because XDR strings are not UTF-8 encoded, but are instead byte streams that can contain any values. Non-ASCII characters are escaped.
-
-:::info[backwards-incompatible]
-
-The defined schema (linked above) is **not** backwards compatible between a given protocol version and prior versions. The best practice is to store required ledger data in XDR format, not in JSON format.
+Stellar XDR is encodable into JSON using the [XDR-JSON] schema.
 
 :::
 
@@ -237,3 +222,4 @@ This overview should give you a strong baseline on understanding how to inspect 
 {/* TODO: Room to expand much more: Tools -> CLI Visualization, JSON Visualization, Stellar Lab */}
 
 [RFC4506]: http://tools.ietf.org/html/rfc4506.html
+[XDR-JSON]: xdr-json

--- a/docs/tools/sdks/library.mdx
+++ b/docs/tools/sdks/library.mdx
@@ -81,7 +81,7 @@ Functionality for interacting with Stellar data can be found in the following Ru
   Provides Stellar Strkey (Address) [SEP-23] encoding/decoding.
 
 [XDR]: ../../learn/encyclopedia/data-format/xdr
-[XDR-JSON]: ../../learn/encyclopedia/data-format/xdr#json-and-xdr-conversion-schema
+[XDR-JSON]: ../../learn/encyclopedia/data-format/xdr-json
 [SEP-23]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md
 
 ### iOS SDK

--- a/docs/tools/sdks/library.mdx
+++ b/docs/tools/sdks/library.mdx
@@ -81,7 +81,7 @@ Functionality for interacting with Stellar data can be found in the following Ru
   Provides Stellar Strkey (Address) [SEP-23] encoding/decoding.
 
 [XDR]: ../../learn/encyclopedia/data-format/xdr
-[XDR-JSON]: ../../learn/encyclopedia/data-format/xdr-json
+[XDR-JSON]: ../../learn/encyclopedia/data-format/xdr-json.mdx
 [SEP-23]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0023.md
 
 ### iOS SDK


### PR DESCRIPTION
### What
Create a new XDR-JSON schema page that contains details about the JSON and XDR conversion schema, tools, libraries, etc.

### Why
It is worth discussing in isolation, so that we can build out documentation about it, link to it, and add more details without taking over the main page about XDR itself.

cc @stellar/devx 