### PR TITLE
Fix local hostnames in SDP Getting Started

### DIFF
--- a/platforms/stellar-disbursement-platform/admin-guide/getting-started.mdx
+++ b/platforms/stellar-disbursement-platform/admin-guide/getting-started.mdx
@@ -133,8 +133,8 @@ When you ran `main.sh` file, you've already created new tenants: `tenants=("redc
 Be sure that the added tenant hosts are included in the host configuration file. To check it, you can run the command cat `/etc/hosts`. To include them, you can run command sudo nano /etc/hosts and insert the lines below:
 
 ```
-127.0.0.1       bluecorp.sdp.local
-127.0.0.1       redcorp.sdp.local
+127.0.0.1       bluecorp.stellar.local
+127.0.0.1       redcorp.stellar.local
 ```
 
 ## Setup Owner User Password for each tenant


### PR DESCRIPTION
`main.sh` and the [docs](https://developers.stellar.org/platforms/stellar-disbursement-platform/admin-guide/getting-started#setup-owner-user-password-for-each-tenant) reference `*.stellar.local` hostnames:
```
🔗Tenant redcorp: http://redcorp.stellar.local:3000
username: owner@redcorp.local  password: Password123!
🔗Tenant bluecorp: http://bluecorp.stellar.local:3000
username: owner@bluecorp.local  password: Password123!
🔗Tenant pinkcorp: http://pinkcorp.stellar.local:3000
username: owner@pinkcorp.local  password: Password123!
WARN pinkcorp.stellar.local missing from /etc/hosts
```

This PR updates the `/etc/host` modifications.