### PR TITLE
Remove scala SDK

### DIFF
--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -112,10 +112,6 @@ This SDK is split up into separate packages, all of which you can find in the [G
 
 [C# .NET SDK](https://github.com/Beans-BV/dotnet-stellar-sdk) | [Docs](https://elucidsoft.github.io/dotnet-stellar-sdk/)
 
-## Scala
-
-[Scala SDK](https://github.com/Synesso/scala-stellar-sdk) | [Docs](https://synesso.github.io/scala-stellar-sdk/)
-
 ## Qt/C++
 
 [Qt/C++ SDK](https://github.com/bnogalm/StellarQtSDK) | [Docs](https://github.com/bnogalm/StellarQtSDK/wiki)


### PR DESCRIPTION
This SDK hasn't been updated in over 4 years and the github repo was archived by the maintainer 2 years ago.