### PR TITLE
Add description for liveUntilLedgerSeq RPC field

### DIFF
--- a/openrpc/src/stellar-rpc/schemas/LedgerEntries.json
+++ b/openrpc/src/stellar-rpc/schemas/LedgerEntries.json
@@ -27,6 +27,7 @@
                 "$ref": "#/components/schemas/LedgerSequence"
             },
             "liveUntilLedgerSeq": {
+                "description": "The ledger sequence number of the ledger that the entry will be live until. May be zero if the entry is no longer live.",
                 "$ref": "#/components/schemas/LedgerSequence"
             }
         }

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -746,7 +746,7 @@
                   },
                   "liveUntilLedgerSeq": {
                     "title": "ledgerSequence",
-                    "description": "Sequence number of the ledger.",
+                    "description": "The ledger sequence number of the ledger that the entry will be live until. May be zero if the entry is no longer live.",
                     "type": "number"
                   }
                 }


### PR DESCRIPTION
### What
  Add description explaining possible values of the liveUntilLedgerSeq field in ledger entries, specifically that zero is possible.

  ### Why
  Clarify that future versions of RPC may return zero for the live until field.

For more context about how this change came about, see:

- https://github.com/stellar/stellar-rpc/issues/413#issuecomment-2960779872
- https://github.com/stellar/stellar-rpc/pull/435#issuecomment-2960716162
- https://github.com/stellar/stellar-core/issues/4766
- https://github.com/stellar/rs-soroban-env/pull/1565#discussion_r2138112888

Close stellar/stellar-rpc#413