### PR TITLE
add `--no-minify` to yarn build commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . /app/
 ARG CROWDIN_PERSONAL_TOKEN
 ARG BUILD_TRANSLATIONS="False"
 
-RUN yarn clear
+RUN yarn cache clean --all
 RUN yarn install
 RUN yarn rpcspec:build --no-minify
 RUN yarn stellar-cli:build --no-minify

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,17 @@ COPY . /app/
 ARG CROWDIN_PERSONAL_TOKEN
 ARG BUILD_TRANSLATIONS="False"
 
+RUN yarn clear
 RUN yarn install
-RUN yarn rpcspec:build
-RUN yarn stellar-cli:build
+RUN yarn rpcspec:build --no-minify
+RUN yarn stellar-cli:build --no-minify
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN if [ "$BUILD_TRANSLATIONS" = "True" ]; then \
-    CROWDIN_PERSONAL_TOKEN=${CROWDIN_PERSONAL_TOKEN} yarn build:production; \
+    CROWDIN_PERSONAL_TOKEN=${CROWDIN_PERSONAL_TOKEN} yarn build:production --no-minify; \
   else \
     # In the preview build, we only want to build for English. Much quicker
-    yarn build; \
+    yarn build --no-minify; \
   fi
 
 FROM nginx:1.27


### PR DESCRIPTION
### What
add `--no-minify` to yarn build commands

### Why
see if it improves build time and lowers memory usage

### Testing before merge
N/A

### Validation after merge
check mem usage on the build agent

### Issue addressed by this PR
https://github.com/stellar/ops/issues/3530