### PR TITLE
Add cloud deployment quickstart docs

### DIFF
--- a/docs/tools/quickstart/cloud/README.mdx
+++ b/docs/tools/quickstart/cloud/README.mdx
@@ -13,7 +13,11 @@ Quickstart can be deployed to any cloud to create a shareable test network for c
 
 Any platform supporting a container runtime can deploy the `docker.io/stellar/quickstart:latest` image.
 
-:::warning Quickstart is designed for development and testing, and not production. :::
+:::warning
+
+Quickstart is designed for development and testing, and not production.
+
+:::
 
 See some examples for how to deploy on different providers:
 

--- a/docs/tools/quickstart/cloud/README.mdx
+++ b/docs/tools/quickstart/cloud/README.mdx
@@ -1,0 +1,17 @@
+---
+title: Cloud Deployment
+description: Quickstart can be deployed to any cloud to create a shareable test network
+sidebar_label: Cloud Deployment
+sidebar_position: 50
+---
+
+import DocCardList from "@theme/DocCardList";
+
+# Cloud Deployment
+
+
+Quickstart can be deployed to any cloud to create a shareable test network for coordinated and multi-person testing.
+
+See some examples for how to deploy on different providers:
+
+<DocCardList />

--- a/docs/tools/quickstart/cloud/README.mdx
+++ b/docs/tools/quickstart/cloud/README.mdx
@@ -17,6 +17,17 @@ Any platform supporting a container runtime can deploy the Quickstart image:
 docker.io/stellar/quickstart:latest
 ```
 
+Use the following environment variables to configure the image:
+
+- `NETWORK` - The network that the container will setup or connect to. One of:
+  - `local` - A new local network will be created for development / testing.
+  - `testnet` - The container will connect to the public testnet.
+- `NETWORK_PASSPHRASE` - For `local` networks the network passphrase that will be used.
+- `RANDOMIZE_NETWORK_PASSPHRASE` - For `local` networks the network passphrase will have a random suffix.
+- `LIMITS` - The network limits that will be configured for smart contracts. One of:
+  - `testnet` - Limits that match the public testnet.
+  - `unlimited` - Max limits supported by the network under any configuration. Useful for experimental testing prior to optimization.
+
 :::warning
 
 Quickstart is designed for development and testing, not production.

--- a/docs/tools/quickstart/cloud/README.mdx
+++ b/docs/tools/quickstart/cloud/README.mdx
@@ -9,8 +9,11 @@ import DocCardList from "@theme/DocCardList";
 
 # Cloud Deployment
 
-
 Quickstart can be deployed to any cloud to create a shareable test network for coordinated and multi-person testing.
+
+Any platform supporting a container runtime can deploy the `docker.io/stellar/quickstart:latest` image.
+
+:::warning Quickstart is designed for development and testing, and not production. :::
 
 See some examples for how to deploy on different providers:
 

--- a/docs/tools/quickstart/cloud/README.mdx
+++ b/docs/tools/quickstart/cloud/README.mdx
@@ -9,16 +9,20 @@ import DocCardList from "@theme/DocCardList";
 
 # Cloud Deployment
 
-Quickstart can be deployed to any cloud to create a shareable test network for coordinated and multi-person testing.
+Quickstart can be deployed to a cloud platform to create a shareable test network for coordinated and multi-person testing.
 
-Any platform supporting a container runtime can deploy the `docker.io/stellar/quickstart:latest` image.
+Any platform supporting a container runtime can deploy the Quickstart image:
+
+```
+docker.io/stellar/quickstart:latest
+```
 
 :::warning
 
-Quickstart is designed for development and testing, and not production.
+Quickstart is designed for development and testing, not production.
 
 :::
 
-See some examples for how to deploy on different providers:
+Examples for how to deploy on different providers:
 
 <DocCardList />

--- a/docs/tools/quickstart/cloud/README.mdx
+++ b/docs/tools/quickstart/cloud/README.mdx
@@ -2,7 +2,7 @@
 title: Cloud Deployment
 description: Quickstart can be deployed to any cloud to create a shareable test network
 sidebar_label: Cloud Deployment
-sidebar_position: 50
+sidebar_position: 45
 ---
 
 import DocCardList from "@theme/DocCardList";

--- a/docs/tools/quickstart/cloud/_category_.json
+++ b/docs/tools/quickstart/cloud/_category_.json
@@ -1,0 +1,3 @@
+{
+    "collapsed": true
+}

--- a/docs/tools/quickstart/cloud/digitalocean.mdx
+++ b/docs/tools/quickstart/cloud/digitalocean.mdx
@@ -1,6 +1,6 @@
 ---
 title: DigitalOcean
-description: Deploying quickstart to DigitalOcean
+description: Deploy Quickstart to DigitalOcean
 sidebar_label: Digital Ocean
 sidebar_position: 10
 ---

--- a/docs/tools/quickstart/cloud/digitalocean.mdx
+++ b/docs/tools/quickstart/cloud/digitalocean.mdx
@@ -7,6 +7,6 @@ sidebar_position: 10
 
 # DigitalOcean
 
-Deploy to DigitalOcean with the DigitalOcean web new app prefilled:
+Deploy to DigitalOcean App Platform using the following link:
 
 [![Deploy to DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/stellar/quickstart/tree/master)

--- a/docs/tools/quickstart/cloud/digitalocean.mdx
+++ b/docs/tools/quickstart/cloud/digitalocean.mdx
@@ -1,0 +1,12 @@
+---
+title: DigitalOcean
+description: Deploying quickstart to DigitalOcean
+sidebar_label: Digital Ocean
+sidebar_position: 10
+---
+
+# DigitalOcean
+
+Deploy to DigitalOcean with the DigitalOcean web new app prefilled:
+
+[![Deploy to DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/stellar/quickstart/tree/master)

--- a/docs/tools/quickstart/cloud/fly.io.mdx
+++ b/docs/tools/quickstart/cloud/fly.io.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fly.io
-description: Deploying quickstart to fly.io
+description: Deploy Quickstart to fly.io
 sidebar_label: Fly.io
 sidebar_position: 10
 ---
@@ -9,17 +9,17 @@ sidebar_position: 10
 
 Deploy to Fly.io using the following steps.
 
-0. Install the Fly CLI.
+1. Install the Fly CLI.
 
    See [fly.io/docs/flyctl/install](https://fly.io/docs/flyctl/install).
 
-1. Create a fly app with:
+2. Create a fly app with:
 
    ```
    fly create
    ```
 
-2. Create a `fly.toml` file starting with the following template.
+3. Create a `fly.toml` file starting with the following template.
 
    ```toml
    # Deploy this Fly app with:
@@ -66,7 +66,7 @@ Deploy to Fly.io using the following steps.
    cpus = 1
    ```
 
-3. Deploy the image:
+4. Deploy the image:
 
    ```
    fly deploy --ha=false

--- a/docs/tools/quickstart/cloud/fly.io.mdx
+++ b/docs/tools/quickstart/cloud/fly.io.mdx
@@ -11,7 +11,7 @@ Deploy to Fly.io using the following steps.
 
 0. Install the Fly CLI.
 
-   See <https://fly.io/docs/flyctl/install>.
+   See [fly.io/docs/flyctl/install](https://fly.io/docs/flyctl/install).
 
 1. Create a fly app with:
 

--- a/docs/tools/quickstart/cloud/fly.io.mdx
+++ b/docs/tools/quickstart/cloud/fly.io.mdx
@@ -7,47 +7,67 @@ sidebar_position: 10
 
 # Fly.io
 
-Create a `fly.toml` file with the following:
+Deploy to Fly.io using the following steps.
 
-```toml
-app = "stellar-unet" # Change the name of your app.
-primary_region = "ord" # Change the region to your closest region from https://fly.io/docs/reference/regions.
+0. Install the Fly CLI.
 
-[build]
-image = "stellar/quickstart:latest"
+   See <https://fly.io/docs/flyctl/install>.
 
-[env]
-NETWORK="local"
-LIMITS="testnet" # Or "unlimited" to increase limits to their max.
-RANDOMIZE_NETWORK_PASSPHRASE="true" # Or turn off to get a stable network passphrase, 'Standalone Network ; February 2017'.
+1. Create a fly app with:
 
-[http_service]
-internal_port = 8000
-force_https = true
-auto_stop_machines = "off"
-auto_start_machines = true
-min_machines_running = 1
+   ```
+   fly create
+   ```
 
-[deploy]
-strategy = "immediate"
+2. Create a `fly.toml` file starting with the following template.
 
-[[vm]]
-memory = "1gb"
-cpu_kind = "shared"
-cpus = 1
-```
+   ```toml
+   # Deploy this Fly app with:
+   # fly app create
+   # fly deploy --ha=false
 
-Create a fly app with:
+   # Change the name of your app to the app created with 'fly app create'.
+   app = "stellar"
 
-```
-fly create
-```
+   [build]
+   image = "docker.io/stellar/quickstart:latest"
 
-Deploy the quickstart image with the `fly.toml` configuration with:
+   [env]
+   # NETWORK chooses the network the image will connect to. Use "local" to start a
+   # new network local to the container, ideal for development and testing.
+   NETWORK="local"
 
-```
-fly deploy --ha=false
-```
+   # LIMITS sets the network configuration that is deployed on network start.
+   # - "testnet" to match the network configuration of the public Stellar testnet.
+   # - "unlimited" raises limits to max, useful for testing prior to optimization.
+   #LIMITS="testnet"
 
->! NOTE
-> The `--ha=false` tells fly to only deploy a single instance, not multiple.
+   # RANDOMIZE_NETWORK_PASSPHRASE sets a random network passphrase on network
+   # start. Find out what the network passphrase is by requesting the root URL.
+   #RANDOMIZE_NETWORK_PASSPHRASE="true"
+
+   # NETWORK_PASSPHRASE sets a network passphrase to uniquely identify the network
+   # and prevent use of transactions for the test network with other networks.
+   #NETWORK_PASSPHRASE="My Network"
+
+   [http_service]
+   internal_port = 8000
+   force_https = true
+   auto_stop_machines = "off"
+   auto_start_machines = true
+   min_machines_running = 1
+
+   [deploy]
+   strategy = "immediate"
+
+   [[vm]]
+   memory = '1gb'
+   cpu_kind = 'shared'
+   cpus = 1
+   ```
+
+3. Deploy the image:
+
+   ```
+   fly deploy --ha=false
+   ```

--- a/docs/tools/quickstart/cloud/fly.io.mdx
+++ b/docs/tools/quickstart/cloud/fly.io.mdx
@@ -5,69 +5,44 @@ sidebar_label: Fly.io
 sidebar_position: 10
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import { getPlatform } from "@site/src/helpers/getPlatform";
+
 # Fly.io
 
 Deploy to Fly.io using the following steps.
 
-1. Install the Fly CLI.
+Install the Fly CLI. See [fly.io/docs/flyctl/install](https://fly.io/docs/flyctl/install) for instructions.
 
-   See [fly.io/docs/flyctl/install](https://fly.io/docs/flyctl/install).
+Launch the image:
 
-2. Create a fly app with:
+<Tabs groupId="platform" defaultValue={getPlatform()}>
+<TabItem value="unix" label="macOS/Linux">
 
-   ```
-   fly create
-   ```
+```shell
+fly launch \
+    --image docker.io/stellar/quickstart:latest \
+    --ha=false \
+    --env NETWORK=local \
+    --env LIMITS=testnet \
+    --env NETWORK_PASSPHRASE="My Network" \
+    --internal-port 8000
+```
 
-3. Create a `fly.toml` file starting with the following template.
+</TabItem>
+<TabItem value="windows" label="Windows (PowerShell)">
 
-   ```toml
-   # Deploy this Fly app with:
-   # fly app create
-   # fly deploy --ha=false
+```powershell
+fly launch `
+    --image docker.io/stellar/quickstart:latest `
+    --ha=false `
+    --env NETWORK=local `
+    --env LIMITS=testnet `
+    --env NETWORK_PASSPHRASE="My Network" `
+    --env RANDOMIZE_NETWORK_PASSPHRASE=false `
+    --internal-port 8000
+```
 
-   # Change the name of your app to the app created with 'fly app create'.
-   app = "stellar"
-
-   [build]
-   image = "docker.io/stellar/quickstart:latest"
-
-   [env]
-   # NETWORK chooses the network the image will connect to. Use "local" to start a
-   # new network local to the container, ideal for development and testing.
-   NETWORK="local"
-
-   # LIMITS sets the network configuration that is deployed on network start.
-   # - "testnet" to match the network configuration of the public Stellar testnet.
-   # - "unlimited" raises limits to max, useful for testing prior to optimization.
-   #LIMITS="testnet"
-
-   # RANDOMIZE_NETWORK_PASSPHRASE sets a random network passphrase on network
-   # start. Find out what the network passphrase is by requesting the root URL.
-   #RANDOMIZE_NETWORK_PASSPHRASE="true"
-
-   # NETWORK_PASSPHRASE sets a network passphrase to uniquely identify the network
-   # and prevent use of transactions for the test network with other networks.
-   #NETWORK_PASSPHRASE="My Network"
-
-   [http_service]
-   internal_port = 8000
-   force_https = true
-   auto_stop_machines = "off"
-   auto_start_machines = true
-   min_machines_running = 1
-
-   [deploy]
-   strategy = "immediate"
-
-   [[vm]]
-   memory = '1gb'
-   cpu_kind = 'shared'
-   cpus = 1
-   ```
-
-4. Deploy the image:
-
-   ```
-   fly deploy --ha=false
-   ```
+</TabItem>
+</Tabs>

--- a/docs/tools/quickstart/cloud/fly.io.mdx
+++ b/docs/tools/quickstart/cloud/fly.io.mdx
@@ -1,0 +1,53 @@
+---
+title: Fly.io
+description: Deploying quickstart to fly.io
+sidebar_label: Fly.io
+sidebar_position: 10
+---
+
+# Fly.io
+
+Create a `fly.toml` file with the following:
+
+```toml
+app = "stellar-unet" # Change the name of your app.
+primary_region = "ord" # Change the region to your closest region from https://fly.io/docs/reference/regions.
+
+[build]
+image = "stellar/quickstart:latest"
+
+[env]
+NETWORK="local"
+LIMITS="testnet" # Or "unlimited" to increase limits to their max.
+RANDOMIZE_NETWORK_PASSPHRASE="true" # Or turn off to get a stable network passphrase, 'Standalone Network ; February 2017'.
+
+[http_service]
+internal_port = 8000
+force_https = true
+auto_stop_machines = "off"
+auto_start_machines = true
+min_machines_running = 1
+
+[deploy]
+strategy = "immediate"
+
+[[vm]]
+memory = "1gb"
+cpu_kind = "shared"
+cpus = 1
+```
+
+Create a fly app with:
+
+```
+fly create
+```
+
+Deploy the quickstart image with the `fly.toml` configuration with:
+
+```
+fly deploy --ha=false
+```
+
+>! NOTE
+> The `--ha=false` tells fly to only deploy a single instance, not multiple.

--- a/routes.txt
+++ b/routes.txt
@@ -552,6 +552,9 @@
 /docs/tools/quickstart/advanced-usage/ports
 /docs/tools/quickstart/advanced-usage/run-command-examples
 /docs/tools/quickstart/advanced-usage/service-options
+/docs/tools/quickstart/cloud
+/docs/tools/quickstart/cloud/digitalocean
+/docs/tools/quickstart/cloud/fly.io
 /docs/tools/quickstart/debugging
 /docs/tools/quickstart/debugging/diagnostic-events
 /docs/tools/quickstart/debugging/viewing-logs


### PR DESCRIPTION
### What
  Add examples for how to setup a lightweight ephemeral test network using quickstart with popular platform-as-a-service providers.

  ### Why
  Show devs how to create shareable test networks for coordinated multi-person testing on simple to use and affordable platforms.

### Todo

- [x] Add fly.io
   - [x] Fix friendbot not starting up https://github.com/stellar/quickstart/issues/335
- [x] Add DigitalOcean
   - [x] Test DigitalOcean to make sure it still works https://github.com/stellar/quickstart/pull/690
- [x] Fill out the examples while keeping them brief
- [x] Consider supporting setting a specific network passphrase and if so use it in these examples https://github.com/stellar/quickstart/issues/299
- [ ] ~Add other providers and tech? (e.g. Helm)~ _[Edit: Can be a follow.]_

cc @janewang @stellar/devx 