### PR TITLE
stellar-rpc: Update getEvents schema

### DIFF
--- a/openrpc/src/stellar-rpc/schemas/Event.json
+++ b/openrpc/src/stellar-rpc/schemas/Event.json
@@ -46,7 +46,7 @@
         "title": "type",
         "description": "The type of event emission.",
         "type": "string",
-        "enum": [ "contract", "diagnostic", "system" ]
+        "enum": [ "contract", "system" ]
     },
     "EventId": {
         "description": "Unique identifier for this event.\n\n- The event's unique id field is based on a [`toid` from Horizon](https://github.com/stellar/go/blob/master/toid/main.go) as used in Horizon's /effects endpoint.\n\n- https://github.com/stellar/go/blob/master/services/horizon/internal/db2/history/effect.go#L58\n\n- Specifically, it is a string containing:\n\n- bigint(32 bit ledger sequence + 20 bit txn number + 12 bit operation) + `<hyphen>` + number for the event within the operation.\n\n- For example: `1234-1`",

--- a/openrpc/src/stellar-rpc/schemas/EventFilters.json
+++ b/openrpc/src/stellar-rpc/schemas/EventFilters.json
@@ -24,7 +24,7 @@
     "EventFilterType": {
         "title": "type",
         "type": "string",
-        "description": "A comma separated list of event types (system, contract, or diagnostic) used to filter events. If omitted, all event types are included."
+        "description": "A comma separated list of event types (system or contract) used to filter events. If omitted, all event types are included."
     },
     "TopicFilters": {
         "title": "topics",
@@ -38,7 +38,7 @@
     "SegmentMatcher": {
         "title": "SegmentMatcher",
         "type": "string",
-        "description": "A `SegmentMatcher` is one of the following:\n\n- For an exact segment match, a string containing a base64-encoded ScVal\n\n- For a wildcard single-segment match, the string \"*\", matches exactly one segment."
+        "description": "A `SegmentMatcher` is one of the following:\n\n- For an exact segment match, a string containing a base64-encoded ScVal\n\n- The string \"*\" functions as a wildcard that matches exactly one segment.\n\n- The string \"**\" matches zero or more segments and is used to match events with variable topic lengths. It can only appear as the final segment.\n\n"
     },
     "TopicFilter": {
         "type": "array",

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -75,7 +75,7 @@
                 "type": {
                   "title": "type",
                   "type": "string",
-                  "description": "A comma separated list of event types (system, contract, or diagnostic) used to filter events. If omitted, all event types are included."
+                  "description": "A comma separated list of event types (system or contract) used to filter events. If omitted, all event types are included."
                 },
                 "contractIds": {
                   "title": "contractIds",
@@ -101,7 +101,7 @@
                     "items": {
                       "title": "SegmentMatcher",
                       "type": "string",
-                      "description": "A `SegmentMatcher` is one of the following:\n\n- For an exact segment match, a string containing a base64-encoded ScVal\n\n- For a wildcard single-segment match, the string \"*\", matches exactly one segment."
+                      "description": "A `SegmentMatcher` is one of the following:\n\n- For an exact segment match, a string containing a base64-encoded ScVal\n\n- The string \"*\" functions as a wildcard that matches exactly one segment.\n\n- The string \"**\" matches zero or more segments and is used to match events with variable topic lengths. It can only appear as the final segment.\n\n"
                     }
                   }
                 }
@@ -162,7 +162,6 @@
                     "type": "string",
                     "enum": [
                       "contract",
-                      "diagnostic",
                       "system"
                     ]
                   },
@@ -200,7 +199,7 @@
                     "items": {
                       "title": "SegmentMatcher",
                       "type": "string",
-                      "description": "A `SegmentMatcher` is one of the following:\n\n- For an exact segment match, a string containing a base64-encoded ScVal\n\n- For a wildcard single-segment match, the string \"*\", matches exactly one segment."
+                      "description": "A `SegmentMatcher` is one of the following:\n\n- For an exact segment match, a string containing a base64-encoded ScVal\n\n- The string \"*\" functions as a wildcard that matches exactly one segment.\n\n- The string \"**\" matches zero or more segments and is used to match events with variable topic lengths. It can only appear as the final segment.\n\n"
                     }
                   },
                   "value": {


### PR DESCRIPTION

Update the getEvents schema to reflect the following changes introduced in stellar-rpc 23.0:

- Support for the new "**" wildcard - https://github.com/stellar/stellar-rpc/pull/419

- Removal of diagnostic events - https://github.com/stellar/stellar-rpc/issues/402
