### PR TITLE
Add tooling docs URL redirects for #1444

### DIFF
--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -186,3 +186,8 @@ rewrite ^/docs/data/galexie(.*)$ "/docs/data/indexers/build-your-own/galexie$1" 
 
 # Indexer redirects
 rewrite ^/docs/data/data-indexers(.*)$ "/docs/data/indexers$1" permanent;
+
+# Moving tooling docs (https://github.com/stellar/stellar-docs/pull/1444)
+rewrite ^/docs/tools/developer-tools/cli(.*)$ "/docs/tools/cli$1" permanent;
+rewrite ^/docs/tools/developer-tools/lab(.*)$ "/docs/tools/lab$1" permanent;
+rewrite ^/docs/tools/developer-tools/quickstart(.*)$ "/docs/tools/quickstart$1" permanent;


### PR DESCRIPTION
### What
Add URL redirects for the moved tooling documentation for #1444.

### Why
Documentation for CLI, Lab, and Quickstart was restructured in PR #1444, requiring redirects to maintain existing links for search engines.