### PR TITLE
Remove dead link

### DIFF
--- a/docs/data/analytics/hubble/developer-guide/data-curation/getting-started.mdx
+++ b/docs/data/analytics/hubble/developer-guide/data-curation/getting-started.mdx
@@ -5,23 +5,11 @@ sidebar_position: 20
 
 [stellar-dbt-public GitHub repository](https://github.com/stellar/stellar-dbt-public/tree/master)
 
-[stellar/stellar-dbt-public docker images](https://hub.docker.com/r/stellar/stellar-dbt-public)
-
 ## Recommended Usage
-
-### Docker Image
-
-Generally if you do not need to modify any of the stellar-dbt-public code, it is recommended that you use the [stellar/stellar-dbt-public docker images](https://hub.docker.com/r/stellar/stellar-dbt-public)
-
-Example to run locally with docker:
-
-```
-docker run --platform linux/amd64 -ti stellar/stellar-dbt-public:latest <parameters>
-```
 
 ### Import stellar-dbt-public as a dbt Package
 
-Alternatively, if you need to build your own models on top of stellar-dbt-public, you can import stellar-dbt-public as a dbt package into a separate dbt project.
+If you need to build your own models on top of stellar-dbt-public, you can import stellar-dbt-public as a dbt package into a separate dbt project.
 
 Example instructions:
 


### PR DESCRIPTION
We do not create docker images for dbt public, therefore removing instruction to access the image