### PR TITLE
Use separate Envs in differential test example

### DIFF
--- a/docs/build/guides/testing/differential-tests.mdx
+++ b/docs/build/guides/testing/differential-tests.mdx
@@ -52,10 +52,10 @@ Assuming the contract has been deployed, and changes are being made to the local
 
    #[test]
    fn differential_test() {
-       let env = Env::default();
        assert_eq!(
            // Baseline – the deployed contract
            {
+               let env = Env::default();
                let contract_id = env.register(deployed::WASM, ());
                let client = IncrementContractClient::new(&env, &contract_id);
                (
@@ -71,6 +71,7 @@ Assuming the contract has been deployed, and changes are being made to the local
            },
            // Local – the changed or refactored contract
            {
+               let env = Env::default();
                let contract_id = env.register(IncrementContract, ());
                let client = IncrementContractClient::new(&env, &contract_id);
                (
@@ -101,12 +102,6 @@ This test uses the same patterns used in [unit tests] and [integration tests]:
 :::tip
 
 Differential tests work best when less assumptions are made. Rather than asserting only on specific return values or on implementation details like specific state, asserting on all observable outcomes and including things like events published or return values of other read-only contract functions will help to discover unexpected changes.
-
-:::
-
-:::info
-
-Depending on the test complexity it can be desirable to use an independent `Env` for testing the deployed vs local. However at the moment it is only possible to compare host values, like `String`, `Bytes`, `Vec`, `Map`, if they've been created using the same `Env`. The tracking issue for supportin comparisons across environments is [stellar/rs-soroban-sdk#1360].
 
 :::
 


### PR DESCRIPTION
### What
Use two envs in the differential test example for each separate run instead of using one env to perform both executions.

### Why
Independent environments better represent real world testing scenarios and that pattern supports a larger variety of situations when doing differential testing. It ensures there are not ID clashes or that the two calls do not pollute each other.

The only reason the test wasn't written this way originally was because of a limitation in the soroban-sdk which has been fixed in:
- https://github.com/stellar/rs-soroban-sdk/pull/1436