### PR TITLE
Add RPCLedgerBackend docs/example in ledger backends

### DIFF
--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/README.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/README.mdx
@@ -9,7 +9,6 @@ A ledger backend is a source of Stellar network ledger data. The ingest SDK supp
 2. **[BufferedStorageBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend)** – Retrieves ledger metadata from cloud storage.
 3. **[RPCLedgetBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend)** – Retrieves ledger metadata from an RPC server.
 
-
 Each backend has its own setup and configuration requirements, which are covered in the following sections.
 
 ### LedgerCloseMeta Structure

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/README.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/README.mdx
@@ -7,6 +7,8 @@ A ledger backend is a source of Stellar network ledger data. The ingest SDK supp
 
 1. **[Captive Core](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/captivecore)** – Invokes the `stellar-core` binary as a subprocess which connects to the live Stellar network and fetches network data (i.e., ledgers).
 2. **[BufferedStorageBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend)** – Retrieves ledger metadata from cloud storage.
+3. **[RPCLedgetBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend)** – Retrieves ledger metadata from an RPC server.
+
 
 Each backend has its own setup and configuration requirements, which are covered in the following sections.
 

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -1,0 +1,79 @@
+---
+title: RPC Ledger Backend
+sidebar_position: 10
+---
+
+The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest). 
+This backend is considred the most lightweight of the available ledger backends as it only requires access to a remote RPC server. Applications use this ledger backend in order to obtain ledger meta data from the Stellar network through the [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) standard interface methods. 
+
+## Prerequisites
+
+A URL of an RPC Server.
+  
+### Example SDK Usage
+
+A complete working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. 
+Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server.
+This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
+
+1. create an empty directory `rpc-backend` and go into the directory.
+2. `go mod init example/rpc-backend`
+3. `go get github.com/stellar/go github.com/stellar/stellar-rpc@rpcclient-v23.0.0`
+4. copy this code snippet to rpc_ledger_backend_demo.go
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/stellar/go/ingest/ledgerbackend"
+    "github.com/stellar/stellar-rpc/client"
+)
+
+func main() {
+    ctx := context.Background()
+
+    // Use the public SDF RPC endpoint
+    endpoint := "https://soroban-testnet.stellar.org"
+
+    // Create a new RPC client
+    rpcClient := client.NewClient(endpoint, nil)
+
+    // Get the latest ledger sequence from the RPC server
+    health, err := rpcClient.GetHealth(ctx)
+    if err != nil {
+            log.Fatalf("Failed to get RPC health: %v", err)
+    }
+    startSeq := health.LatestLedger
+
+    // Configure the RPC Ledger Backend
+    backend := ledgerbackend.NewRPCLedgerBackend(ledgerbackend.RPCLedgerBackendOptions{
+            RPCServerURL: endpoint,
+    })
+    defer backend.Close()
+
+    fmt.Printf("Prepare unbounded range starting with Testnet ledger sequence %d: \n", startSeq)
+    // Prepare an unbounded range starting from the latest ledger
+    if err := backend.PrepareRange(ctx, ledgerbackend.UnboundedRange(startSeq)); err != nil {
+            log.Fatalf("Failed to prepare range: %v", err)
+    }
+
+    fmt.Println("Iterating over Testnet ledgers:")
+    seq := startSeq
+    for {
+            ledger, err := backend.GetLedger(ctx, seq)
+            if err != nil {
+                    fmt.Printf("No more ledgers or error at sequence %d: %v\n", seq, err)
+                    break
+            }
+            fmt.Printf("Ledger %d: Hash=%x, CloseTime=%d\n", ledger.LedgerSequence(), ledger.LedgerHash(), ledger.LedgerCloseTime())
+            seq++
+    }
+
+    fmt.Println("Done.")
+}
+```
+5. `go mod tidy`
+6. `go run rpc_ledger_backend_demo.go`

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -85,5 +85,5 @@ func main() {
 }
 ```
 
-5. `go mod tidy`
-6. `go run rpc_ledger_backend_demo.go`
+5. Run `go mod tidy`
+6. Run `go run rpc_ledger_backend_demo.go`

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -23,10 +23,11 @@ Usage of the RPCLedgerBackend implies having awareness of the retention window a
 
 A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
 
-1. create an empty directory `rpc-backend` and go into the directory.
-2. `go mod init example/rpc-backend`
-3. `go get github.com/stellar/go github.com/stellar/stellar-rpc@rpcclient-v23.0.0`
-4. copy this code snippet to rpc_ledger_backend_demo.go
+Prerequisites:
+1. Create an empty directory `rpc-backend` and`cd` into the directory.
+2. Run `go mod init example/rpc-backend`
+3. Run `go get github.com/stellar/go github.com/stellar/stellar-rpc@rpcclient-v23.0.0`
+4. Copy this code snippet to `rpc_ledger_backend_demo.go`
 
 ```go
 package main

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -3,15 +3,25 @@ title: RPC Ledger Backend
 sidebar_position: 10
 ---
 
-The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest). This backend is considred the most lightweight of the available ledger backends as it only requires access to a remote RPC server. Applications use this ledger backend in order to obtain ledger meta data from the Stellar network through the [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) standard interface methods.
+The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest) which uses an RPC Server as the backing source of ledger meta data.
 
-## Prerequisites
+Applications can use this ledger backend in order to obtain ledger meta data from the Stellar network through the standard [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) interface methods. This ledger backend is considered the most lightweight of the available ledger backends as it only requires an HTTP client to access a remote RPC server.
 
-A URL of an RPC Server.
+Usage of the RPCLedgerBackend implies having awareness of the retention window and data lake settings on the remote RPC server as these aspects determine the range of ledgers which are accessible through the RPCLedgerBackend.
 
-### Example SDK Usage
+- `HISTORY_RETENTION_WINDOW` - This is a setting on the RPC server which determines the range of ledgers retained by the RPC in a sliding window from latest on Stellar network. The default is to retain the latest 7 days worth of ledger data from the Stellar network.
+- [Data Lake Integration](/docs/data/apis/rpc/admin-guide/data-lake-integration) - If the RPC has the Data Lake integration enabled then the range of ledgers available will be a minimum of RPC's Retention Window and extends further back in history out to the larger range provided by the data lake.
 
-A complete working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
+## Example SDK Usage
+
+### Prerequisites
+
+1. A URL of an RPC Server.
+2. Go 1.2x runtime
+
+### Code
+
+A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
 
 1. create an empty directory `rpc-backend` and go into the directory.
 2. `go mod init example/rpc-backend`
@@ -33,7 +43,7 @@ import (
 func main() {
     ctx := context.Background()
 
-    // Use the public SDF RPC endpoint
+    // Use the public SDF Testnet RPC for demo purpose
     endpoint := "https://soroban-testnet.stellar.org"
 
     // Create a new RPC client

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -3,9 +3,9 @@ title: RPC Ledger Backend
 sidebar_position: 10
 ---
 
-The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest) which uses an RPC Server as the backing source of ledger meta data.
+The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest) which uses an RPC Server as the backing source of ledger meta data.
 
-Applications can use this ledger backend in order to obtain ledger meta data from the Stellar network through the standard [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) interface methods. This ledger backend is considered the most lightweight of the available ledger backends as it only requires an HTTP client to access a remote RPC server.
+Applications can use this ledger backend in order to obtain ledger meta data from the Stellar network through the standard [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go) interface methods. This ledger backend is considered the most lightweight of the available ledger backends as it only requires an HTTP client to access a remote RPC server.
 
 Usage of the RPCLedgerBackend implies having awareness of the retention window and data lake settings on the remote RPC server as these aspects determine the range of ledgers which are accessible through the RPCLedgerBackend.
 
@@ -21,9 +21,10 @@ Usage of the RPCLedgerBackend implies having awareness of the retention window a
 
 ### Code
 
-A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
+A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
 
 Prerequisites:
+
 1. Create an empty directory `rpc-backend` and`cd` into the directory.
 2. Run `go mod init example/rpc-backend`
 3. Run `go get github.com/stellar/go github.com/stellar/stellar-rpc@rpcclient-v23.0.0`

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -3,23 +3,21 @@ title: RPC Ledger Backend
 sidebar_position: 10
 ---
 
-The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest). 
-This backend is considred the most lightweight of the available ledger backends as it only requires access to a remote RPC server. Applications use this ledger backend in order to obtain ledger meta data from the Stellar network through the [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) standard interface methods. 
+The [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) is a [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) implementation in Stellar [Ingest SDK](https://github.com/stellar/go/tree/master/ingest). This backend is considred the most lightweight of the available ledger backends as it only requires access to a remote RPC server. Applications use this ledger backend in order to obtain ledger meta data from the Stellar network through the [LedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/ledger_backend.go#L10) standard interface methods.
 
 ## Prerequisites
 
 A URL of an RPC Server.
-  
+
 ### Example SDK Usage
 
-A complete working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. 
-Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server.
-This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
+A complete working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go/blob/master/ingest/ledgerbackend/rpc_backend.go#L40) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go#L14) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
 
 1. create an empty directory `rpc-backend` and go into the directory.
 2. `go mod init example/rpc-backend`
 3. `go get github.com/stellar/go github.com/stellar/stellar-rpc@rpcclient-v23.0.0`
 4. copy this code snippet to rpc_ledger_backend_demo.go
+
 ```go
 package main
 
@@ -75,5 +73,6 @@ func main() {
     fmt.Println("Done.")
 }
 ```
+
 5. `go mod tidy`
 6. `go run rpc_ledger_backend_demo.go`

--- a/routes.txt
+++ b/routes.txt
@@ -436,6 +436,7 @@
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/captivecore
+/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerreaders
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide/prerequisites
 /docs/data/indexers/build-your-own/ingest-sdk/examples


### PR DESCRIPTION
Create new page to document the RPCLedgerBackend.
Include a working code example to run RPCLedgerBackend against Testnet RPC.

Closes #1641 