### PR TITLE
Add information about running validators in kubernetes

### DIFF
--- a/docs/validators/admin-guide/prerequisites.mdx
+++ b/docs/validators/admin-guide/prerequisites.mdx
@@ -86,13 +86,13 @@ Buckets should be stored on a fast, local disk with sufficient space to store se
 
 ## Kubernetes considerations
 
-We currently do not recommend runnig validator nodes in kubernetes. If you choose to do so, consider the following:
+We currently do not recommend running validator nodes in Kubernetes. If you choose to do so, consider the following:
 
-- sensitive data such as node seeds will be stored in kubernetes etcd. Consider consuming credentials using tools like [vault agent](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) or the [AWS Secrets Store CSI driver](https://github.com/aws/secrets-store-csi-driver-provider-aws) to improve security
-- consider how external traffic will reach the pods. Tier 1 nodes need public DNS names and necessary ports must be accessible from the internet
-- validators have unique seeds and history archive configurations, so each pod will require its own specific configuration
-- ensure that sufficient resources are always available to the pods
-- depending on how history archives are published, you may need to fork docker images to include extra tooling
+- Sensitive data such as node seeds will be stored in Kubernetes etcd. Consider consuming credentials using tools like [vault agent](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) or the [AWS Secrets Store CSI driver](https://github.com/aws/secrets-store-csi-driver-provider-aws) to improve security
+- Consider how external traffic will reach the pods. Tier 1 nodes need public DNS names and necessary ports must be accessible from the internet
+- Validators have unique seeds and history archive configurations, so each pod will require its own specific configuration
+- Ensure that sufficient resources are always available to the pods
+- Depending on how history archives are published, you may need to fork docker images to include extra tooling
 
 [configure]: ./configuring.mdx
 [c5d.2xlarge]: https://aws.amazon.com/ec2/instance-types/c5/

--- a/docs/validators/admin-guide/prerequisites.mdx
+++ b/docs/validators/admin-guide/prerequisites.mdx
@@ -84,6 +84,16 @@ Stellar-core stores ledger state in the form of flat XDR files called "buckets."
 
 Buckets should be stored on a fast, local disk with sufficient space to store several times the size of the current ledger. Current ledger size is approximately 10 GB (as of April 2024), so please plan accordingly.
 
+## Kubernetes considerations
+
+We currently do not recommend runnig validator nodes in kubernetes. If you choose to do so, consider the following:
+- sensitive data such as node seeds will be stored in kubernetes etcd. Consider consuming credentials using tools like [vault agent](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) or  the [AWS Secrets Store CSI driver](https://github.com/aws/secrets-store-csi-driver-provider-aws) to improve security
+- consider how external traffic will reach the pods. Tier 1 nodes need public DNS names and necessary ports must be accessible from the internet
+- validators have unique seeds and history archive configurations, so each pod will require its own specific configuration
+- ensure that sufficient resources are always available to the pods
+- depending on how history archives are published, you may need to fork docker images to include extra tooling
+
+
 [configure]: ./configuring.mdx
 [c5d.2xlarge]: https://aws.amazon.com/ec2/instance-types/c5/
 [n4-highcpu-8]: https://cloud.google.com/compute/docs/general-purpose-machines#n4-highcpu

--- a/docs/validators/admin-guide/prerequisites.mdx
+++ b/docs/validators/admin-guide/prerequisites.mdx
@@ -87,12 +87,11 @@ Buckets should be stored on a fast, local disk with sufficient space to store se
 ## Kubernetes considerations
 
 We currently do not recommend runnig validator nodes in kubernetes. If you choose to do so, consider the following:
-- sensitive data such as node seeds will be stored in kubernetes etcd. Consider consuming credentials using tools like [vault agent](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) or  the [AWS Secrets Store CSI driver](https://github.com/aws/secrets-store-csi-driver-provider-aws) to improve security
+- sensitive data such as node seeds will be stored in kubernetes etcd. Consider consuming credentials using tools like [vault agent](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) or the [AWS Secrets Store CSI driver](https://github.com/aws/secrets-store-csi-driver-provider-aws) to improve security
 - consider how external traffic will reach the pods. Tier 1 nodes need public DNS names and necessary ports must be accessible from the internet
 - validators have unique seeds and history archive configurations, so each pod will require its own specific configuration
 - ensure that sufficient resources are always available to the pods
 - depending on how history archives are published, you may need to fork docker images to include extra tooling
-
 
 [configure]: ./configuring.mdx
 [c5d.2xlarge]: https://aws.amazon.com/ec2/instance-types/c5/

--- a/docs/validators/admin-guide/prerequisites.mdx
+++ b/docs/validators/admin-guide/prerequisites.mdx
@@ -87,6 +87,7 @@ Buckets should be stored on a fast, local disk with sufficient space to store se
 ## Kubernetes considerations
 
 We currently do not recommend runnig validator nodes in kubernetes. If you choose to do so, consider the following:
+
 - sensitive data such as node seeds will be stored in kubernetes etcd. Consider consuming credentials using tools like [vault agent](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) or the [AWS Secrets Store CSI driver](https://github.com/aws/secrets-store-csi-driver-provider-aws) to improve security
 - consider how external traffic will reach the pods. Tier 1 nodes need public DNS names and necessary ports must be accessible from the internet
 - validators have unique seeds and history archive configurations, so each pod will require its own specific configuration


### PR DESCRIPTION
### What

This change will add guidance for running validators in kubernetes. It also documents what things to consider if operators choose to do so

### Why

Kubernetes is a popular orchestrator so clarify should help the community make informed choices about hosting.