### PR TITLE
Move Sora details into a note on CLI page

### DIFF
--- a/docs/tools/developer-tools/cli/README.mdx
+++ b/docs/tools/developer-tools/cli/README.mdx
@@ -1,12 +1,10 @@
 ---
-title: CLI
-description: Explore a suite of developer tools for Stellar, including CLI.
+title: Stellar CLI
+description: The CLI for interacting with the Stellar network
 sidebar_position: 50
 ---
 
-# CLI
-
-### [Stellar CLI](https://github.com/stellar/stellar-cli)
+# Stellar CLI
 
 The command line interface to Soroban smart contracts. It allows you to build, deploy, and interact with smart contracts; configure identities; generate key pairs; manage networks; and more.
 

--- a/docs/tools/developer-tools/cli/README.mdx
+++ b/docs/tools/developer-tools/cli/README.mdx
@@ -14,6 +14,10 @@ Install Stellar CLI as explained in [Setup](../../../build/smart-contracts/getti
 
 The auto-generated comprehensive reference documentation is available [here](stellar-cli.mdx).
 
-### [Sora](https://github.com/tolgayayci/sora)
+:::note
 
-Sora is a cross platform GUI designed to simplify use of Stellar CLI. It offers a user-friendly interface for managing projects, identities, networks, contract methods, events, logs and so more in ease.
+[Sora] is a cross platform GUI designed that provides a graphical interface to the Stellar CLI. It offers a user-friendly interface for managing projects, identities, networks, contract methods, events, logs and so more in a graphical user interface rather than command line interface.
+
+:::
+
+[Sora]: https://github.com/tolgayayci/sora


### PR DESCRIPTION
### What
Move the Sora details into a note block on the CLI documentation page rather than being a section.

### Why
It's somewhat confusing going to the page and seeing Sora listed under CLI. It makes it sound like the Sora tool is another CLI, when it's a GUI ontop of the CLI. A note looks to me like a good way to present that information. The page is primarily about the Stellar CLI, and notes are a good way to present ancillary information that take the user away to other related things.