### PR TITLE
Fixed invoke example #1177

### DIFF
--- a/docs/build/smart-contracts/example-contracts/custom-types.mdx
+++ b/docs/build/smart-contracts/example-contracts/custom-types.mdx
@@ -248,7 +248,7 @@ target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm
 
 ## Run the Contract
 
-If you have [`stellar-cli`] installed, you can invoke contract functions in the Wasm using it.
+If you have [`stellar-cli`] installed, you can [deploy] and invoke contract function.
 
 <Tabs groupId="platform" defaultValue={getPlatform()}>
 
@@ -256,8 +256,9 @@ If you have [`stellar-cli`] installed, you can invoke contract functions in the 
 
 ```sh
 stellar contract invoke \
-    --wasm target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm \
-    --id 1 \
+    --id CACDYF3CYMJEJTIVFESQYZTN67GO2R5D5IUABTCUG3HXQSRXCSOROBAN \
+    --source alice \
+    --network testnet \
     -- \
     increment \
     --incr 5
@@ -269,8 +270,9 @@ stellar contract invoke \
 
 ```powershell
 stellar contract invoke `
-    --wasm target/wasm32-unknown-unknown/release/soroban_custom_types_contract.wasm `
-    --id 1 `
+    --id CACDYF3CYMJEJTIVFESQYZTN67GO2R5D5IUABTCUG3HXQSRXCSOROBAN `
+    --source alice `
+    --network testnet `
     -- `
     increment `
     --incr 5
@@ -299,3 +301,4 @@ STATE,"{""count"":25,""last_incr"":15}"
 ```
 
 [`stellar-cli`]: ../getting-started/setup.mdx#install-the-stellar-cli
+[deploy]: ../getting-started/deploy-to-testnet


### PR DESCRIPTION
The invoke command used the `--wasm` parameter, which is not supported.