### PR TITLE
fix: correct import path for hello_world contract client

### DIFF
--- a/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world-frontend.mdx
@@ -99,7 +99,7 @@ The default Astro project consists of a page (`pages/index.astro`) and a welcome
 
 ```ts title="src/pages/index.astro"
 ---
-import * as Client from './packages/hello_world';
+import * as Client from './packages/hello_world/src/index.ts';
 
 const contract = new Client.Client({
    ...Client.networks.testnet,


### PR DESCRIPTION
Fixed the import path to point to the actual location of the TypeScript file at packages/hello_world/src/index.ts, resolving the module not found error.