### PR TITLE
Fix start ledger required param

### DIFF
--- a/openrpc/src/stellar-rpc/contentDescriptors/StartLedger.json
+++ b/openrpc/src/stellar-rpc/contentDescriptors/StartLedger.json
@@ -3,7 +3,7 @@
         "name": "startLedger",
         "summary": "ledger to begin searching from",
         "description": "Ledger sequence number to start fetching responses from (inclusive). This method will return an error if `startLedger` is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a cursor is included in the request, `startLedger` must be omitted.",
-        "required": true,
+        "required": false,
         "schema": {
             "$ref": "#/components/schemas/LedgerSequence"
         }

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -43,7 +43,7 @@
           "name": "startLedger",
           "summary": "ledger to begin searching from",
           "description": "Ledger sequence number to start fetching responses from (inclusive). This method will return an error if `startLedger` is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a cursor is included in the request, `startLedger` must be omitted.",
-          "required": true,
+          "required": false,
           "schema": {
             "title": "ledgerSequence",
             "description": "Sequence number of the ledger.",
@@ -857,7 +857,7 @@
           "name": "startLedger",
           "summary": "ledger to begin searching from",
           "description": "Ledger sequence number to start fetching responses from (inclusive). This method will return an error if `startLedger` is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a cursor is included in the request, `startLedger` must be omitted.",
-          "required": true,
+          "required": false,
           "schema": {
             "title": "ledgerSequence",
             "description": "Sequence number of the ledger.",
@@ -1267,7 +1267,7 @@
           "name": "startLedger",
           "summary": "ledger to begin searching from",
           "description": "Ledger sequence number to start fetching responses from (inclusive). This method will return an error if `startLedger` is less than the oldest ledger stored in this node, or greater than the latest ledger seen by this node. If a cursor is included in the request, `startLedger` must be omitted.",
-          "required": true,
+          "required": false,
           "schema": {
             "title": "ledgerSequence",
             "description": "Sequence number of the ledger.",


### PR DESCRIPTION
Fixes https://github.com/stellar/stellar-docs/issues/826

This PR makes the `startLedger` an optional parameter. `startLedger` is part of the request of the following endpoints:

- `getTransactions`
- `getLedgers`
- `getEvents`

The reason why `startLedger` is optional is because it cannot be set if a `cursor` is provided in the request.