### PR TITLE
Remove unmaintained SDKs (#1549)

### DIFF
--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -101,12 +101,6 @@ The `stellar-php-sdk` is an open source Stellar SDK for PHP developers. It provi
 
 The PHP Stellar SDK is maintained by dedicated community developer, Soneso.
 
-## Elixir SDK
-
-[Soroban Elixir SDK](https://github.com/kommitters/soroban.ex) & [Docs](https://github.com/kommitters/soroban.ex#documentation)| [Stellar Elixir SDK](https://github.com/kommitters/stellar_sdk) & [Docs](https://hexdocs.pm/stellar_sdk/readme.html#documentation) | [Examples](https://github.com/kommitters/stellar_sdk/tree/main/docs)
-
-This SDK is maintained by dedicated community developers, kommitters Open Source.
-
 ## Java SDK
 
 [Java SDK](https://github.com/lightsail-network/java-stellar-sdk) | [Docs](https://lightsail-network.github.io/java-stellar-sdk/)
@@ -126,20 +120,8 @@ This SDK is split up into separate packages, all of which you can find in the [G
 - `RPC Client` [SDK](https://github.com/stellar/stellar-rpc/tree/main/client) | [Docs](https://pkg.go.dev/github.com/stellar/stellar-rpc/client): provide sdk wrapper to invoke RPC endpoints.
 - [Ingest SDK](../../data/indexers/build-your-own/ingest-sdk/README.mdx): acquire and parse data from the Stellar network.
 
-## Ruby
-
-[Ruby SDK](https://github.com/astroband/ruby-stellar-sdk) | [Base Source](https://github.com/astroband/ruby-stellar-sdk/blob/master/base/README.md) | [SDK Source](https://github.com/astroband/ruby-stellar-sdk/blob/master/sdk/README.md) | [Docs](https://www.rubydoc.info/gems/stellar-sdk) | [Base Examples](https://github.com/astroband/ruby-stellar-sdk/tree/master/base/examples) | [SDK Examples](https://github.com/astroband/ruby-stellar-sdk/tree/master/sdk/examples)
-
-**This SDK is maintained by dedicated community developers.**
-
 ## C# .NET
 
 [C# .NET SDK](https://github.com/Beans-BV/dotnet-stellar-sdk) | [Docs](https://elucidsoft.github.io/dotnet-stellar-sdk/)
-
-**This SDK is maintained by dedicated community developers.**
-
-## Qt/C++
-
-[Qt/C++ SDK](https://github.com/bnogalm/StellarQtSDK) | [Docs](https://github.com/bnogalm/StellarQtSDK/wiki)
 
 **This SDK is maintained by dedicated community developers.**


### PR DESCRIPTION
Removing the following unmaintained SDKs from docs:

- Elixir
- Ruby
- Qt