### PR TITLE
Update `SorobanRpc` to `rpc` and use `StellarRpc`

### DIFF
--- a/docs/build/guides/archival/restore-data-js.mdx
+++ b/docs/build/guides/archival/restore-data-js.mdx
@@ -32,7 +32,7 @@ import {
   Keypair,
   TransactionBuilder,
   SorobanDataBuilder,
-  SorobanRpc,
+  rpc as SorobanRpc,
   xdr,
 } from "@stellar/stellar-sdk"; // add'l imports to submitTx
 const { Api, assembleTransaction } = SorobanRpc;

--- a/docs/build/guides/archival/restore-data-js.mdx
+++ b/docs/build/guides/archival/restore-data-js.mdx
@@ -32,10 +32,10 @@ import {
   Keypair,
   TransactionBuilder,
   SorobanDataBuilder,
-  rpc as SorobanRpc,
+  rpc as StellarRpc,
   xdr,
 } from "@stellar/stellar-sdk"; // add'l imports to submitTx
-const { Api, assembleTransaction } = SorobanRpc;
+const { Api, assembleTransaction } = StellarRpc;
 
 // assume that `server` is the Server() instance from the submitTx
 

--- a/docs/build/guides/conventions/deploy-sac-with-code.mdx
+++ b/docs/build/guides/conventions/deploy-sac-with-code.mdx
@@ -89,12 +89,12 @@ await deployStellarAssetContract();
 import * as StellarSdk from "@stellar/stellar-sdk";
 
 const networkRPC = "https://soroban-testnet.stellar.org";
-const server = new StellarSdk.SorobanRpc.Server(networkRPC);
+const server = new StellarSdk.rpc.Server(networkRPC);
 const network_passphrase = StellarSdk.Networks.TESTNET;
 ```
 
 - `networkRPC`: The URL for the Soroban testnet.
-- `server`: A new instance of `SorobanRpc.Server` is created, which will be used to interact with the Soroban testnet.
+- `server`: A new instance of `rpc.Server` is created, which will be used to interact with the Soroban testnet.
 - `network_passphrase`: sets the network passphrase to the TESTNET
 
 **`DeployStellarAssetContract` function**

--- a/docs/build/guides/dapps/frontend-guide.mdx
+++ b/docs/build/guides/dapps/frontend-guide.mdx
@@ -386,7 +386,7 @@ Below is a snippet that shows how to set up the Stellar SDK in your project. We 
 ```typescript
 import * as StellarSdk from "@stellar/stellar-sdk";
 
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
 
 export const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org"); // soroban testnet server
 
@@ -414,7 +414,7 @@ Now, let's update our `app/page` component to interact with the Stellar network:
 import React, { useState, useEffect } from "react";
 import SendPaymentForm from "../components/SendPaymentForm";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
 import {
   isConnected,
   setAllowed,
@@ -543,7 +543,7 @@ import {
   BASE_FEE,
   Contract,
   Networks,
-  SorobanRpc,
+  rpc as SorobanRpc,
   Transaction,
   TransactionBuilder,
   xdr,

--- a/docs/build/guides/dapps/frontend-guide.mdx
+++ b/docs/build/guides/dapps/frontend-guide.mdx
@@ -386,9 +386,9 @@ Below is a snippet that shows how to set up the Stellar SDK in your project. We 
 ```typescript
 import * as StellarSdk from "@stellar/stellar-sdk";
 
-import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { rpc as StellarRpc } from "@stellar/stellar-sdk";
 
-export const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org"); // soroban testnet server
+export const server = new StellarRpc.Server("https://soroban-testnet.stellar.org"); // soroban testnet server
 
 const transaction = new StellarSdk.TransactionBuilder(account, {
     fee:  StellarSdk.BASE_FEE
@@ -414,7 +414,7 @@ Now, let's update our `app/page` component to interact with the Stellar network:
 import React, { useState, useEffect } from "react";
 import SendPaymentForm from "../components/SendPaymentForm";
 import * as StellarSdk from "@stellar/stellar-sdk";
-import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { rpc as StellarRpc } from "@stellar/stellar-sdk";
 import {
   isConnected,
   setAllowed,
@@ -458,7 +458,7 @@ export default function Home() {
     }
 
     try {
-      const server = new SorobanRpc.Server(
+      const server = new StellarRpc.Server(
         "https://soroban-testnet.stellar.org",
       );
       const sourceAccount = await server.getAccount(publicKey);
@@ -543,7 +543,7 @@ import {
   BASE_FEE,
   Contract,
   Networks,
-  rpc as SorobanRpc,
+  rpc as StellarRpc,
   Transaction,
   TransactionBuilder,
   xdr,
@@ -588,7 +588,7 @@ export default function CounterPage() {
     setLoading(true);
 
     try {
-      const server = new SorobanRpc.Server(SOROBAN_URL);
+      const server = new StellarRpc.Server(SOROBAN_URL);
       const account = await server.getAccount(publicKey);
 
       const contract = new Contract(CONTRACT_ID);

--- a/docs/build/guides/dapps/state-archival.mdx
+++ b/docs/build/guides/dapps/state-archival.mdx
@@ -148,7 +148,7 @@ import {
 
 import { Api } from "@stellar/stellar-sdk/rpc";
 const rpcUrl = "https://soroban-testnet.stellar.org";
-const server = new StellarSdk.SorobanRpc.Server(rpcUrl);
+const server = new StellarSdk.rpc.Server(rpcUrl);
 const networkPassphrase = StellarSdk.Networks.TESTNET; // Use PUBLIC for production
 ```
 

--- a/docs/build/guides/events/ingest.mdx
+++ b/docs/build/guides/events/ingest.mdx
@@ -185,10 +185,10 @@ events = res.events
 We use the `@stellar/stellar-sdk` library:
 
 ```javascript
-import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { rpc as StellarRpc } from "@stellar/stellar-sdk";
 import { PrismaClient } from "@prisma/client";
 
-const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+const server = new StellarRpc.Server("https://soroban-testnet.stellar.org");
 const prisma = new PrismaClient();
 
 let latestEventIngested = await prisma.sorobanEvent.findFirst({

--- a/docs/build/guides/events/ingest.mdx
+++ b/docs/build/guides/events/ingest.mdx
@@ -185,7 +185,7 @@ events = res.events
 We use the `@stellar/stellar-sdk` library:
 
 ```javascript
-import { SorobanRpc } from "@stellar/stellar-sdk";
+import { rpc as SorobanRpc } from "@stellar/stellar-sdk";
 import { PrismaClient } from "@prisma/client";
 
 const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");

--- a/docs/build/guides/transactions/install-deploy-contract-with-code.mdx
+++ b/docs/build/guides/transactions/install-deploy-contract-with-code.mdx
@@ -150,7 +150,7 @@ This function constructs a transaction, signs it, and submits it to the network,
 Execute the deployment script:
 
 ```javascript
-const server = new StellarSDK.SorobanRpc.Server(
+const server = new StellarSDK.rpc.Server(
   "https://soroban-testnet.stellar.org:443",
 );
 const sourceKeypair = StellarSDK.Keypair.fromSecret("Your_Secret_Key");
@@ -232,7 +232,7 @@ async function buildAndSendTransaction(account, operations) {
   }
 }
 
-const server = new StellarSDK.SorobanRpc.Server(
+const server = new StellarSDK.rpc.Server(
   "https://soroban-testnet.stellar.org:443",
 );
 const sourceKeypair = StellarSDK.Keypair.fromSecret("Your_Secret_Key");

--- a/docs/build/guides/transactions/install-wasm-bytecode.mdx
+++ b/docs/build/guides/transactions/install-wasm-bytecode.mdx
@@ -132,7 +132,7 @@ async function buildAndSendTransaction(account, operations) {
 }
 
 // Upload contract to the testnet
-const server = new StellarSDK.SorobanRpc.Server(
+const server = new StellarSDK.rpc.Server(
   "https://soroban-testnet.stellar.org:443",
 );
 // Replace `Your_Secret_Key`

--- a/docs/build/guides/transactions/simulateTransaction-Deep-Dive.mdx
+++ b/docs/build/guides/transactions/simulateTransaction-Deep-Dive.mdx
@@ -89,7 +89,7 @@ The Stellar SDK provides a convenient method to simulate a transaction:
 ```javascript
 import {
   Keypair,
-  rpc as SorobanRpc,
+  rpc as StellarRpc,
   scValToNative,
   TransactionBuilder,
   BASE_FEE,
@@ -114,7 +114,7 @@ await fetch(`https://friendbot-testnet.stellar.org/?addr=${publicKey}`).then(
 );
 
 // Initialize the rpcServer
-const RpcServer = new SorobanRpc.Server(rpc_url, { allowHttp: true });
+const RpcServer = new StellarRpc.Server(rpc_url, { allowHttp: true });
 
 // Load the account (getting the sequence number for the account and making an account object.)
 const account = await RpcServer.getAccount(publicKey);
@@ -190,7 +190,7 @@ import {
   Keypair,
   Operation,
   SorobanDataBuilder,
-  rpc as SorobanRpc,
+  rpc as StellarRpc,
   TimeoutInfinite,
   Transaction,
   TransactionBuilder,
@@ -209,10 +209,10 @@ export async function simulateRestorationIfNeeded(
   contract: ContractAddress,
   txParams: TxParams,
 ): Promise<
-  SorobanRpc.Api.SimulateTransactionRestoreResponse | string | undefined
+  StellarRpc.Api.SimulateTransactionRestoreResponse | string | undefined
 > {
   try {
-    const RpcServer = new SorobanRpc.Server(
+    const RpcServer = new StellarRpc.Server(
       "https://soroban-testnet.stellar.org",
       { allowHttp: true },
     );
@@ -247,17 +247,17 @@ export async function simulateRestorationIfNeeded(
         .build();
       // Simulate a transaction with a restoration operation to check if it's necessary
 
-      const restorationSimulation: SorobanRpc.Api.SimulateTransactionResponse =
+      const restorationSimulation: StellarRpc.Api.SimulateTransactionResponse =
         await RpcServer.simulateTransaction(restoreTx);
 
       //check if restore is necessary. this code also checks if the simulation was successful.
-      const restoreNeeded = SorobanRpc.Api.isSimulationRestore(
+      const restoreNeeded = StellarRpc.Api.isSimulationRestore(
         restorationSimulation,
       );
       console.log(`restoration needed: ${restoreNeeded}`);
       // Check if the simulation indicates a need for restoration
       if (restoreNeeded) {
-        return restorationSimulation as SorobanRpc.Api.SimulateTransactionRestoreResponse;
+        return restorationSimulation as StellarRpc.Api.SimulateTransactionRestoreResponse;
       } else {
         console.log("No restoration needed., bumping the ttl.");
         const account1 = await RpcServer.getAccount(
@@ -277,9 +277,9 @@ export async function simulateRestorationIfNeeded(
             }),
           ) // The actual TTL extension operation
           .build();
-        const ttlSimResponse: SorobanRpc.Api.SimulateTransactionResponse =
+        const ttlSimResponse: StellarRpc.Api.SimulateTransactionResponse =
           await RpcServer.simulateTransaction(bumpTTLtx);
-        const assembledTx = SorobanRpc.assembleTransaction(
+        const assembledTx = StellarRpc.assembleTransaction(
           bumpTTLtx,
           ttlSimResponse,
         ).build();
@@ -310,15 +310,15 @@ export async function simulateRestorationIfNeeded(
 
 /**
  * Handles the restoration of a Soroban contract.
- * @param {SorobanRpc.Api.SimulateTransactionRestoreResponse} simResponse - The simulation response containing restoration information.
+ * @param {StellarRpc.Api.SimulateTransactionRestoreResponse} simResponse - The simulation response containing restoration information.
  * @param {TxParams} txParams - The transaction parameters.
  * @returns {Promise<void>} A promise that resolves when the restoration transaction has been submitted.
  */
 export async function handleRestoration(
-  simResponse: SorobanRpc.Api.SimulateTransactionRestoreResponse,
+  simResponse: StellarRpc.Api.SimulateTransactionRestoreResponse,
   txParams: TxParams,
 ): Promise<void> {
-  const RpcServer = new SorobanRpc.Server(
+  const RpcServer = new StellarRpc.Server(
     "https://soroban-testnet.stellar.org",
     { allowHttp: true },
   );
@@ -334,9 +334,9 @@ export async function handleRestoration(
     .addOperation(Operation.restoreFootprint({})) // Add the RestoreFootprint operation
     .build(); // Build the transaction
 
-  const simulation: SorobanRpc.Api.SimulateTransactionResponse =
+  const simulation: StellarRpc.Api.SimulateTransactionResponse =
     await RpcServer.simulateTransaction(restoreTx);
-  const assembledTx = SorobanRpc.assembleTransaction(
+  const assembledTx = StellarRpc.assembleTransaction(
     restoreTx,
     simulation,
   ).build();

--- a/docs/build/guides/transactions/simulateTransaction-Deep-Dive.mdx
+++ b/docs/build/guides/transactions/simulateTransaction-Deep-Dive.mdx
@@ -89,7 +89,7 @@ The Stellar SDK provides a convenient method to simulate a transaction:
 ```javascript
 import {
   Keypair,
-  SorobanRpc,
+  rpc as SorobanRpc,
   scValToNative,
   TransactionBuilder,
   BASE_FEE,
@@ -190,7 +190,7 @@ import {
   Keypair,
   Operation,
   SorobanDataBuilder,
-  SorobanRpc,
+  rpc as SorobanRpc,
   TimeoutInfinite,
   Transaction,
   TransactionBuilder,

--- a/docs/data/rpc/api-reference/json-rpc.mdx
+++ b/docs/data/rpc/api-reference/json-rpc.mdx
@@ -7,7 +7,7 @@ Stellar-RPC will accept HTTP POST requests using the [JSON-RPC 2.0] specificatio
 
 For production and other publicly-accessible instances, the JSON-RPC endpoint should be served over SSL on port 443, where possible, for security and ease of use. Though, stellar-rpc does not terminate ssl by itself, so will need a load-balancer or other service to terminate SSL for it.
 
-To interact with stellar-rpc from inside a JavaScript application, use the [JavaScript SDK] package, which gives a convenient interface for the RPC methods inside of its `SorobanRpc` module.
+To interact with stellar-rpc from inside a JavaScript application, use the [JavaScript SDK] package, which gives a convenient interface for the RPC methods inside of its `rpc` module.
 
 When XDR is passed as a parameter or returned, it is always a string encoded using standard base64.
 

--- a/docs/data/rpc/api-reference/methods/getLedgerEntries.mdx
+++ b/docs/data/rpc/api-reference/methods/getLedgerEntries.mdx
@@ -82,7 +82,7 @@ console.log(
 
 :::note
 
-This functionality is included in the JavaScript [`stellar-sdk`](https://www.npmjs.com/package/stellar-sdk) package as `SorobanRpc.Server.getAccount(address)`.
+This functionality is included in the JavaScript [`stellar-sdk`](https://www.npmjs.com/package/stellar-sdk) package as `rpc.Server.getAccount(address)`.
 
 :::
 

--- a/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction.mdx
+++ b/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction.mdx
@@ -45,7 +45,7 @@ npm install --save @stellar/stellar-sdk
   const {
     Keypair,
     Contract,
-    SorobanRpc,
+    rpc as SorobanRpc,
     TransactionBuilder,
     Networks,
     BASE_FEE,

--- a/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction.mdx
+++ b/docs/learn/encyclopedia/contract-development/contract-interactions/stellar-transaction.mdx
@@ -45,7 +45,7 @@ npm install --save @stellar/stellar-sdk
   const {
     Keypair,
     Contract,
-    rpc as SorobanRpc,
+    rpc as StellarRpc,
     TransactionBuilder,
     Networks,
     BASE_FEE,
@@ -58,7 +58,7 @@ npm install --save @stellar/stellar-sdk
   );
 
   // Configure the SDK to use the `stellar-rpc` instance of your choosing.
-  const server = new SorobanRpc.Server(
+  const server = new StellarRpc.Server(
     "https://soroban-testnet.stellar.org:443",
   );
 

--- a/docs/learn/encyclopedia/storage/state-archival.mdx
+++ b/docs/learn/encyclopedia/storage/state-archival.mdx
@@ -220,10 +220,10 @@ import {
   Keypair,
   TransactionBuilder,
   SorobanDataBuilder,
-  rpc as SorobanRpc,
+  rpc as StellarRpc,
   xdr,
 } from "@stellar/stellar-sdk"; // add'l imports to preamble
-const { Api, assembleTransaction } = SorobanRpc;
+const { Api, assembleTransaction } = StellarRpc;
 
 // assume that `server` is the Server() instance from the preamble
 
@@ -315,13 +315,13 @@ import {
   TransactionBuilder,
   SorobanDataBuilder,
   Operation,
-  rpc as SorobanRpc,
+  rpc as StellarRpc,
 } from "@stellar/stellar-sdk";
 
 async function restoreContract(
   signer: Keypair,
   c: Contract,
-): Promise<SorobanRpc.Api.GetTransactionResponse> {
+): Promise<StellarRpc.Api.GetTransactionResponse> {
   const instance = c.getFootprint();
 
   const account = await server.getAccount(signer.publicKey());

--- a/docs/learn/encyclopedia/storage/state-archival.mdx
+++ b/docs/learn/encyclopedia/storage/state-archival.mdx
@@ -220,7 +220,7 @@ import {
   Keypair,
   TransactionBuilder,
   SorobanDataBuilder,
-  SorobanRpc,
+  rpc as SorobanRpc,
   xdr,
 } from "@stellar/stellar-sdk"; // add'l imports to preamble
 const { Api, assembleTransaction } = SorobanRpc;
@@ -315,7 +315,7 @@ import {
   TransactionBuilder,
   SorobanDataBuilder,
   Operation,
-  SorobanRpc,
+  rpc as SorobanRpc,
 } from "@stellar/stellar-sdk";
 
 async function restoreContract(


### PR DESCRIPTION
1. js-stellar-sdk [v13.0.0](https://github.com/stellar/js-stellar-sdk/releases/tag/v13.0.0) removed `SorobanRpc`. 

> The SorobanRpc import, previously deprecated, has been removed. You can import rpc instead:

2. We rebranded `SorobanRpc` to `StellarRpc` in November 2024

This PR is to update the doc accordingly.