### PR TITLE
change an absolute URL to a relative one

### DIFF
--- a/docs/build/guides/conventions/workspace.mdx
+++ b/docs/build/guides/conventions/workspace.mdx
@@ -75,7 +75,7 @@ impl ContractAdd {
 
 :::tip
 
-In this tutorial we use workspaces to import contract client. However, it's also possible to use contract's compiled code instead (for example, if you don't have a source code for it). See [making cross-contract calls](/docs/build/guides/conventions/cross-contract.mdx) guide for more info
+In this tutorial we use workspaces to import contract client. However, it's also possible to use contract's compiled code instead (for example, if you don't have a source code for it). See [making cross-contract calls](./cross-contract.mdx) guide for more info
 
 :::
 


### PR DESCRIPTION
The docker build is failing, because there is a link to an `/absolute/URL.mdx` somewhere, and that borks the translation links. This PR resolves that failure.