### PR TITLE
Rename fork testing guide

### DIFF
--- a/docs/build/guides/testing/fork-testing.mdx
+++ b/docs/build/guides/testing/fork-testing.mdx
@@ -1,11 +1,11 @@
 ---
-title: Integration Tests with Mainnet Data
+title: Fork Testing
 hide_table_of_contents: true
-description: Integration testing uses dependency contracts instead of mocks.
+description: Integration testing using mainnet data.
 sidebar_position: 6
 ---
 
-Testing with mainnet data is another form of [integration test], where not only mainnet contracts can be used, but also their data on mainnet.
+Fork testing is another form of [integration test], where not only mainnet contracts can be used, but also their data on mainnet. A snapshot of the ledger is taken and used to create an environment for testing. The test operates as a fork of that initial state.
 
 Our ability to test a contract that relies on another contract is limited to our own knowledge of this other contract and the different states it can get into. Integration testing, where real dependencies are used removes some assumptions, but if a dependency has complex state it may also be useful to test against mainnet data as it exists at different points in time.
 

--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -162,3 +162,4 @@ rewrite ^/docs/smart-contracts(.*)$ "/docs/build/smart-contracts$1" permanent;
 
 # Moving testing docs around
 rewrite ^/docs/build/guides/testing/detecting-changes-with-test-snapshots(.*)$ "/docs/build/guides/testing/differential-tests-with-test-snapshots$1" permanent;
+rewrite ^/docs/build/guides/testing/integration-tests-with-mainnet-data(.*)$ "/docs/build/guides/testing/fork-testing$1" permanent;


### PR DESCRIPTION
### What
Rename the gu7ide about integration testing with mainnet data to fork testing.

### Why
The term fork testing is more commonly used by tools to do this type of integration testing where the state of the test begins with the state of a network. The test then behaves as a fork, taking a different path for the execution of the test.