### PR TITLE
Move CLI source link in installation docs

### DIFF
--- a/docs/tools/developer-tools/cli/install-cli.mdx
+++ b/docs/tools/developer-tools/cli/install-cli.mdx
@@ -6,7 +6,7 @@ sidebar_position: 50
 
 # Install the Stellar CLI
 
-### [Stellar CLI](https://github.com/stellar/stellar-cli)
+### Stellar CLI
 
 There are a few ways to install the latest released version of Stellar CLI.
 
@@ -16,7 +16,7 @@ Install with Homebrew (macOS, Linux):
 brew install stellar-cli
 ```
 
-Install with cargo from source:
+Install with cargo from source ([github.com/stellar/stellar-cli](https://github.com/stellar/stellar-cli)):
 
 ```sh
 cargo install --locked stellar-cli --features opt


### PR DESCRIPTION
### What
Move the CLI GitHub source link from the title to below the source installation instructions.

### Why
The link on the heading makes the heading look odd compared to the other headings on the page. It also wasn't obvious to me that it was linking to the code. I'm not sure where we can put an explicit link to the code, so I just added it next to where it discusses the source.