### PR TITLE
change simulation state changes type to string

### DIFF
--- a/openrpc/src/anchor-platform/contentDescriptors/customer.json
+++ b/openrpc/src/anchor-platform/contentDescriptors/customer.json
@@ -2,7 +2,7 @@
   "customer_id": {
     "name": "customer_id",
     "description": "The SEP-12 ID of the customer",
-    "required": "false",
+    "required": false,
     "schema": {
       "type": "string"
     }
@@ -10,7 +10,7 @@
   "customer_type": {
     "name": "customer_type",
     "description": "The SEP-12 type of the customer",
-    "required": "false",
+    "required": false,
     "schema": {
       "type": "string"
     }

--- a/openrpc/src/stellar-rpc/methods/simulateTransaction.json
+++ b/openrpc/src/stellar-rpc/methods/simulateTransaction.json
@@ -85,8 +85,12 @@
                         "type": "object",
                         "properties": {
                             "type": {
-                                "type": "integer",
-                                "enum": [1, 2, 3],
+                                "type": "string",
+                                "enum": [
+                                    "created",
+                                    "updated",
+                                    "deleted"
+                                ],
                                 "description": "Indicates if the entry was created (1), updated (2), or deleted (3)"
                             },
                             "key": {

--- a/openrpc/src/stellar-rpc/methods/simulateTransaction.json
+++ b/openrpc/src/stellar-rpc/methods/simulateTransaction.json
@@ -91,7 +91,7 @@
                                     "updated",
                                     "deleted"
                                 ],
-                                "description": "Indicates if the entry was created (1), updated (2), or deleted (3)"
+                                "description": "Indicates if the entry was created, updated, or deleted"
                             },
                             "key": {
                                 "type": "string",

--- a/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
+++ b/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
@@ -2654,7 +2654,7 @@
         {
           "name": "customer_id",
           "description": "The SEP-12 ID of the customer",
-          "required": "false",
+          "required": false,
           "schema": {
             "type": "string"
           }
@@ -2662,7 +2662,7 @@
         {
           "name": "customer_type",
           "description": "The SEP-12 type of the customer",
-          "required": "false",
+          "required": false,
           "schema": {
             "type": "string"
           }

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -1944,7 +1944,7 @@
                       "updated",
                       "deleted"
                     ],
-                    "description": "Indicates if the entry was created (1), updated (2), or deleted (3)"
+                    "description": "Indicates if the entry was created, updated, or deleted"
                   },
                   "key": {
                     "type": "string",

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -35,7 +35,7 @@
       "summary": "returns contract events",
       "description": "Clients can request a filtered list of events emitted by a given ledger range.\n\nStellar-RPC will support querying within a maximum 7 days of recent ledgers.\n\nNote, this could be used by the client to only prompt a refresh when there is a new ledger with relevant events. It should also be used by backend Dapp components to \"ingest\" events into their own database for querying and serving.\n\nIf making multiple requests, clients should deduplicate any events received, based on the event's unique id field. This prevents double-processing in the case of duplicate events being received.\n\nBy default stellar-rpc retains the most recent 24 hours of events.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getEvents"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getEvents"
       },
       "paramStructure": "by-name",
       "params": [
@@ -194,7 +194,7 @@
                   },
                   "topic": {
                     "type": "array",
-                    "description": "List containing the topic this event was emitted with.",
+                    "description": "The [ScVal](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-contract.x#L214)s containing the topics this event was emitted with (as a base64 string).",
                     "minItems": 1,
                     "maxItems": 4,
                     "items": {
@@ -204,7 +204,7 @@
                     }
                   },
                   "value": {
-                    "description": "The emitted body value of the [DiagnosticEvent](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L360) structure (serialized as a base64 string).",
+                    "description": "The data emitted by the event (an [ScVal](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-contract.x#L214), serialized as a base64 string).",
                     "type": "string"
                   },
                   "txHash": {
@@ -368,7 +368,7 @@
       "summary": "returns statistics about charged inclusion fees",
       "description": "Statistics for charged inclusion fees. The inclusion fee statistics are calculated from the inclusion fees that were paid for the transactions to be included onto the ledger. For Soroban transactions and Stellar transactions, they each have their own inclusion fees and own surge pricing. Inclusion fees are used to prevent spam and prioritize transactions during network traffic surge.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getFeeStats"
       },
       "paramStructure": "by-name",
       "params": [],
@@ -580,7 +580,7 @@
       "summary": "returns node health",
       "description": "General node health check.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getHealth"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getHealth"
       },
       "paramStructure": "by-name",
       "params": [],
@@ -630,7 +630,7 @@
       "summary": "returns latest known ledger",
       "description": "For finding out the current latest known ledger of this node. This is a subset of the ledger info from Horizon.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getLatestLedger"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getLatestLedger"
       },
       "paramStructure": "by-name",
       "params": [],
@@ -681,7 +681,7 @@
       "summary": "returns ledger entries",
       "description": "For reading the current value of ledger entries directly.\n\nThis method enables querying live ledger state: accounts, trustlines, offers, data, claimable balances, and liquidity pools. It also provides direct access to inspect a contract's current state, its code, or any other ledger entry. This serves as a primary method to access your contract data which may not be available via events or `simulateTransaction`.\n\nTo fetch contract wasm byte-code, use the ContractCode ledger entry key.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getLedgerEntries"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getLedgerEntries"
       },
       "paramStructure": "by-name",
       "params": [
@@ -850,7 +850,7 @@
       "summary": "returns a list of ledgers with their details",
       "description": "The `getLedgers` method returns a detailed list of ledgers starting from the user specified starting point that you can paginate as long as the pages fall within the history retention of their corresponding RPC provider.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getLedgers"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getLedgers"
       },
       "paramStructure": "by-name",
       "params": [
@@ -1010,7 +1010,7 @@
       "summary": "returns network config",
       "description": "General information about the currently configured network. This response will contain all the information needed to successfully submit transactions to the network this node serves.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getNetwork"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getNetwork"
       },
       "paramStructure": "by-name",
       "params": [],
@@ -1074,7 +1074,7 @@
       "summary": "returns transaction details",
       "description": "The getTransaction method provides details about the specified transaction. Clients are expected to periodically query this method to ascertain when a transaction has been successfully recorded on the blockchain. The stellar-rpc system maintains a restricted history of recently processed transactions, with the default retention window set at 24 hours. For private soroban-rpc instances, it is possible to modify the retention window value by adjusting the transaction-retention-window configuration setting, but we do not recommend values longer than 7 days. For debugging needs that extend beyond this timeframe, it is advisable to index this data yourself, employ a third-party [indexer](https://developers.stellar.org/docs/tools/developer-tools/data-indexers), or query [Hubble](https://developers.stellar.org/docs/data/hubble) (our public BigQuery data set).",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransaction"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getTransaction"
       },
       "paramStructure": "by-name",
       "params": [
@@ -1264,7 +1264,7 @@
       "summary": "returns a list of transactions with their details",
       "description": "The `getTransactions` method return a detailed list of transactions starting from the user specified starting point that you can paginate as long as the pages fall within the history retention of their corresponding RPC provider.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransactions"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getTransactions"
       },
       "paramStructure": "by-name",
       "params": [
@@ -1575,7 +1575,7 @@
       "summary": "returns version information of RPC and Captive Core",
       "description": "Version information about the RPC and Captive core. RPC manages its own, pared-down version of Stellar Core optimized for its own subset of needs. we'll refer to this as a \"Captive Core\" instance.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getVersionInfo"
       },
       "paramStructure": "by-name",
       "params": [],
@@ -1642,7 +1642,7 @@
       "summary": "submits a transaction",
       "description": "Submit a real transaction to the Stellar network. This is the only way to make changes on-chain.\n\n Unlike Horizon, this does not wait for transaction completion. It simply validates and enqueues the transaction. Clients should call `getTransaction` to learn about transaction success/failure.\n\nThis supports all transactions, not only smart contract-related transactions.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/sendTransaction"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/sendTransaction"
       },
       "paramStructure": "by-name",
       "params": [
@@ -1808,7 +1808,7 @@
       "summary": "submits a trial contract invocation transaction",
       "description": "Submit a trial contract invocation to simulate how it would be executed by the network. This endpoint calculates the effective transaction data, required authorizations, and minimal resource fee. It provides a way to test and analyze the potential outcomes of a transaction without actually submitting it to the network.",
       "externalDocs": {
-        "url": "https://developers.stellar.org/docs/data/rpc/api-reference/methods/simulateTransaction"
+        "url": "https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/simulateTransaction"
       },
       "paramStructure": "by-name",
       "params": [
@@ -1938,11 +1938,11 @@
                 ],
                 "properties": {
                   "type": {
-                    "type": "integer",
+                    "type": "string",
                     "enum": [
-                      1,
-                      2,
-                      3
+                      "created",
+                      "updated",
+                      "deleted"
                     ],
                     "description": "Indicates if the entry was created (1), updated (2), or deleted (3)"
                   },


### PR DESCRIPTION
This modifies the `simulateTransaction` response to include the `stateChanges[].type` as a string, like it is returned from the RPC server.

It appears [here](https://github.com/stellar/stellar-rpc/blob/49af4430cbcef8bb9995e4b266a36c619da7650f/protocol/simulate_transaction.go#L47C12-L47C12) in the `soroban-rpc` repo, that `LedgerEntryChangeType` is indeed an integer, but then there are some fancy-looking Golang things that I don't fully understand, but seems like it's what's responsible for it being returned as a string. @Shaptic, can you confirm that it's not a bug in the RPC server, but rather the spec, and that the server _is indeed_ designed to return a string for the state change type?

Fixes #1399