### PR TITLE
adjust structure of payment guide to include RPC and SAC details

### DIFF
--- a/docs/build/guides/basics/send-and-receive-payments.mdx
+++ b/docs/build/guides/basics/send-and-receive-payments.mdx
@@ -71,84 +71,68 @@ try {
   throw error;
 }
 
-// The next step is to parametrize and build the transaction object
-let transaction: StellarSdk.Transaction;
-try {
-  // Using the source account we just loaded we begin to assemble the transaction.
-  // We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
-  // We also set the network passphrase to TESTNET.
-  transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
-    fee: StellarSdk.BASE_FEE,
-    networkPassphrase: StellarSdk.Networks.TESTNET,
-  })
-    // We then add a payment operation to the transaction oject.
-    // This operation will send 10 XLM to the destination account.
-    // Obs.: Not specifying a explicit source account here means that the
-    // operation will use the source account of the whole transaction, which we specified above.
-    .addOperation(
-      StellarSdk.Operation.payment({
-        destination: destinationId,
-        asset: StellarSdk.Asset.native(),
-        amount: "10",
-      })
-    )
-    // We include an optional memo which oftentimes is used to identify the transaction
-    // when working with pooled accounts or to facilitate reconciliation.
-    .addMemo(StellarSdk.Memo.id("1234567890"))
-    // Finally, we set a timeout for the transaction.
-    // This means that the transaction will not be valid anymore after 180 seconds.
-    .setTimeout(180)
-    .build();
-} catch (error) {
-  console.error("Error building transaction:", error);
-  throw error;
+// The next step is to parametrize and build the transaction object:
+// Using the source account we just loaded we begin to assemble the transaction.
+// We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
+// We also set the network passphrase to TESTNET.
+const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+  fee: StellarSdk.BASE_FEE,
+  networkPassphrase: StellarSdk.Networks.TESTNET,
+})
+  // We then add a payment operation to the transaction oject.
+  // This operation will send 10 XLM to the destination account.
+  // Obs.: Not specifying a explicit source account here means that the
+  // operation will use the source account of the whole transaction, which we specified above.
+  .addOperation(
+    StellarSdk.Operation.payment({
+      destination: destinationId,
+      asset: StellarSdk.Asset.native(),
+      amount: "10",
+    })
+  )
+  // We include an optional memo which oftentimes is used to identify the transaction
+  // when working with pooled accounts or to facilitate reconciliation.
+  .addMemo(StellarSdk.Memo.id("1234567890"))
+  // Finally, we set a timeout for the transaction.
+  // This means that the transaction will not be valid anymore after 180 seconds.
+  .setTimeout(180)
+  .build();
+
+
+// We sign the transaction with the source account's secret key.
+transaction.sign(sourceKeys);
+
+// Now we can send the transaction to the network.
+// The sendTransaction method immediately returns a reply with the transaction hash
+// and the status "PENDING". This means the transaction was received and is being processed.
+const sendTransactionResponse = await rpc.sendTransaction(transaction);
+
+// Here we check the status of the transaction as there are
+// a possible outcomes after sending a transaction that would have
+// to be handled accordingly, such as "DUPLICATE" or "TRY_AGAIN_LATER".
+if (sendTransactionResponse.status !== "PENDING") {
+  throw new Error(
+    `Failed to send transaction, status: ${sendTransactionResponse.status}`
+  );
 }
 
-try {
-  // We sign the transaction with the source account's secret key.
-  transaction.sign(sourceKeys);
-} catch (error) {
-  console.error("Error signing transaction:", error);
-  throw error;
-}
+// Here we poll the transaction status to await for its final result.
+// We can use the transaction hash to poll the transaction status later.
+const finalStatus = await rpc.pollTransaction(sendTransactionResponse.hash, {
+  sleepStrategy: (_iter: number) => 500,
+  attempts: 5,
+});
 
-let sendTransactionResponse: StellarSdk.rpc.Api.SendTransactionResponse;
-try {
-  // Now we can send the transaction to the network.
-  // The sendTransaction method immediately returns a reply with the transaction hash
-  // and the status "PENDING". This means the transaction was received and is being processed.
-  sendTransactionResponse = await rpc.sendTransaction(transaction);
-
-  if (sendTransactionResponse.status !== "PENDING") {
-    throw sendTransactionResponse;
-  }
-} catch (error) {
-  console.error("Error sending transaction:", error);
-  throw error;
-}
-
-try {
-  // Here we poll the transaction status to await for its final result.
-  // We can use the transaction hash to poll the transaction status later.
-  const finalStatus = await rpc.pollTransaction(sendTransactionResponse.hash, {
-    sleepStrategy: (_iter: number) => 500,
-    attempts: 5,
-  });
-
-  // The pollTransaction method will return the final status of the transaction
-  // after the specified number of attempts or when the transaction is finalized.
-  // We then check the final status of the transaction and handle it accordingly.
-  switch (finalStatus.status) {
-    case StellarSdk.rpc.Api.GetTransactionStatus.FAILED:
-    case StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND:
-      throw new Error(`Transaction failed with status: ${finalStatus.status}`);
-    case StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS:
-      console.log("Success! Results:", finalStatus);
-      break;
-  }
-} catch (error) {
-  console.error("Error polling transaction status:", error);
-  throw error;
+// The pollTransaction method will return the final status of the transaction
+// after the specified number of attempts or when the transaction is finalized.
+// We then check the final status of the transaction and handle it accordingly.
+switch (finalStatus.status) {
+  case StellarSdk.rpc.Api.GetTransactionStatus.FAILED:
+  case StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND:
+    throw new Error(`Transaction failed with status: ${finalStatus.status}`);
+  case StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS:
+    console.log("Success! Results:", finalStatus);
+    break;
 }
 
 ```
@@ -201,46 +185,36 @@ try {
   throw error;
 }
 
-// The next step is to parametrize and build the transaction object
-let transaction: StellarSdk.Transaction;
-try {
-  // Using the source account we just loaded we begin to assemble the transaction.
-  // We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
-  // We also set the network passphrase to TESTNET.
-  transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+// The next step is to parametrize and build the transaction object:
+// Using the source account we just loaded we begin to assemble the transaction.
+// We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
+// We also set the network passphrase to TESTNET.
+const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
     fee: StellarSdk.BASE_FEE,
     networkPassphrase: StellarSdk.Networks.TESTNET,
   })
-    // We then add a payment operation to the transaction oject.
-    // This operation will send 10 XLM to the destination account.
-    // Obs.: Not specifying a explicit source account here means that the
-    // operation will use the source account of the whole transaction, which we specified above.
-    .addOperation(
-      StellarSdk.Operation.payment({
-        destination: destinationId,
-        asset: StellarSdk.Asset.native(),
-        amount: "10",
-      })
-    )
-    // We include an optional memo which oftentimes is used to identify the transaction
-    // when working with pooled accounts or to facilitate reconciliation.
-    .addMemo(StellarSdk.Memo.id("1234567890"))
-    // Finally, we set a timeout for the transaction.
-    // This means that the transaction will not be valid anymore after 180 seconds.
-    .setTimeout(180)
-    .build();
-} catch (error) {
-  console.error("Error building transaction:", error);
-  throw error;
-}
+  // We then add a payment operation to the transaction oject.
+  // This operation will send 10 XLM to the destination account.
+  // Obs.: Not specifying a explicit source account here means that the
+  // operation will use the source account of the whole transaction, which we specified above.
+  .addOperation(
+    StellarSdk.Operation.payment({
+      destination: destinationId,
+      asset: StellarSdk.Asset.native(),
+      amount: "10",
+    })
+  )
+  // We include an optional memo which oftentimes is used to identify the transaction
+  // when working with pooled accounts or to facilitate reconciliation.
+  .addMemo(StellarSdk.Memo.id("1234567890"))
+  // Finally, we set a timeout for the transaction.
+  // This means that the transaction will not be valid anymore after 180 seconds.
+  .setTimeout(180)
+  .build();
 
-try {
-  // We sign the transaction with the source account's secret key.
-  transaction.sign(sourceKeys);
-} catch (error) {
-  console.error("Error signing transaction:", error);
-  throw error;
-}
+
+// We sign the transaction with the source account's secret key.
+transaction.sign(sourceKeys);
 
 // Now we can send the transaction to the network.
 // The sendTransaction method returns a promise that resolves with the transaction result.


### PR DESCRIPTION
Update the Send and receive payments guide with the following adjustments:
- Modify the page structure and description to include mentions about the option of using RPC, Custom tokens and the Stellar Asset Contract.
- Include snippets and detailed examples to:
  - Send classic payments through RPC
  - Send SAC payments
  - Receive SAC payments


Not included: 
- Receive a classic payment through RPC: This should be added in the future once Classic payments emit soroban events.