### PR TITLE
[stellar-cli] Add note about how to make your plugin discoverable by the CLI.

### DIFF
--- a/docs/tools/cli/plugins.mdx
+++ b/docs/tools/cli/plugins.mdx
@@ -69,6 +69,12 @@ $ stellar hello
 hello from stellar plugin
 ```
 
+:::tip
+
+If you're using GitHub to host your plugin's repository, consider adding a `stellar-cli-plugin` [repository topic](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics). This way, your plugin will be listed by `stellar plugin search`.
+
+:::
+
 ### Troubleshooting
 
 If Stellar CLI can't find your plugin, make sure you clear all items above:


### PR DESCRIPTION
We need to wait until https://github.com/stellar/stellar-cli/pull/2019 is merged and released.

![CleanShot 2025-05-01 at 15 19 18](https://github.com/user-attachments/assets/7fad7ae7-e749-4ce0-8ae0-58e49d0e5577)
