### PR TITLE
Add URLs back to api providers table

### DIFF
--- a/docs/data/apis/api-providers.mdx
+++ b/docs/data/apis/api-providers.mdx
@@ -32,11 +32,16 @@ These providers allow access to the Futurenet, Testnet and Mainnet network.
 
 ### Publicly Accessible APIs
 
-| Provider | Futurenet | Testnet | Mainnet |
-| --- | --- | --- | --- |
-| [Liquify](https://www.liquify.io/) | ✅ [RPC](https://stellar.liquify.com/api=41EEWAH79Y5OCGI7/futurenet) | ✅ [RPC](https://stellar.liquify.com/api=41EEWAH79Y5OCGI7/testnet) | ✅ [RPC](https://stellar-mainnet.liquify.com/api=41EEWAH79Y5OCGI7/mainnet) |
-| [Gateway](https://gateway.fm/) | ❌ | ✅ [RPC](https://soroban-rpc.testnet.stellar.gateway.fm) | ✅ [RPC](https://soroban-rpc.mainnet.stellar.gateway.fm) |
-| [sorobanrpc.com](https://sorobanrpc.com/) | ❌ | ❌ | ✅ [RPC](https://mainnet.sorobanrpc.com) |
-| [Nodies](https://nodies.org) | ❌ | [RPC](https://stellar-soroban-testnet-public.nodies.app) | ✅ [RPC](https://stellar-soroban-public.nodies.app) |
-| [SDF](http://www.stellar.org) | ✅ [RPC](https://rpc-futurenet.stellar.org) <br /> ✅ [Horizon](https://horizon-futurenet.stellar.org) | ✅ [RPC](https://soroban-testnet.stellar.org) <br /> ✅ [Horizon](https://horizon-testnet.stellar.org) | ❌ |
-| [LOBSTR](https://lobstr.co) | ❌ | ❌ | ✅ [Horizon](https://horizon.stellar.lobstr.co) |
+| Provider | Network | URL |
+| --- | --- | --- |
+| [Liquify](https://www.liquify.io/) | Futurenet | RPC: `https://stellar.liquify.com/api=41EEWAH79Y5OCGI7/futurenet` |
+|  | Testnet | RPC: `https://stellar.liquify.com/api=41EEWAH79Y5OCGI7/testnet` |
+|  | Mainnet | RPC: `https://stellar-mainnet.liquify.com/api=41EEWAH79Y5OCGI7/mainnet` |
+| [Gateway](https://gateway.fm/) | Testnet | RPC: `https://soroban-rpc.testnet.stellar.gateway.fm` |
+|  | Mainnet | RPC: `https://soroban-rpc.mainnet.stellar.gateway.fm` |
+| [sorobanrpc.com](https://sorobanrpc.com/) | Mainnet | RPC: `https://mainnet.sorobanrpc.com` |
+| [Nodies](https://nodies.org) | Testnet | RPC: `https://stellar-soroban-testnet-public.nodies.app` |
+|  | Mainnet | RPC: `https://stellar-soroban-public.nodies.app` |
+| [SDF](http://www.stellar.org) | Futurenet | RPC: `https://rpc-futurenet.stellar.org` <br /> Horizon: `https://horizon-futurenet.stellar.org` |
+|  | Testnet | RPC: `https://soroban-testnet.stellar.org` <br /> Horizon: `https://horizon-testnet.stellar.org` |
+| [LOBSTR](https://lobstr.co) | Mainnet | Horizon: `https://horizon.stellar.lobstr.co` |


### PR DESCRIPTION
We want the actual text of the URLs to appear in this table so that people can copy/paste them easily (ex. into Stellar Lab). Thread [here](https://stellarfoundation.slack.com/archives/C076K52SECF/p1741875960131389).

Just straight replacing the links with URLs makes the table wide and adds a scroll bar such that rightmost columns get hidden, like so:

![image](https://github.com/user-attachments/assets/b4266c3d-0001-4fd8-9269-ae7a8b510bb4)

Instead I've reformatted the table slightly to show the same info but alleviate that issue:

![image](https://github.com/user-attachments/assets/c2e1f76b-5313-4e56-8006-ff63e6abf912)

I'm open to other ideas opinions on what would be better.