### PR TITLE
Update retention window reference in tutorial

### DIFF
--- a/docs/build/guides/dapps/frontend-guide.mdx
+++ b/docs/build/guides/dapps/frontend-guide.mdx
@@ -839,7 +839,4 @@ State Archival is a characteristic of soroban contracts where some data stored o
 
 ### Data Retention
 
-A few things to note about data retention in soroban contracts:
-
-- Events Data can be queried within 7 days of the event happening. So you may need an indexer to store events for longer periods.
-- Transaction data is stored with a retention period of 1440 ledgers. This means after 1440 ledgers, the transaction data cannot be queried using the RPC. Again, you may need an indexer to store transaction data for longer periods.
+Data can only be queried within the configured retention window of the RPC instance you are using (the default is 7 days). So you may need an indexer to store transaction or event data for longer periods.


### PR DESCRIPTION
RPC used to have 2 different retention windows for transactions and events, but they were unified into a single one in a prior protocol release. This section of the docs missed the update.