### PR TITLE
Remove ingest SDK placeholder 

### DIFF
--- a/docs/data/indexers/build-your-own/README.mdx
+++ b/docs/data/indexers/build-your-own/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build Your Own Indexing
+title: Build Your Own Indexer
 sidebar_position: 0
 ---
 
@@ -8,7 +8,3 @@ Learn about the services and tools that you can build custom indexing with.
 ## [Galexie](./galexie/README.mdx)
 
 Galexie is a tool for extracting, processing, exporting Stellar ledger metadata to external storage, and creating a data lake of pre-processed ledger metadata. Galexie is the foundation of the Composable Data Pipeline (CDP) and serves as the first step in extracting raw Stellar ledger metadata and making it accessible. Learn more about CDP’s benefits and applications in [this blog post](https://stellar.org/blog/developers/composable-data-platform).
-
-## Ingest Library
-
-Placeholder for ingest docs


### PR DESCRIPTION
While we wait for the merge of ingest docs. Cause it's weird to have mention of a placeholder in the public docs