### PR TITLE
docs: add resource feecomparison to fees documentation

### DIFF
--- a/docs/learn/fundamentals/fees-resource-limits-metering.mdx
+++ b/docs/learn/fundamentals/fees-resource-limits-metering.mdx
@@ -27,7 +27,7 @@ All smart contract transactions require a resource fee in addition to an inclusi
 
 `Transaction Fee (Tx.fee) = Resource Fee (sorobanData.resourceFee) + Inclusion Fee`
 
-Transactions that do not execute a smart contract can be thought of as having a resource fee of zero (`resourceFee == 0`). Conversely, for smart contract transactions, you can subtract the resource fee from the total transaction fee to derive the equivalent classic transaction fee component.
+Transactions that do not execute a smart contract can be thought of as having a resource fee of zero (`resourceFee == 0`). Conversely, for smart contract transactions, you can subtract the resource fee from the total transaction fee to derive the equivalent classic transaction fee component, which is the inclusion fee.
 
 ![Soroban Fees](/assets/diagrams/soroban_fees.png) _\* Diagram: Solid line boxes are what is actually present in the transaction, while dotted lines are derivable._
 


### PR DESCRIPTION
Adding a short clear comparison between classic and soroban txs from a resource fee perspective. Based on this [slack **discussion](https://stellarfoundation.slack.com/archives/C9H5JTW1J/p1750287030205699?thread_ts=1750284159.116829&cid=C9H5JTW1J)**. 