### PR TITLE
Add infinite event streaming pagination example

### DIFF
--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -144,11 +144,12 @@ For a quick high-level demonstration, though, we'll use the [TypeScript SDK](../
 
 <CodeExample>
 
-```typescript
+```javascript
 import {
   humanizeEvents,
   nativeToScVal,
   scValToNative,
+  Networks,
   Asset,
   xdr
 } from "@stellar/stellar-sdk";
@@ -160,17 +161,18 @@ function main() {
   const response = await s.getLatestLedger();
   const xlmFilter = {
     type: "contract",
-    contractIds: [Asset.native().contractId()],
+    contractIds: [Asset.native().contractId(Networks.TESTNET)],
     topics: [[
       nativeToScVal("transfer", { type: "symbol" }),
-      "*",
-      "*",
+      "*", // to anyone
+      "*", // from anyone
     ]],
   };
   let page = await s.getEvents({
     startLedger: response.sequence - 1,
     filters: [xlmFilter],
   });
+  let latestLedger = page.latestLedger;
 
   while (true) { // run forever until Ctrl+C by user
     //
@@ -178,48 +180,44 @@ function main() {
     //  1. the RPC response itself for human-readable text
     //  2. a helper for the XDR structured-equivalent for human-readable JSON
     //
+    console.log(JSON.stringify(simpleEventLog(events), null, 2));
+    console.log(JSON.stringify(fullEventLog(events), null, 2));
 
-    // 1: lazy
-    console.log(
-      JSON.stringify(
-        page.events.map(event => {
-          return {
-            topics: event.topics.map(t => scValToNative(t)),
-            value: scValToNative(event.value),
-          };
-        ),
-        null,
-        2, // indent JSON
-      )
-
-    // 2: comprehensive
-    console.log(
-      JSON.stringify(
-        humanizeEvents(
-          page.events.map(event => {
-            // rebuild the decomposed response into its original XDR structure
-            return new xdr.ContractEvent({
-              contractId: new Address(event.contractId).toBuffer(),
-              type: xdr.ContractEventType.contract(), // since we filtered on 'contract'
-              body: new xdr.ContractEventBody(0, new xdr.ContractEventV0({
-                topics: event.topic.map(t => xdr.ScVal.fromXDR(t, "base64")),
-                value: xdr.ScVal.fromXDR(event.value, "base64"),
-              }))
-            });
-          })
-        ),
-        null,
-        2, // indent JSON
-      )
-    );
-
-    await new Promise(r => setTimeout(r, 5000)); // pause until the next ledger-ish
-
+    // Fetch the next page until events are exhausted, then wait.
     page = await s.getEvents({
-      pagination: { cursor: page.cursor },
+      pagination: { cursor: page.cursor, limit: 200 },
       filters: [xlmFilter],
     });
+
+    if (!page.events.length) {
+      await new Promise(r => setTimeout(r, 2000));
+    }
   }
+}
+
+function simpleEventLog(events) {
+  return page.events.map(event => {
+    return {
+      topics: event.topics.map(t => scValToNative(t)),
+      value: scValToNative(event.value),
+    };
+  );
+}
+
+function fullEventLog(events) {
+  return humanizeEvents(
+    page.events.map(event => {
+      // rebuild the decomposed response into its original XDR structure
+      return new xdr.ContractEvent({
+        contractId: new Address(event.contractId).toBuffer(),
+        type: xdr.ContractEventType.contract(), // since we filtered on 'contract'
+        body: new xdr.ContractEventBody(0, new xdr.ContractEventV0({
+          topics: event.topic.map(t => xdr.ScVal.fromXDR(t, "base64")),
+          value: xdr.ScVal.fromXDR(event.value, "base64"),
+        }))
+      });
+    })
+  );
 }
 ```
 

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -27,9 +27,9 @@ Events are the mechanism that applications off-chain can use to monitor changes 
 
 ### ContractEvent
 
-An events topics don't have to be made of the same type. You can mix different types.
+An event's topics don't have to be made of the same type: you can mix different types.
 
-An event also contains a data object of any value or type including types defined by contracts using `#[contracttype]`
+An event also contains a data object of any value or type, including [custom types](./types/custom-types.mdx) defined by contracts using `#[contracttype]`:
 
 ```cpp
 struct ContractEvent

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -164,6 +164,8 @@ async function main() {
     type: "contract",
     contractIds: [Asset.native().contractId(Networks.TESTNET)],
     topics: [
+      // Defined in https://stellar.org/protocol/sep-41#interface
+      // for all compatible transfer events.
       [
         nativeToScVal("transfer", { type: "symbol" }).toXDR("base64"),
         "*", // from anyone
@@ -178,8 +180,8 @@ async function main() {
     limit: 10,
   });
 
+  // Run forever until Ctrl+C'd by user
   while (true) {
-    // run forever until Ctrl+C by user
     if (!page.events.length) {
       await new Promise((r) => setTimeout(r, 2000));
     } else {
@@ -229,6 +231,7 @@ function fullEventLog(events) {
   );
 }
 
+// A custom JSONification method to handle bigints.
 function cereal(data) {
   return JSON.stringify(
     data,

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -172,7 +172,6 @@ function main() {
     startLedger: response.sequence - 1,
     filters: [xlmFilter],
   });
-  let latestLedger = page.latestLedger;
 
   while (true) { // run forever until Ctrl+C by user
     //

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -145,17 +145,22 @@ For a quick high-level demonstration, though, we'll use the [TypeScript SDK](../
 <CodeExample>
 
 ```typescript
-import { humanizeEvents, nativeToScVal } from "@stellar/stellar-sdk";
+import {
+  humanizeEvents,
+  nativeToScVal,
+  scValToNative,
+  Asset,
+  xdr
+} from "@stellar/stellar-sdk";
 import { Server } from "@stellar/stellar-sdk/rpc";
 
 const s = new Server("https://soroban-testnet.stellar.org");
 
 function main() {
-  const r = await s.getLatestLedger();
-
+  const response = await s.getLatestLedger();
   const xlmFilter = {
     type: "contract",
-    contractIds: ["CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"],
+    contractIds: [Asset.native().contractId()],
     topics: [[
       nativeToScVal("transfer", { type: "symbol" }),
       "*",
@@ -163,11 +168,11 @@ function main() {
     ]],
   };
   let page = await s.getEvents({
-    startLedger: r.sequence - 1,
+    startLedger: response.sequence - 1,
     filters: [xlmFilter],
   });
 
-  while (true) {
+  while (true) { // run forever until Ctrl+C by user
     //
     // Two ways to output a human-friendly version:
     //  1. the RPC response itself for human-readable text
@@ -208,12 +213,12 @@ function main() {
       )
     );
 
+    await new Promise(r => setTimeout(r, 5000)); // pause until the next ledger-ish
+
     page = await s.getEvents({
       pagination: { cursor: page.cursor },
       filters: [xlmFilter],
     });
-
-    await new Promise(r => setTimeout(r, 5000)); // pause until the next ledger-ish
   }
 }
 ```

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -149,75 +149,95 @@ import {
   humanizeEvents,
   nativeToScVal,
   scValToNative,
+  Address,
   Networks,
   Asset,
-  xdr
+  xdr,
 } from "@stellar/stellar-sdk";
 import { Server } from "@stellar/stellar-sdk/rpc";
 
 const s = new Server("https://soroban-testnet.stellar.org");
 
-function main() {
+async function main() {
   const response = await s.getLatestLedger();
   const xlmFilter = {
     type: "contract",
     contractIds: [Asset.native().contractId(Networks.TESTNET)],
-    topics: [[
-      nativeToScVal("transfer", { type: "symbol" }),
-      "*", // to anyone
-      "*", // from anyone
-    ]],
+    topics: [
+      [
+        nativeToScVal("transfer", { type: "symbol" }).toXDR("base64"),
+        "*", // from anyone
+        "*", // to anyone
+        "*", // any asset (it'll be XLM anyway)
+      ],
+    ],
   };
   let page = await s.getEvents({
-    startLedger: response.sequence - 1,
+    startLedger: response.sequence - 120, // start ~10m in the past
     filters: [xlmFilter],
+    limit: 10,
   });
 
-  while (true) { // run forever until Ctrl+C by user
-    //
-    // Two ways to output a human-friendly version:
-    //  1. the RPC response itself for human-readable text
-    //  2. a helper for the XDR structured-equivalent for human-readable JSON
-    //
-    console.log(JSON.stringify(simpleEventLog(events), null, 2));
-    console.log(JSON.stringify(fullEventLog(events), null, 2));
+  while (true) {
+    // run forever until Ctrl+C by user
+    if (!page.events.length) {
+      await new Promise((r) => setTimeout(r, 2000));
+    } else {
+      //
+      // Two ways to output a human-friendly version:
+      //  1. the RPC response itself for human-readable text
+      //  2. a helper for the XDR structured-equivalent for human-readable JSON
+      //
+      console.log(cereal(simpleEventLog(page.events)));
+      console.log(cereal(fullEventLog(page.events)));
+    }
 
     // Fetch the next page until events are exhausted, then wait.
     page = await s.getEvents({
-      pagination: { cursor: page.cursor, limit: 200 },
       filters: [xlmFilter],
+      cursor: page.cursor,
+      limit: 10,
     });
-
-    if (!page.events.length) {
-      await new Promise(r => setTimeout(r, 2000));
-    }
   }
 }
 
 function simpleEventLog(events) {
-  return page.events.map(event => {
+  return events.map((event) => {
     return {
-      topics: event.topics.map(t => scValToNative(t)),
+      topics: event.topic.map((t) => scValToNative(t)),
       value: scValToNative(event.value),
     };
-  );
+  });
 }
 
 function fullEventLog(events) {
   return humanizeEvents(
-    page.events.map(event => {
+    events.map((event) => {
       // rebuild the decomposed response into its original XDR structure
       return new xdr.ContractEvent({
-        contractId: new Address(event.contractId).toBuffer(),
+        contractId: event.contractId.address().toBuffer(),
         type: xdr.ContractEventType.contract(), // since we filtered on 'contract'
-        body: new xdr.ContractEventBody(0, new xdr.ContractEventV0({
-          topics: event.topic.map(t => xdr.ScVal.fromXDR(t, "base64")),
-          value: xdr.ScVal.fromXDR(event.value, "base64"),
-        }))
+        body: new xdr.ContractEventBody(
+          0,
+          new xdr.ContractEventV0({
+            topics: event.topic,
+            data: event.value,
+          }),
+        ),
       });
-    })
+    }),
   );
 }
+
+function cereal(data) {
+  return JSON.stringify(
+    data,
+    (k, v) => (typeof v === "bigint" ? v.toString() : v),
+    2,
+  );
+}
+
+main().catch((e) => console.error(e));
 ```
 
 </CodeExample>

--- a/docs/learn/encyclopedia/contract-development/events.mdx
+++ b/docs/learn/encyclopedia/contract-development/events.mdx
@@ -21,13 +21,7 @@ Events are the mechanism that applications off-chain can use to monitor changes 
 
 ## How are events emitted?
 
-`ContractEvents` are emitted in Stellar Core's `TransactionMeta`. You can see in the [TransactionMetaV3] XDR below that there is a list of `OperationEvents` called `events`. Each `OperationEvent` corresponds to an operation in a transaction, and itself contains a list of `ContractEvents`. Note that `events` will only be populated if the transaction succeeds. Take a look at the [events guides](../../../build/guides/events/README.mdx) and [this example](../../../build/smart-contracts/example-contracts/events.mdx) to learn more about how to work with events.
-
-:::info
-
-Events are ephemeral, the data retention window is a maximum of 7 days. See the [ingestion guide](../../../build/guides/events/ingest.mdx) to learn how to work with this constraint.
-
-:::
+`ContractEvents` are emitted in Stellar Core's `TransactionMeta`. You can see in the [TransactionMetaV3] XDR below that there is a list of `OperationEvents` called `events`. Each `OperationEvent` corresponds to an operation in a transaction, and itself contains a list of `ContractEvents`. Note that `events` will only be populated if the transaction succeeds.
 
 [transactionmetav3]: #transactionmetav3
 
@@ -133,3 +127,97 @@ The `fn_return` diagnostic event is emitted when a contract call completes and c
 `events` contain `ContractEvents` that should convey information about state changes. `diagnosticEvents` on the other hand contain events that are not useful for most users, but may be helpful in debugging issues or building the contract call stack. Because they won't be used by most users, they can be optionally enabled because they are not hashed into the ledger, and therefore are not part of the protocol. This is done so a stellar-core node can stay in sync with the network while emitting these events that normally would not be useful for most users.
 
 Due to the fact that a node with diagnostic events enabled will be executing code paths that diverge from a regular node, we highly encourage only using this feature on watcher node (nodes where `NODE_IS_VALIDATOR=false` is set).
+
+## Reading events
+
+You can use the [`getEvents`](../../../data/rpc/api-reference/methods/getEvents.mdx) endpoint of any RPC service to fetch and filter events by type, contract, and topic.
+
+:::warning
+
+Events are ephemeral: RPC providers typically only keep short chunks (less than a week) of history around.
+
+:::
+
+To learn more about working with events, take a look at the [events guides](../../../build/guides/events/README.mdx) and [this example contract](../../../build/smart-contracts/example-contracts/events.mdx).
+
+For a quick high-level demonstration, though, we'll use the [TypeScript SDK](../../../tools/sdks/README.mdx) to infinitely fetch all `transfer` events (defined by the [Soroban Token Interface](https://stellar.org/protocol/sep-41#interface)) involving the [XLM contract](https://stellar.expert/explorer/testnet/contract/CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC) and display them in a human-friendly format.
+
+<CodeExample>
+
+```typescript
+import { humanizeEvents, nativeToScVal } from "@stellar/stellar-sdk";
+import { Server } from "@stellar/stellar-sdk/rpc";
+
+const s = new Server("https://soroban-testnet.stellar.org");
+
+function main() {
+  const r = await s.getLatestLedger();
+
+  const xlmFilter = {
+    type: "contract",
+    contractIds: ["CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"],
+    topics: [[
+      nativeToScVal("transfer", { type: "symbol" }),
+      "*",
+      "*",
+    ]],
+  };
+  let page = await s.getEvents({
+    startLedger: r.sequence - 1,
+    filters: [xlmFilter],
+  });
+
+  while (true) {
+    //
+    // Two ways to output a human-friendly version:
+    //  1. the RPC response itself for human-readable text
+    //  2. a helper for the XDR structured-equivalent for human-readable JSON
+    //
+
+    // 1: lazy
+    console.log(
+      JSON.stringify(
+        page.events.map(event => {
+          return {
+            topics: event.topics.map(t => scValToNative(t)),
+            value: scValToNative(event.value),
+          };
+        ),
+        null,
+        2, // indent JSON
+      )
+
+    // 2: comprehensive
+    console.log(
+      JSON.stringify(
+        humanizeEvents(
+          page.events.map(event => {
+            // rebuild the decomposed response into its original XDR structure
+            return new xdr.ContractEvent({
+              contractId: new Address(event.contractId).toBuffer(),
+              type: xdr.ContractEventType.contract(), // since we filtered on 'contract'
+              body: new xdr.ContractEventBody(0, new xdr.ContractEventV0({
+                topics: event.topic.map(t => xdr.ScVal.fromXDR(t, "base64")),
+                value: xdr.ScVal.fromXDR(event.value, "base64"),
+              }))
+            });
+          })
+        ),
+        null,
+        2, // indent JSON
+      )
+    );
+
+    page = await s.getEvents({
+      pagination: { cursor: page.cursor },
+      filters: [xlmFilter],
+    });
+
+    await new Promise(r => setTimeout(r, 5000)); // pause until the next ledger-ish
+  }
+}
+```
+
+</CodeExample>
+
+You can also leverage RPC's alternate [XDR encoding formats](../../../data/rpc/api-reference/structure/data-format) like JSON to see human-readable events from the command-line directly, for example by passing `xdrFormat: "json"` as an additional parameter to the `getEvents` [example](../../../data/rpc/api-reference/methods/getEvents#examples).

--- a/openrpc/src/stellar-rpc/schemas/Event.json
+++ b/openrpc/src/stellar-rpc/schemas/Event.json
@@ -30,7 +30,7 @@
             },
             "topic": {
                 "type": "array",
-                "description": "List containing the topic this event was emitted with.",
+                "description": "The [ScVal](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-contract.x#L214)s containing the topics this event was emitted with (as a base64 string).",
                 "$ref": "#/components/schemas/TopicFilter"
             },
             "value": {
@@ -53,7 +53,7 @@
         "type": "string"
     },
     "EventValue": {
-        "description": "The emitted body value of the [DiagnosticEvent](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L360) structure (serialized as a base64 string).",
+        "description": "The data emitted by the event (an [ScVal](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-contract.x#L214), serialized as a base64 string).",
         "type": "string"
     }
 }


### PR DESCRIPTION
The main purpose is to highlight [`humanizeEvents`](https://stellar.github.io/js-stellar-sdk/global.html#humanizeEvents) but it's a little hard to shoe-horn in without a fuller example.

Closes part of https://github.com/stellar/stellar-docs/issues/471.

[Direct link](https://developers-pr1380.previews.kube001.services.stellar-ops.com/docs/learn/encyclopedia/contract-development/events) to page in preview.