### PR TITLE
Fix wrong horizon streaming link

### DIFF
--- a/docs/build/guides/auth/contract-authorization.mdx
+++ b/docs/build/guides/auth/contract-authorization.mdx
@@ -436,7 +436,7 @@ As this test case shows, `testing __check_auth()` is very simple using `try_invo
 
 #### `set_auths()`
 
-:::Note
+:::note
 
 `set_auths()` may not be relevant for most developers.
 

--- a/src/theme/ApiExplorer/index.tsx
+++ b/src/theme/ApiExplorer/index.tsx
@@ -16,7 +16,7 @@ export default function ApiExplorerWrapper(props: Props): ReactNode {
       {props?.item?.["x-supports-streaming"] && (
         <Admonition type="tip" title="Supports Streaming">
           This endpoint supports streaming. To read more about this, visit the
-          <Link className="padding-horiz--xs" to="/docs/data/horizon/api-reference/structure/streaming">
+          <Link className="padding-horiz--xs" to="/docs/data/apis/horizon/api-reference/structure/streaming">
             streaming section.
           </Link>
         </Admonition>


### PR DESCRIPTION
This PR changes the URL in the custom react component, so the streaming admonition will be accurate on any page it's displayed for.

Refs: #1615 