### PR TITLE
Add note about wasm features and targets

### DIFF
--- a/docs/learn/encyclopedia/contract-development/rust-dialect.mdx
+++ b/docs/learn/encyclopedia/contract-development/rust-dialect.mdx
@@ -76,3 +76,21 @@ Host objects have significantly different semantics than typical Rust data struc
 In particular: host objects are **immutable**, and any "modification" to a host object returns a **full new copy** of the object, leaving the initial one unchanged. For the most part this distinction is hidden through wrappers in the SDK, such that objects like `Map` or `Vec` appear to the contract programmer to be uniquely owned mutable values similar to Rust's standard library types, but the underlying host objects are immutable, so have different performance characteristics. Specifically: cloning such an object is O(1), whereas any modification is O(N). Since most host objects are typically very small, the O(N) cost of modification is typically cheaper than any alternative implementation involving shared substructures.
 
 **Note**: these container types `Vec` and `Map` should _not_ be used for managing large or unbounded collections of data. For such cases, contracts should store data in multiple separate ledger entries, each with its own unique contract-defined key. Doing so also limits the IO cost of a contract to only the entries it accesses, and furthermore allows concurrent modification of entries with separate keys from separate transactions.
+
+## Limited Webassembly features
+
+The Webassembly specification has grown significantly since its initial introduction and now supports many _features_ that may or may not be available on a given implementation of Webassembly.
+
+Soroban intentionally limits which Webassembly features it supports, to minimize the security-critical surface area and retain flexibility in choice of Webassembly implementations.
+
+The Rust compiler's `wasm32-unknown-unknown` target used to Webassembly that used only a small subset of features, up until Rust 1.81. As of Rust 1.82 the `wasm32-unknown-unknown` target added more features, which meant that Rust 1.82 produced code that might be rejected by Soroban due to accidental use of newer Webassembly features.
+
+As of Rust 1.84, a new target `wasm32v1-none` was added to Rust that intentionally restricts itself to the "Webassembly 1.0" subset of features, all of which Soroban supports.
+
+As a consequence, new Soroban contracts should be built with Rust 1.84 or later, and use the `wasm32v1-none` target, not `wasm32-unknown-unknown`. If the contract needs earlier versions of Rust, or wants to keep using `wasm32-unknown-unknown`, it should restrict itself to Rust 1.81 or earlier.
+
+The stellar CLI automatically detects the Rust version and selects the appropriate target when building contracts for Webassembly.
+
+Note: the `wasm32v1-none` target does not, by default, ship with a version of the `std` library at all. This is because the version of `std` that ships with `wasm32-unknown-unknown` is _mostly_ considered a mistake by its designers: for example most of the IO facilities in that version of `std` are stubs that either do nothing or panic when called. When adding the `wasm32v1-none` target, it was decided that these sorts of stubs were not of any benefit to users.
+
+The `wasm32v1-none` target _does_ include a copy of the `alloc` crate, which contains most of the _containers_ (such as vectors and maps) that are re-exported by `std`. For example, rather than using `std::vec::Vec` one can use `alloc::vec::Vec`, which is the same code under a different name. But as mentioned above in the seciton on dynamic memory allocation, generally Soroban contracts should avoid `alloc` as well: a crate like `heapless` will usually perform better.


### PR DESCRIPTION
There was some complexity that came up in the Rust 1.81 - 1.84 timeframe concerning wasm features and targets. This addition to the docs explains it.