### PR TITLE
chore: update frontend-guide example to latest freighter-api

### DIFF
--- a/docs/build/guides/dapps/frontend-guide.mdx
+++ b/docs/build/guides/dapps/frontend-guide.mdx
@@ -569,7 +569,6 @@ export default function CounterPage() {
 
   const server = new StellarRpc.Server(SOROBAN_URL);
 
-
   useEffect(() => {
     const checkWallet = async () => {
       const connected = await isConnected();
@@ -766,8 +765,6 @@ const getInitialCount = async () => {
   try {
     const topic1 = xdr.ScVal.scvSymbol("COUNTER").toXDR("base64");
     const topic2 = xdr.ScVal.scvSymbol("increment").toXDR("base64");
-
-    const server = new StellarRpc.Server(SOROBAN_URL);
 
     const latestLedger = await server.getLatestLedger();
     const events = await server.getEvents({


### PR DESCRIPTION
The frontend-guide example was breaking because it relied on an outdated version of the freighter-api SDK. 
I updated this page of the docs to use the new interface (getAddress instead of getPublicKey), so the example now works properly. 
This should remove a blocker for newcomers trying to follow the guide.