### PR TITLE
add error codes on JSON-RPC doc

### DIFF
--- a/docs/data/apis/rpc/api-reference/structure/json-rpc.mdx
+++ b/docs/data/apis/rpc/api-reference/structure/json-rpc.mdx
@@ -17,6 +17,19 @@ Please note that parameter structure must contain named parameters as a by-name 
 
 :::
 
+## Error codes
+
+<div>
+
+| Error code | Meaning                                      |
+| :--------- | :------------------------------------------- |
+| -32600     | The JSON sent is not a valid Request object  |
+| -32601     | The method does not exist / is not available |
+| -32602     | Invalid method parameter(s)                  |
+| -32603     | Internal JSON-RPC error                      |
+
+</div>
+
 ## Example Request
 
 ```json


### PR DESCRIPTION
RPC Error Codes are listed under [Anchor Platform Doc](https://developers.stellar.org/platforms/anchor-platform/admin-guide/sep6/integration#error-codes). It would be nice to also list it under `JSON-RPC` doc