### PR TITLE
add contract errors for SACs

### DIFF
--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -109,6 +109,57 @@ Priviliged mutators require authorization from a specific privileged identity, k
 
 This interface can be found in the [SDK]. It extends the common [SEP-41 Token Interface].
 
+## Contract Errors
+
+All built-in smart contracts on the Stellar network share the same error types, outlined below.
+
+```rust
+#[derive(Debug, FromPrimitive, PartialEq, Eq)]
+pub(crate) enum ContractError {
+    // Indicates something has gone wrong with an account's trustline/balance,
+    // or some unexpected input.
+    InternalError = 1,
+    // Indicates an impossible function has been invoked, such as clawback for
+    // an asset that does not have clawback enabled. Or, an operation has been
+    // called affecting the issuer's trustline.
+    OperationNotSupportedError = 2,
+    // Indicates the SAC has already been initialized.
+    AlreadyInitializedError = 3,
+
+    // Unused, from what I can tell.
+    UnauthorizedError = 4,
+    // Indicates a problem with a transaction's signature(s), such as too many
+    // signatures, too low signature weight(s), improper signature order, etc.
+    AuthenticationError = 5,
+    // An account which would be modified by this transaction does not exist on
+    // the network.
+    AccountMissingError = 6,
+    // Unused, from what I can tell.
+    AccountIsNotClassic = 7,
+
+    // Indicates an amount less-than zero was provided for a transfer amount.
+    NegativeAmountError = 8,
+    // Indicates an insufficient spender's available allowance amount. Also used
+    // to indicate a problem with expiration ledger when creating an allowance.
+    AllowanceError = 9,
+    // Indicates too low of a balance to spend the requested amount, or a
+    // balance as a result of this transaction would be too low or high, or a
+    // problem with attempting a clawback on a non-clawback-enabled trustline.
+    BalanceError = 10,
+    // Indicates an address has had its balance authorization revoked by the
+    // asset issuer.
+    BalanceDeauthorizedError = 11,
+    // Indicates this transaction would result in a spender's allowance
+    // overflowing.
+    OverflowError = 12,
+    // Indicates a trustline entry does not exist for this address to hold this
+    // asset.
+    TrustlineMissingError = 13,
+}
+```
+
+Source: https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/builtin_contracts/contract_error.rs
+
 [assets]: ../learn/fundamentals/stellar-data-structures/assets.mdx
 [sdk]: https://docs.rs/soroban-sdk/latest/soroban_sdk/token/index.html
 [cap-46-6 smart contract standardized asset]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md


### PR DESCRIPTION
I've copied the contract errors from the [built-in contracts crate](https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/builtin_contracts/contract_error.rs).

Questions for specific people:

@briwylde08 Do the notes make sense? I'm sure there are ways they could be reworded or cleaned up, especially the ones that are like "never used i think" lol

@dmkozh I searched in that repo for occurrences of `ContractError::ErrorNameHere` and tried my best to make sense of what I was seeing. Did I capture correctly what each one is doing? What's the best way to handle the "never used" errors?

refs: #1499