### PR TITLE
Fix(docs): Align contract call parameter with implementation on cross-contract-call.mdx

### DIFF
--- a/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
+++ b/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
@@ -302,7 +302,7 @@ stellar contract invoke \
     --id b \
     -- \
     add_with \
-    --contract_id a \
+    --contract a \
     --x 5 \
     --y 7
 ```

--- a/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
+++ b/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
@@ -316,7 +316,7 @@ stellar contract invoke `
     --id b `
     -- `
     add_with `
-    --contract_id a `
+    --contract a `
     --x 5 `
     --y 7
 ```

--- a/docs/learn/interactive/README.mdx
+++ b/docs/learn/interactive/README.mdx
@@ -5,6 +5,6 @@ sidebar_position: 60
 
 import DocCardList from "@theme/DocCardList";
 
-Learn by doing in this collection of resources designed to get you up and running on the Stellar network in no-time!
+Learn by doing in this collection of resources designed to get you up and running on the Stellar network in no time!
 
 <DocCardList />


### PR DESCRIPTION
The parameter for calling another contract is contract, but the documentation incorrectly listed it as contract_id.

This PR updates the documentation to use the correct parameter name.