### PR TITLE
fix: Add latestVersion reference back

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -94,7 +94,7 @@ The [Stellar CLI](https://github.com/stellar/stellar-cli) can execute smart cont
 
 :::info
 
-The latest stable release is [v22.6.0](https://github.com/stellar/stellar-cli/releases/latest).
+The latest stable release is [v{latestVersion}](https://github.com/stellar/stellar-cli/releases/latest).
 
 :::
 


### PR DESCRIPTION
On the Setup for smart contracts page, the info box is locked to a static version number for the CLI: https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli

<img width="1756" height="352" alt="image" src="https://github.com/user-attachments/assets/615f0f76-6e28-4c37-b97c-7ad386f5ad77" />

(at this moment, the current CLI version is 22.8.2)

This regression was added in https://github.com/stellar/stellar-docs/pull/1336

This PR updates that section back to using the `latestVersion` reference