### PR TITLE
Change code block syntax highlighting in CLI install docs

### DIFF
--- a/docs/tools/developer-tools/cli/install-cli.mdx
+++ b/docs/tools/developer-tools/cli/install-cli.mdx
@@ -12,13 +12,13 @@ There are a few ways to install the latest released version of Stellar CLI.
 
 Install with Homebrew (macOS, Linux):
 
-```sh
+```text
 brew install stellar-cli
 ```
 
 Install with cargo from source:
 
-```sh
+```text
 cargo install --locked stellar-cli --features opt
 ```
 
@@ -26,7 +26,7 @@ cargo install --locked stellar-cli --features opt
 
 The Stellar CLI supports some autocompletion. To set up, run the following commands:
 
-```sh
+```text
 stellar completion --shell <SHELL>
 ```
 
@@ -34,13 +34,13 @@ Possible SHELL values are `bash`, `elvish`, `fish`, `powershell`, `zsh`, etc.
 
 To enable autocomplete in the current bash shell, run:
 
-```sh
+```text
 source <(stellar completion --shell bash)
 ```
 
 To enable autocomplete permanently, run:
 
-```sh
+```text
 echo "source <(stellar completion --shell bash)" >> ~/.bashrc
 ```
 


### PR DESCRIPTION
### What
Change the shell code block syntax highlighting from `sh` to `text` in the CLI install docs.

### Why
The text syntax highlighting provides more consistent rendering of shell commands without attempting to parse them as shell scripts. The commands are afterall just commands to be typed at the terminal, and aren't bash or shell scripts.