### PR TITLE
fix absolute paths using '/docs/' in some ingest links

### DIFF
--- a/docs/data/indexers/build-your-own/README.mdx
+++ b/docs/data/indexers/build-your-own/README.mdx
@@ -13,7 +13,7 @@ Galexie is a tool for acquiring Stellar ledger metadata from the network and exp
 
 - You want to maintain a data lake of pre-computed ledger metadata for historical and currently closed network ledgers.
 
-## Ingest SDK
+## [Ingest SDK](./ingest-sdk/README.mdx)
 
 A set of Golang packages which can be used within application as a programmatic domain model to interact with Stellar network.
 

--- a/docs/data/indexers/build-your-own/ingest-sdk/README.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/README.mdx
@@ -5,27 +5,27 @@ sidebar_position: 0
 
 ## What is the Ingest SDK?
 
-The SDK is composed of several published Golang packages under `github.com/stellar/go` for acquiring and parsing data from the Stellar network. It provides language level bindings which convert the [binary XDR encoded](/docs/learn/encyclopedia/data-format/xdr) streams emitted from the network into fluent programmatic data model bindings.
+The SDK is composed of several published Golang packages under `github.com/stellar/go` for acquiring and parsing data from the Stellar network. It provides language level bindings which convert the [binary XDR encoded](../../../../learn/encyclopedia/data-format/xdr.mdx) streams emitted from the network into fluent programmatic data model bindings.
 
 ## Why use the Ingest SDK?
 
-Applications can leverage the SDK to rapidly develop ingestion pipelines capable of acquiring real-time or historical Stellar network data and deriving custom data models. The SDK enables applications to traverse the hierarchal data structures of the network: [history archives](/docs/validators/admin-guide/environment-preparation#history-archives), [ledgers](/docs/learn/fundamentals/stellar-data-structures/ledgers), transactions, operations, ledger state changes, and events.
+Applications can leverage the SDK to rapidly develop ingestion pipelines capable of acquiring real-time or historical Stellar network data and deriving custom data models. The SDK enables applications to traverse the hierarchal data structures of the network: [history archives](../../../../validators/admin-guide/environment-preparation.mdx#history-archives), [ledgers](../../../../learn/fundamentals/stellar-data-structures/ledgers.mdx), transactions, operations, ledger state changes, and events.
 
 Use the SDK for an intuitive, compile-time, type-safe developer experience to work with the main types of network data:
 
 ### Ledger Entries
 
-Obtain the final state of [ledger entries](/docs/learn/fundamentals/stellar-data-structures/ledgers.mdx) on the network at close of any recent or historically aged checkpoint ledger sequence. A Checkpoint ledger occurs once every 64 ledgers, during which the network will publish this data to [history archives](/docs/validators/admin-guide/environment-preparation#history-archives) in the format of compressed files which contain lists of `BucketEntry`, wherein each contains one `LedgerEntry` and the `LedgerKey`.
+Obtain the final state of [ledger entries](../../../../learn/fundamentals/stellar-data-structures/ledgers.mdx) on the network at close of any recent or historically aged checkpoint ledger sequence. A Checkpoint ledger occurs once every 64 ledgers, during which the network will publish this data to [history archives](../../../../validators/admin-guide/environment-preparation.mdx#history-archives) in the format of compressed files which contain lists of `BucketEntry`, wherein each contains one `LedgerEntry` and the `LedgerKey`.
 
-Ledger entries are cryptographically signed as part of each ledger and therefore represent the trusted, cumulative state at a point in time for [assets](/docs/learn/fundamentals/stellar-data-structures/assets.mdx) related to an [account](/docs/learn/fundamentals/stellar-data-structures/accounts) or [contract](/docs/learn/encyclopedia/storage/persisting-data). Examples of asset types:
+Ledger entries are cryptographically signed as part of each ledger and therefore represent the trusted, cumulative state at a point in time for [assets](../../../../learn/fundamentals/stellar-data-structures/assets.mdx) related to an [account](../../../../learn/fundamentals/stellar-data-structures/accounts.mdx) or [contract](../../../../learn/encyclopedia/storage/persisting-data.mdx). Examples of asset types:
 
 - trustlines which hold token balances
-- offers which hold bid and asks on the [stellar network DEX](/docs/learn/encyclopedia/sdex/liquidity-on-stellar-sdex-liquidity-pools#sdex)
+- offers which hold bid and asks on the [stellar network DEX](../../../../learn/encyclopedia/sdex/liquidity-on-stellar-sdex-liquidity-pools.mdx#sdex)
 - contract data which holds key/value stores for contracts
 
 ### Ledger Metadata
 
-Gain access to all transactions and their nested operations which were included in each closed ledger. It also contains the changes(pre/post) for each ledger entry when it is changed due to transaction activity and all [Soroban contract events](/docs/learn/encyclopedia/contract-development/events) emitted as a result of [contract](/docs/learn/fundamentals/stellar-data-structures/contracts) invocations during transaction execution. It is effectively a commit log for ledger entries.
+Gain access to all transactions and their nested operations which were included in each closed ledger. It also contains the changes(pre/post) for each ledger entry when it is changed due to transaction activity and all [Soroban contract events](../../../../learn/encyclopedia/contract-development/events.mdx) emitted as a result of [contract](../../../../learn/fundamentals/stellar-data-structures/contracts.mdx) invocations during transaction execution. It is effectively a commit log for ledger entries.
 
 Use the metadata to detect incremental changes in ledger entries that occur as a result of each transaction. These changes and the events emitted after each transaction represent valuabe data models specific to a point in time(expressed as a ledger sequence on the network), some real world examples:
 

--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -102,7 +102,7 @@ This SDK is split up into separate packages, all of which you can find in the [G
 - `txnbuild` [SDK](https://github.com/stellar/go/tree/master/txnbuild) | [Docs](https://godoc.org/github.com/stellar/go/txnbuild): enables the construction, signing, and encoding of Stellar transactions.
 - `Horizon Client` [SDK](https://github.com/stellar/go/tree/master/clients/horizonclient) | [Docs](https://godoc.org/github.com/stellar/go/clients/horizonclient): provides a web client for interfacing with Horizon server REST endpoints to retrieve ledger information and submit transactions built with `txnbuild`.
 - `RPC Client` [SDK](https://github.com/stellar/stellar-rpc/tree/main/client) | [Docs](https://pkg.go.dev/github.com/stellar/stellar-rpc/client): provide sdk wrapper to invoke RPC endpoints.
-- [Ingest SDK](/docs/data/indexers/build-your-own/ingest-sdk/README.mdx): acquire and parse data from the Stellar network.
+- [Ingest SDK](../../data/indexers/build-your-own/ingest-sdk/README.mdx): acquire and parse data from the Stellar network.
 
 ## Ruby
 


### PR DESCRIPTION
there were a few remaining links that used absolute link paths starting with  '/docs/', converted them to relative, and needed to add `.mdx` to the links also, it was causing deployment job to fail.

i'm able to run `yarn build --no-minify` locally with no errors on links and `yarn serve` looks good

@ElliotFriend , what's the best way to test that a version will work with internationalization/translation? 