### PR TITLE
Adding a build dapp step to guide #945

### DIFF
--- a/docs/build/apps/dapp-frontend.mdx
+++ b/docs/build/apps/dapp-frontend.mdx
@@ -3,7 +3,6 @@ sidebar_position: 70
 sidebar_label: Build a Dapp Frontend
 title: "Build a dapp Frontend: Connect Wallets, Handle Transactions & More"
 description: "Learn how to build a dapp frontend that connects to smart contracts. Explore best practices for integrating wallets, handling transactions, and interacting with the Stellar network."
-pagination_prev: build/smart-contracts/getting-started/deploy-increment-contract
 ---
 
 # Build a Dapp Frontend

--- a/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
+++ b/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
@@ -3,7 +3,6 @@ sidebar_position: 40
 title: "Deploy the Increment Smart Contract on Testnet Using the CLI: A Guide"
 sidebar_label: 4. Deploy the Increment Contract
 description: "Follow this step-by-step guide in the final section of Getting Started to learn how to deploy the increment smart contract on Testnet using the Stellar CLI."
-pagination_next: build/apps/dapp-frontend
 ---
 
 # 4. Deploy the Increment Contract

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -7,15 +7,13 @@ description: "Build a frontend for the Hello World contract by using Stellar CLI
 
 # 5. Build a Hello World Frontend
 
-In the previous examples we invoked the contracts using the Stellar CLI, and in this last part of the guide we'll create a web app that interacts with the contracts through TypeScript bindings.
+In the previous examples we invoked the contracts using the Stellar CLI, and in this last part of the guide we'll create a web app that interacts with the Hello World contract through TypeScript bindings.
 
 :::info
 
 This example shows one way of creating a binding between a contract and a frontend, for a more comprehensive guide see the [Build a Dapp Frontend](../../apps/dapp-frontend.mdx) documentation.
 
 :::
-
-Let's get started.
 
 ## Initialize a frontend toolchain
 

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -74,7 +74,7 @@ cp -R ../soroban-hello-world/.stellar/ .stellar
 
 ## Generate an NPM package for the Hello World contract
 
-Before we open the new frontend files, let's generate an NPM package for the Hello World contract. This is our suggested way to interact with contracts from frontends. These generated libraries work with any JavaScript project (not a specific UI like React), and make it easy to work with some of the trickiest bits of Soroban, like encoding [XDR](../../learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx).
+Before we open the new frontend files, let's generate an NPM package for the Hello World contract. This is our suggested way to interact with contracts from frontends. These generated libraries work with any JavaScript project (not a specific UI like React), and make it easy to work with some of the trickiest bits of Soroban, like encoding [XDR](../../../learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx).
 
 This is going to use the CLI command `stellar contract bindings typescript`:
 

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -17,15 +17,15 @@ This example shows one way of creating a binding between a contract and a fronte
 
 ## Initialize a frontend toolchain
 
-You can build a Soroban app with any frontend toolchain or integrate it into any existing full-stack app. For this tutorial, we're going to use [Astro](https://astro.build/). Astro works with React, Vue, Svelte, any other UI library, or no UI library at all. In this tutorial, we're not using a UI library. The Soroban-specific parts of this tutorial will be similar no matter what frontend toolchain you use.
+You can build a Stellar dapp with any frontend toolchain or integrate it into any existing full-stack app. For this tutorial, we're going to use [Astro](https://astro.build/). Astro works with React, Vue, Svelte, any other UI library, or no UI library at all. In this tutorial, we're not using a UI library. The smart contract-specific parts of this tutorial will be similar no matter what frontend toolchain you use.
 
-If you're new to frontend, don't worry. We won't go too deep. But it will be useful for you to see and experience the frontend development process used by Soroban apps. We'll cover the relevant bits of JavaScript and Astro, but teaching all of frontend development and Astro is beyond the scope of this tutorial.
+If you're new to frontend, don't worry. We won't go too deep. But it will be useful for you to see and experience the frontend development process used by smart contract apps. We'll cover the relevant bits of JavaScript and Astro, but teaching all of frontend development and Astro is beyond the scope of this tutorial.
 
 Let's get started.
 
 You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) v18.14.1 or greater. If you haven't yet, install it now.
 
-We want to create an Astro project with the contracts from the previous lesson. To do this, we can clone a template. You can find Soroban templates on GitHub by [searching for repositories that start with "soroban-template-"](https://github.com/search?q=%22soroban-template-%22&type=repositories). For this tutorial, we'll use [stellar/soroban-template-astro](https://github.com/stellar/soroban-template-astro). We'll also use a tool called [degit](https://github.com/Rich-Harris/degit) to clone the template without its git history. This will allow us to set it up as our own git project.
+We want to create an Astro project with the contracts from the previous lesson. To do this, we can clone a template. You can find templates on GitHub by [searching for repositories that start with "soroban-template-"](https://github.com/search?q=%22soroban-template-%22&type=repositories). For this tutorial, we'll use [stellar/soroban-template-astro](https://github.com/stellar/soroban-template-astro). We'll also use a tool called [degit](https://github.com/Rich-Harris/degit) to clone the template without its git history. This will allow us to set it up as our own git project.
 
 Since you have `node` and its package manager `npm` installed, you also have `npx`.
 
@@ -72,7 +72,7 @@ cp -R ../soroban-hello-world/.stellar/ .stellar
 
 ## Generate an NPM package for the Hello World contract
 
-Before we open the new frontend files, let's generate an NPM package for the Hello World contract. This is our suggested way to interact with contracts from frontends. These generated libraries work with any JavaScript project (not a specific UI like React), and make it easy to work with some of the trickiest bits of Soroban, like encoding [XDR](../../../learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx).
+Before we open the new frontend files, let's generate an NPM package for the Hello World contract. This is our suggested way to interact with contracts from frontends. These generated libraries work with any JavaScript project (not a specific UI like React), and make it easy to work with some of the trickiest bits of smart contracts on Stellar, like encoding [XDR](../../../learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx).
 
 This is going to use the CLI command `stellar contract bindings typescript`:
 
@@ -121,7 +121,7 @@ npm run dev
 
 And open [localhost:4321](http://localhost:4321) in your browser. You should see the greeting from the contract!
 
-You can try updating the `{ to: 'Soroban' }` argument. When you save the file, the page will automatically update.
+You can try updating the `{ to: 'Stellar' }` argument. When you save the file, the page will automatically update.
 
 :::info
 

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -25,7 +25,7 @@ Let's get started.
 
 You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) v20 or greater. If you haven't yet, install it now.
 
-We want to create an Astro project with the Hello World contract from the previous lessons. To do this, we can install the default Astro project:
+We want to create an Astro project with the Hello World contract from the previous lessons integrated. To do this, we install the default Astro project:
 
 ```bash
 npm create astro@latest

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -3,6 +3,7 @@ sidebar_position: 50
 sidebar_label: "5. Build a Hello World Frontend"
 title: "Build a frontend for the Hello World contract"
 description: "Build a frontend for the Hello World contract by using Stellar CLI to generate TypeScript bindings."
+pagination_next: build/apps/dapp-frontend
 ---
 
 # 5. Build a Hello World Frontend

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -7,7 +7,7 @@ description: "Build a frontend for the Hello World contract by using Stellar CLI
 
 # 5. Build a Hello World Frontend
 
-In the previous examples we invoked the contracts using the Stellar CLI, and in this last part of the guide we'll create a web app that interacts with the Hello World contract through TypeScript bindings.
+In the previous examples, we invoked the contracts using the Stellar CLI, and in this last part of the guide we'll create a web app that interacts with the Hello World contract through TypeScript bindings.
 
 :::info
 
@@ -125,6 +125,6 @@ You can try updating the `{ to: 'Soroban' }` argument. When you save the file, t
 
 :::info
 
-When you start up the dev server with `npm run dev`, you will see similar output in your terminal as when you ran `npm run init`. This is because the `dev` script in package.json is set up to run `npm run init` and `astro dev`, so that you can ensure that your deployed contract and your generated NPM pacakage are always in sync. If you want to just start the dev server without the initialize.js script, you can run `npm run astro dev`.
+When you start up the dev server with `npm run dev`, you will see similar output in your terminal as when you ran `npm run init`. This is because the `dev` script in package.json is set up to run `npm run init` and `astro dev`, so that you can ensure that your deployed contract and your generated NPM package are always in sync. If you want to just start the dev server without the initialize.js script, you can run `npm run astro dev`.
 
 :::

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -23,40 +23,30 @@ If you're new to frontend, don't worry. We won't go too deep. But it will be use
 
 Let's get started.
 
-You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) v18.14.1 or greater. If you haven't yet, install it now.
+You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) v20 or greater. If you haven't yet, install it now.
 
-We want to create an Astro project with the contracts from the previous lesson. To do this, we can clone a template. You can find templates on GitHub by [searching for repositories that start with "soroban-template-"](https://github.com/search?q=%22soroban-template-%22&type=repositories). For this tutorial, we'll use [stellar/soroban-template-astro](https://github.com/stellar/soroban-template-astro). We'll also use a tool called [degit](https://github.com/Rich-Harris/degit) to clone the template without its git history. This will allow us to set it up as our own git project.
-
-Since you have `node` and its package manager `npm` installed, you also have `npx`.
-
-We're going to create a new project directory with this template to make things easier in this tutorial, so make sure you're no longer in your `soroban-hello-world` directory and then run:
-
-```sh
-npx degit stellar/soroban-template-astro first-soroban-app
-cd first-soroban-app
-git init
-git add .
-git commit -m "first commit: initialize from stellar/soroban-template-astro"
-```
-
-This project has the following directory structure, which we'll go over in more detail below.
+We want to create an Astro project with the Hello World contract from the previous lessons. To do this, we can install the default Astro project:
 
 ```bash
-├── contracts
-│   ├── hello_world
-│   └── increment
-├── CONTRIBUTING.md
-├── Cargo.toml
-├── Cargo.lock
-├── initialize.js
+npm create astro@latest
+```
+
+This project has the following directory structure.
+
+```bash
+extra-escape
+├── astro.config.mjs
 ├── package-lock.json
 ├── package.json
 ├── packages
 ├── public
+├── README.md
 ├── src
+│   ├── assets
+│   │   ├── astro.svg
+│   │   └── background.svg
 │   ├── components
-│   │   └── Card.astro
-│   ├── env.d.ts
+│   │   └── Welcome.astro
 │   ├── layouts
 │   │   └── Layout.astro
 │   └── pages
@@ -64,10 +54,10 @@ This project has the following directory structure, which we'll go over in more 
 └── tsconfig.json
 ```
 
-The `contracts` are the same ones you walked through in the previous steps of the tutorial. Since we already deployed these contracts with aliases, we can reuse the generated contract ID files by copying them from the `soroban-hello-world/.stellar` directory into this project:
+Since we already deployed these contracts with aliases, we can reuse the generated contract ID files by copying them from the `soroban-hello-world/.stellar` directory into this project:
 
 ```sh
-cp -R ../soroban-hello-world/.stellar/ .stellar
+cp -R ../.stellar/ .stellar
 ```
 
 ## Generate an NPM package for the Hello World contract
@@ -89,29 +79,46 @@ Notice that we were able to use the contract alias, `hello_world`, in place of t
 
 :::
 
-This project is set up as an NPM Workspace, and so the `hello_world` client library was generated in the `packages` directory at `packages/hello_world`.
+The binding will be created in as a NPM package in the directory `packages/hello_world` as specified in the CLI command. We'll need to build the bindings package, since (in its initial state) the package is mostly TypeScript types and stubs for the various contract functions.
+
+```bash
+cd packages/hello_world
+npm install
+npm run build
+cd ../..
+```
 
 We attempt to keep the code in these generated libraries readable, so go ahead and look around. Open up the new `packages/hello_world` directory in your editor. If you've built or contributed to Node projects, it will all look familiar. You'll see a `package.json` file, a `src` directory, a `tsconfig.json`, and even a README.
 
 ## Call the contract from the frontend
 
-Now let's open up `src/pages/index.astro` and take a look at how the frontend code integrates with the NPM package we created for our contract.
+Now let's open up `src/pages/index.astro` and use the binding to call the `hello` contract function with an argument. 
 
-Here we can see that we're importing our generated `helloWorld` client from `../contracts/hello_world`. We're then invoking the `hello` method and adding the result to the page.
+The default Astro project consists of a page (`pages/index.astro`) and a welcome component (`component/Welcome.astro`), and we don't need any of that code. Replace the `pages/index.astro` code with this code (the welcome component will not be needed):
 
 ```ts title="src/pages/index.astro"
 ---
-import Layout from "../layouts/Layout.astro";
-import Card from "../components/Card.astro";
-import helloWorld from "../contracts/hello_world";
-const { result } = await helloWorld.hello({ to: "you" });
+import * as Client from './packages/hello_world'; 
+
+const contract = new Client.Client({ 
+   ...Client.networks.testnet, 
+   rpcUrl: 'https://soroban-testnet.stellar.org:443' 
+});
+
+const { result } = await contract.hello({to: "Devs!"});
 const greeting = result.join(" ");
 ---
 
- ...
-
-<h1>{greeting}</h1>
+<h1>
+	{greeting}
+</h1>
 ```
+
+First we import the binding library, and then we need to define a contract client we can use for invoking the contract function we deployed to testnet in a previous step. 
+
+The `hello()` contract function is invoked synchronously with the argument `{to: "Devs!"}` and the expected response is an array consisting of "Hello" and "Devs!". We join the result array and the constant `greeting` should now hold the text `Hello Devs!`
+
+Jumping down to the HTML section we now want to display the `greeting` text in the browser, and wrap it in <h1>-tags just for styling. 
 
 Let's see it in action! Start the dev server:
 
@@ -121,7 +128,7 @@ npm run dev
 
 And open [localhost:4321](http://localhost:4321) in your browser. You should see the greeting from the contract!
 
-You can try updating the `{ to: 'Stellar' }` argument. When you save the file, the page will automatically update.
+You can try updating the argument to `{ to: 'Stellar' }`. When you save the file, the page will automatically update.
 
 :::info
 

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -1,0 +1,132 @@
+---
+sidebar_position: 50
+sidebar_label: "5. Build a Hello World Frontend"
+title: "Build a frontend for the Hello World contract"
+description: "Build a frontend for the Hello World contract by using Stellar CLI to generate TypeScript bindings."
+---
+
+# 5. Build a Hello World Frontend
+
+In the previous examples we invoked the contracts using the Stellar CLI, and in this last part of the guide we'll create a web app that interacts with the contracts through TypeScript bindings.
+
+:::info
+
+This example shows one way of creating a binding between a contract and a frontend, for a more comprehensive guide see the [Build a Dapp Frontend](../../apps/dapp-frontend.mdx) documentation.
+
+:::
+
+Let's get started.
+
+## Initialize a frontend toolchain
+
+You can build a Soroban app with any frontend toolchain or integrate it into any existing full-stack app. For this tutorial, we're going to use [Astro](https://astro.build/). Astro works with React, Vue, Svelte, any other UI library, or no UI library at all. In this tutorial, we're not using a UI library. The Soroban-specific parts of this tutorial will be similar no matter what frontend toolchain you use.
+
+If you're new to frontend, don't worry. We won't go too deep. But it will be useful for you to see and experience the frontend development process used by Soroban apps. We'll cover the relevant bits of JavaScript and Astro, but teaching all of frontend development and Astro is beyond the scope of this tutorial.
+
+Let's get started.
+
+You're going to need [Node.js](https://nodejs.org/en/download/package-manager/) v18.14.1 or greater. If you haven't yet, install it now.
+
+We want to create an Astro project with the contracts from the previous lesson. To do this, we can clone a template. You can find Soroban templates on GitHub by [searching for repositories that start with "soroban-template-"](https://github.com/search?q=%22soroban-template-%22&type=repositories). For this tutorial, we'll use [stellar/soroban-template-astro](https://github.com/stellar/soroban-template-astro). We'll also use a tool called [degit](https://github.com/Rich-Harris/degit) to clone the template without its git history. This will allow us to set it up as our own git project.
+
+Since you have `node` and its package manager `npm` installed, you also have `npx`.
+
+We're going to create a new project directory with this template to make things easier in this tutorial, so make sure you're no longer in your `soroban-hello-world` directory and then run:
+
+```sh
+npx degit stellar/soroban-template-astro first-soroban-app
+cd first-soroban-app
+git init
+git add .
+git commit -m "first commit: initialize from stellar/soroban-template-astro"
+```
+
+This project has the following directory structure, which we'll go over in more detail below.
+
+```bash
+├── contracts
+│   ├── hello_world
+│   └── increment
+├── CONTRIBUTING.md
+├── Cargo.toml
+├── Cargo.lock
+├── initialize.js
+├── package-lock.json
+├── package.json
+├── packages
+├── public
+├── src
+│   ├── components
+│   │   └── Card.astro
+│   ├── env.d.ts
+│   ├── layouts
+│   │   └── Layout.astro
+│   └── pages
+│       └── index.astro
+└── tsconfig.json
+```
+
+The `contracts` are the same ones you walked through in the previous steps of the tutorial. Since we already deployed these contracts with aliases, we can reuse the generated contract ID files by copying them from the `soroban-hello-world/.stellar` directory into this project:
+
+```sh
+cp -R ../soroban-hello-world/.stellar/ .stellar
+```
+
+## Generate an NPM package for the Hello World contract
+
+Before we open the new frontend files, let's generate an NPM package for the Hello World contract. This is our suggested way to interact with contracts from frontends. These generated libraries work with any JavaScript project (not a specific UI like React), and make it easy to work with some of the trickiest bits of Soroban, like encoding [XDR](../../learn/encyclopedia/contract-development/types/fully-typed-contracts.mdx).
+
+This is going to use the CLI command `stellar contract bindings typescript`:
+
+```bash
+stellar contract bindings typescript \
+  --network testnet \
+  --contract-id hello_world \
+  --output-dir packages/hello_world
+```
+
+:::tip
+
+Notice that we were able to use the contract alias, `hello_world`, in place of the contract id!
+
+:::
+
+This project is set up as an NPM Workspace, and so the `hello_world` client library was generated in the `packages` directory at `packages/hello_world`.
+
+We attempt to keep the code in these generated libraries readable, so go ahead and look around. Open up the new `packages/hello_world` directory in your editor. If you've built or contributed to Node projects, it will all look familiar. You'll see a `package.json` file, a `src` directory, a `tsconfig.json`, and even a README.
+
+## Call the contract from the frontend
+
+Now let's open up `src/pages/index.astro` and take a look at how the frontend code integrates with the NPM package we created for our contract.
+
+Here we can see that we're importing our generated `helloWorld` client from `../contracts/hello_world`. We're then invoking the `hello` method and adding the result to the page.
+
+```ts title="src/pages/index.astro"
+---
+import Layout from "../layouts/Layout.astro";
+import Card from "../components/Card.astro";
+import helloWorld from "../contracts/hello_world";
+const { result } = await helloWorld.hello({ to: "you" });
+const greeting = result.join(" ");
+---
+
+ ...
+
+<h1>{greeting}</h1>
+```
+
+Let's see it in action! Start the dev server:
+
+```bash
+npm run dev
+```
+
+And open [localhost:4321](http://localhost:4321) in your browser. You should see the greeting from the contract!
+
+You can try updating the `{ to: 'Soroban' }` argument. When you save the file, the page will automatically update.
+
+:::info
+
+When you start up the dev server with `npm run dev`, you will see similar output in your terminal as when you ran `npm run init`. This is because the `dev` script in package.json is set up to run `npm run init` and `astro dev`, so that you can ensure that your deployed contract and your generated NPM pacakage are always in sync. If you want to just start the dev server without the initialize.js script, you can run `npm run astro dev`.
+
+:::

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -109,18 +109,14 @@ const { result } = await contract.hello({to: "Devs!"});
 const greeting = result.join(" ");
 ---
 
-<h1>
-	{greeting}
-</h1>
+<h1>{greeting}</h1>
 ```
 
 First we import the binding library, and then we need to define a contract client we can use for invoking the contract function we deployed to testnet in a previous step.
 
 The `hello()` contract function is invoked synchronously with the argument `{to: "Devs!"}` and the expected response is an array consisting of "Hello" and "Devs!". We join the result array and the constant `greeting` should now hold the text `Hello Devs!`
 
-Jumping down to the HTML section we now want to display the `greeting` text in the browser, and wrap it in <h1>-tags just for styling.
-
-Let's see it in action! Start the dev server:
+Jumping down to the HTML section we now want to display the `greeting` text in the browser. Let's see it in action! Start the dev server:
 
 ```bash
 npm run dev

--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -92,17 +92,17 @@ We attempt to keep the code in these generated libraries readable, so go ahead a
 
 ## Call the contract from the frontend
 
-Now let's open up `src/pages/index.astro` and use the binding to call the `hello` contract function with an argument. 
+Now let's open up `src/pages/index.astro` and use the binding to call the `hello` contract function with an argument.
 
 The default Astro project consists of a page (`pages/index.astro`) and a welcome component (`component/Welcome.astro`), and we don't need any of that code. Replace the `pages/index.astro` code with this code (the welcome component will not be needed):
 
 ```ts title="src/pages/index.astro"
 ---
-import * as Client from './packages/hello_world'; 
+import * as Client from './packages/hello_world';
 
-const contract = new Client.Client({ 
-   ...Client.networks.testnet, 
-   rpcUrl: 'https://soroban-testnet.stellar.org:443' 
+const contract = new Client.Client({
+   ...Client.networks.testnet,
+   rpcUrl: 'https://soroban-testnet.stellar.org:443'
 });
 
 const { result } = await contract.hello({to: "Devs!"});
@@ -114,11 +114,11 @@ const greeting = result.join(" ");
 </h1>
 ```
 
-First we import the binding library, and then we need to define a contract client we can use for invoking the contract function we deployed to testnet in a previous step. 
+First we import the binding library, and then we need to define a contract client we can use for invoking the contract function we deployed to testnet in a previous step.
 
 The `hello()` contract function is invoked synchronously with the argument `{to: "Devs!"}` and the expected response is an array consisting of "Hello" and "Devs!". We join the result array and the constant `greeting` should now hold the text `Hello Devs!`
 
-Jumping down to the HTML section we now want to display the `greeting` text in the browser, and wrap it in <h1>-tags just for styling. 
+Jumping down to the HTML section we now want to display the `greeting` text in the browser, and wrap it in <h1>-tags just for styling.
 
 Let's see it in action! Start the dev server:
 


### PR DESCRIPTION
Adding a part of the [Build a Dapp Frontend](https://developers.stellar.org/docs/build/apps/dapp-frontend) page as the 5th step in the [Getting Started](https://developers.stellar.org/docs/build/smart-contracts/getting-started) guide. 

The entire Build a Dapp Frontend page could just be moved to the Getting Started guide, but it seems to be too comprehensive with two ways to bind the contracts, integration of wallet etc. In my opinion the Getting Started guide should be short and only have information needed to get started. 

The Build a Dapp Frontend does have a lot of useful information, so I think it still belongs in the Build Applications section.