### PR TITLE
[ANCHOR-963] Event processor not started in the stellar docs docker compose example

### DIFF
--- a/ap_versioned_docs/version-2.10/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.10/admin-guide/getting-started.mdx
@@ -30,22 +30,14 @@ Let's create a minimal compose file to get started.
 services:
   sep-server:
     image: stellar/anchor-platform:2.10.0
-    command: --sep-server
-    ports:
-      - "8080:8080"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-  platform-server:
-    image: stellar/anchor-platform:2.10.0
-    command: --platform-server
-    ports:
-      - "8085:8085"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
+     command: --sep-server --platform-server --event-processor
+     ports:
+       - "8080:8080"
+       - "8085:8085"
+     env_file:
+       - ./dev.env
+     volumes:
+       - ./config:/home
 ```
 
 </CodeExample>
@@ -210,18 +202,7 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:2.10.0
-    command: --sep-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:2.10.0
-    command: --platform-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:

--- a/ap_versioned_docs/version-2.10/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.10/admin-guide/getting-started.mdx
@@ -46,6 +46,8 @@ The `--sep-server` option tells the Anchor Platform to make the API endpoints de
 
 The `--platform-sever` option makes the Platform API available, which is the backend API your service(s) will use to communicate with the Anchor Platform. It will be available on port 8085
 
+The `--event-server` option makes the Event Processor available, which drives the communication between the Anchor Platform services and the business server.
+
 ## Configuration
 
 The Anchor Platform supports two approaches for configuration:

--- a/ap_versioned_docs/version-2.10/admin-guide/sep31/integration.mdx
+++ b/ap_versioned_docs/version-2.10/admin-guide/sep31/integration.mdx
@@ -30,23 +30,13 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:2.10.0
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:
       - ./config:/home
     ports:
       - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:2.10.0
-    command: --platform-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
       - "8085:8085"
     depends_on:
       - db

--- a/ap_versioned_docs/version-2.11/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.11/admin-guide/getting-started.mdx
@@ -46,6 +46,8 @@ The `--sep-server` option tells the Anchor Platform to make the API endpoints de
 
 The `--platform-sever` option makes the Platform API available, which is the backend API your service(s) will use to communicate with the Anchor Platform. It will be available on port 8085
 
+The `--event-server` option makes the Event Processor available, which drives the communication between the Anchor Platform services and the business server.
+
 ## Configuration
 
 The Anchor Platform supports two approaches for configuration:

--- a/ap_versioned_docs/version-2.11/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.11/admin-guide/getting-started.mdx
@@ -30,17 +30,9 @@ Let's create a minimal compose file to get started.
 services:
   sep-server:
     image: stellar/anchor-platform:2.11.0
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     ports:
       - "8080:8080"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-  platform-server:
-    image: stellar/anchor-platform:2.11.0
-    command: --platform-server
-    ports:
       - "8085:8085"
     env_file:
       - ./dev.env
@@ -210,18 +202,7 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:2.11.0
-    command: --sep-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:2.11.0
-    command: --platform-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:

--- a/ap_versioned_docs/version-2.11/admin-guide/sep31/integration.mdx
+++ b/ap_versioned_docs/version-2.11/admin-guide/sep31/integration.mdx
@@ -30,23 +30,13 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:2.11.0
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:
       - ./config:/home
     ports:
       - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:2.11.0
-    command: --platform-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
       - "8085:8085"
     depends_on:
       - db

--- a/ap_versioned_docs/version-2.8/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.8/admin-guide/getting-started.mdx
@@ -30,17 +30,9 @@ Let's create a minimal compose file to get started.
 services:
   sep-server:
     image: stellar/anchor-platform:2.8.4
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     ports:
       - "8080:8080"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-  platform-server:
-    image: stellar/anchor-platform:2.8.4
-    command: --platform-server
-    ports:
       - "8085:8085"
     env_file:
       - ./dev.env
@@ -210,18 +202,7 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:2.8.4
-    command: --sep-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:2.8.4
-    command: --platform-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:

--- a/ap_versioned_docs/version-2.8/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.8/admin-guide/getting-started.mdx
@@ -46,6 +46,7 @@ The `--sep-server` option tells the Anchor Platform to make the API endpoints de
 
 The `--platform-sever` option makes the Platform API available, which is the backend API your service(s) will use to communicate with the Anchor Platform. It will be available on port 8085
 
+The `--event-server` option makes the Event Processor available, which drives the communication between the Anchor Platform services and the business server.
 ## Configuration
 
 The Anchor Platform supports two approaches for configuration:

--- a/ap_versioned_docs/version-2.8/admin-guide/sep31/integration.mdx
+++ b/ap_versioned_docs/version-2.8/admin-guide/sep31/integration.mdx
@@ -30,26 +30,16 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:2.8.4
-    command: --sep-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:2.8.4
-    command: --platform-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8085:8085"
-    depends_on:
-      - db
+     command: --sep-server --platform-server --event-processor
+     env_file:
+       - ./dev.env
+     volumes:
+       - ./config:/home
+     ports:
+       - "8080:8080"
+       - "8085:8085"
+     depends_on:
+       - db
 
   server:
     build: .

--- a/ap_versioned_docs/version-2.9/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.9/admin-guide/getting-started.mdx
@@ -30,17 +30,9 @@ Let's create a minimal compose file to get started.
 services:
   sep-server:
     image: stellar/anchor-platform:2.9.0
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     ports:
       - "8080:8080"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-  platform-server:
-    image: stellar/anchor-platform:2.9.0
-    command: --platform-server
-    ports:
       - "8085:8085"
     env_file:
       - ./dev.env

--- a/ap_versioned_docs/version-2.9/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-2.9/admin-guide/getting-started.mdx
@@ -46,6 +46,7 @@ The `--sep-server` option tells the Anchor Platform to make the API endpoints de
 
 The `--platform-sever` option makes the Platform API available, which is the backend API your service(s) will use to communicate with the Anchor Platform. It will be available on port 8085
 
+The `--event-server` option makes the Event Processor available, which drives the communication between the Anchor Platform services and the business server.
 ## Configuration
 
 The Anchor Platform supports two approaches for configuration:

--- a/ap_versioned_docs/version-2.9/admin-guide/sep31/integration.mdx
+++ b/ap_versioned_docs/version-2.9/admin-guide/sep31/integration.mdx
@@ -41,12 +41,13 @@ services:
       - db
   platform-server:
     image: stellar/anchor-platform:2.9.0
-    command: --platform-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:
       - ./config:/home
     ports:
+      - "8080:8080"
       - "8085:8085"
     depends_on:
       - db

--- a/ap_versioned_docs/version-3.0/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-3.0/admin-guide/getting-started.mdx
@@ -29,23 +29,15 @@ Let's create a minimal compose file to get started.
 # docker-compose.yml
 services:
   sep-server:
-    image: stellar/anchor-platform:latest
-    command: --sep-server
-    ports:
-      - "8080:8080"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-  platform-server:
-    image: stellar/anchor-platform:latest
-    command: --platform-server
-    ports:
-      - "8085:8085"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
+    image: stellar/anchor-platform:3.0.0
+     command: --sep-server --platform-server --event-processor
+     ports:
+       - "8080:8080"
+       - "8085:8085"
+     env_file:
+       - ./dev.env
+     volumes:
+       - ./config:/home
 ```
 
 </CodeExample>
@@ -208,18 +200,7 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:latest
-    command: --sep-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:latest
-    command: --platform-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:

--- a/ap_versioned_docs/version-3.0/admin-guide/getting-started.mdx
+++ b/ap_versioned_docs/version-3.0/admin-guide/getting-started.mdx
@@ -46,6 +46,7 @@ The `--sep-server` option tells the Anchor Platform to make the API endpoints de
 
 The `--platform-sever` option makes the Platform API available, which is the backend API your service(s) will use to communicate with the Anchor Platform. It will be available on port 8085
 
+The `--event-server` option makes the Event Processor available, which drives the communication between the Anchor Platform services and the business server.
 ## Configuration
 
 The Anchor Platform supports two approaches for configuration:

--- a/ap_versioned_docs/version-3.0/admin-guide/sep31/integration.mdx
+++ b/ap_versioned_docs/version-3.0/admin-guide/sep31/integration.mdx
@@ -28,23 +28,13 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:latest
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:
       - ./config:/home
     ports:
       - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:latest
-    command: --platform-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
       - "8085:8085"
     depends_on:
       - db

--- a/platforms/anchor-platform/admin-guide/getting-started.mdx
+++ b/platforms/anchor-platform/admin-guide/getting-started.mdx
@@ -30,17 +30,9 @@ Let's create a minimal compose file to get started.
 services:
   sep-server:
     image: stellar/anchor-platform:latest
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     ports:
       - "8080:8080"
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-  platform-server:
-    image: stellar/anchor-platform:latest
-    command: --platform-server
-    ports:
       - "8085:8085"
     env_file:
       - ./dev.env
@@ -208,18 +200,7 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:latest
-    command: --sep-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
-      - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:latest
-    command: --platform-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:

--- a/platforms/anchor-platform/admin-guide/getting-started.mdx
+++ b/platforms/anchor-platform/admin-guide/getting-started.mdx
@@ -46,6 +46,8 @@ The `--sep-server` option tells the Anchor Platform to make the API endpoints de
 
 The `--platform-sever` option makes the Platform API available, which is the backend API your service(s) will use to communicate with the Anchor Platform. It will be available on port 8085
 
+The `--event-server` option makes the Event Processor available, which drives the communication between the Anchor Platform services and the business server.
+
 ## Configuration
 
 The Anchor Platform supports two approaches for configuration:

--- a/platforms/anchor-platform/admin-guide/sep31/integration.mdx
+++ b/platforms/anchor-platform/admin-guide/sep31/integration.mdx
@@ -28,23 +28,13 @@ version: "3.8"
 services:
   sep-server:
     image: stellar/anchor-platform:latest
-    command: --sep-server
+    command: --sep-server --platform-server --event-processor
     env_file:
       - ./dev.env
     volumes:
       - ./config:/home
     ports:
       - "8080:8080"
-    depends_on:
-      - db
-  platform-server:
-    image: stellar/anchor-platform:latest
-    command: --platform-server
-    env_file:
-      - ./dev.env
-    volumes:
-      - ./config:/home
-    ports:
       - "8085:8085"
     depends_on:
       - db


### PR DESCRIPTION
Event processor not started in the stellar docs docker compose example of the `Getting Started` and `Integration` guides.