### PR TITLE
Update llvm-cov command syntax in fuzzing docs

### DIFF
--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -147,14 +147,15 @@ Getting code coverage data for fuzz tests requires some different tooling than w
 4. Run the llvm-cov command to convert the profdata file to an lcov file.
 
    ```
-   LLVM_TOOLS_PATH=$(dirname $(find $(rustc +nightly --print sysroot) -name 'llvm-cov'))
-   $LLVM_TOOLS_PATH/llvm-cov export -instr-profile=fuzz/coverage/fuzz_target_1/coverage.profdata \
-       -format=lcov \
+   $(find $(rustc --print sysroot) -name llvm-cov) export \
+       -instr-profile=fuzz/coverage/fuzz_target_1/coverage.profdata \
        -object target/aarch64-apple-darwin/coverage/aarch64-apple-darwin/release/fuzz_target_1 \
-       --ignore-filename-regex "rustc" > lcov.info
+       --ignore-filename-regex "rustc" \
+       -format=lcov \
+       > lcov.info
    ```
 
-   Load the `lcov.info` file into your IDE using it's coverage feature. In VSCode this can be done by installing the [Coverage Gutters] extension and executing the `Coverage Gutters: Watch` command.
+   Load the `lcov.info` file into your IDE using its coverage feature. In VSCode this can be done by installing the [Coverage Gutters] extension and executing the `Coverage Gutters: Watch` command.
 
 :::tip
 


### PR DESCRIPTION
### What
Modify llvm-cov command syntax and fix formatting in fuzzing documentation.

### Why
The existing command was valid, but longer than necessary