### PR TITLE
Add p23/testnet section to software versions

### DIFF
--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -36,8 +36,8 @@ Release candidates are software releases that are also released to the [Testnet]
 New features in Protocol 23:
 
 - [Release Notes](https://github.com/stellar/stellar-core/releases/tag/v23.0.0rc4)
-- Unified Events, [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md)
-- State Archival, [CAP-62](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0062.md) and [CAP-66](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0066.md)
+- Unified Events: [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md)
+- State Archival: [CAP-62](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0062.md) and [CAP-66](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0066.md)
 
 ## Protocol 22 (Mainnet, December 5, 2024)
 


### PR DESCRIPTION
Started a new section for Protocol 23 versions for Testnet as it was just updated on 7/17 and people are likely looking for single place to reference the versions across the full stack.

This is starting the block and have filled in a few known versions, but will need input from some app owners to complete before this merges.