### PR TITLE
Fix events method access in diff test docs

### DIFF
--- a/docs/build/guides/testing/differential-tests.mdx
+++ b/docs/build/guides/testing/differential-tests.mdx
@@ -66,7 +66,7 @@ Assuming the contract has been deployed, and changes are being made to the local
                        client.increment(),
                    ),
                    // Events
-                   env.events.all(),
+                   env.events().all(),
                )
            },
            // Local – the changed or refactored contract
@@ -81,7 +81,7 @@ Assuming the contract has been deployed, and changes are being made to the local
                        client.increment(),
                    ),
                    // Events
-                   env.events.all(),
+                   env.events().all(),
                )
            },
        );


### PR DESCRIPTION
### What
This change corrects the method access syntax for events in the differential testing documentation example from env.events.all() to env.events().all().

### Why
The syntax is incorrect and has a typo.