### PR TITLE
re-set the time for the crowdin download action cron time

### DIFF
--- a/.github/workflows/crowdin-download-workflow.yml
+++ b/.github/workflows/crowdin-download-workflow.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: "main"
   schedule:
-    - cron: '0 20 * * *' # Runs daily at 20:00 UTC (15:00 Central)
+    - cron: '25 20 * * *' # Runs daily at 20:25 UTC (15:25 Central)
 
 permissions:
   contents: write


### PR DESCRIPTION
it was set to hourly, for testing purposes. this PR will set it back to once daily at 20:00 UTC (3pm Central Time)