### PR TITLE
add install target instructions for new wasm32v1-none target

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -64,7 +64,15 @@ For other methods of installing [Rust], see: https://www.rust-lang.org/tools/ins
 
 ## Install the target
 
-Install the `wasm32-unknown-unknown` target.
+You'll need a "target" for which your target will be compiled. _Which target_ you need will depend on the version of Rust you're using.
+
+For Rust `v1.85.0` or higher, install the `wasm32v1-none` target.
+
+```sh
+rustup target add wasm32v1-none
+```
+
+For older versions of Rust, install the `wasm32-unknown-unknown` target.
 
 ```sh
 rustup target add wasm32-unknown-unknown
@@ -145,7 +153,7 @@ The auto-generated comprehensive reference documentation is available [here](../
 You can use `stellar completion` to generate shell completion for different shells. You should absolutely try it out. It will feel like a super power!
 
 <Tabs id="shell" defaultValue={getShell()}>
-  
+
 <TabItem value="bash" label="Bash">
 
 To enable autocomplete on the current shell session:


### PR DESCRIPTION
This is a kinda "quick fix" PR to get the bare essentials for this change into the docs, at least _somewhere_. I'll get a more complete PR next week, after consensus.

Does this seem like enough for that, or do we need some more?