### PR TITLE
Add Windows installation method using winget to cli install page

### DIFF
--- a/docs/tools/developer-tools/cli/install-cli.mdx
+++ b/docs/tools/developer-tools/cli/install-cli.mdx
@@ -16,6 +16,12 @@ Install with Homebrew (macOS, Linux):
 brew install stellar-cli
 ```
 
+Install with winget (Windows):
+
+```text
+winget install --id Stellar.StellarCLI
+```
+
 Install with cargo from source:
 
 ```sh


### PR DESCRIPTION
### What
Add windows install method using winget to the cli install page.

### Why
The install method is promoted on the build setup page, but not on the cli page.