### PR TITLE
DocPoc_09_25: rewrite send and recv payments guide

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 # openapi generated pages
 **/*.api.mdx
 **/*.tag.mdx
+
+# Skip specific guide files that get mangled by prettier format.
+docs/build/guides/transactions/send-and-receive-payments.mdx

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -6,1405 +6,339 @@ sidebar_position: 7
 
 import { CodeExample } from "@site/src/components/CodeExample";
 import { Alert } from "@site/src/components/Alert";
+import Details from "@theme/Details";
 
-Most of the time, you’ll be sending money to someone else who has their own account. For this tutorial, however, you'll need a second account to transact with. So before proceeding, follow the steps outlined in [Create an Account](./create-account.mdx) to make _two_ accounts: one for sending and one for receiving. We'll also be using both payment operations as well as smart contract invocations to perform payments. For more details about the different types of transactions, see the [Operations and Transactions](../../../learn/fundamentals/transactions/README.mdx) documentation.
+## Payments Overview
 
-## About Operations and Transactions
+A payment constitutes the transfer of a token from one account to another. On Stellar network a token can be either a Stellar asset or a contract token.
 
-There are two ways to make payments on Stellar. One approach is to use Stellar's payment-related operations, and the other is to invoke a function on the token's contract, and the approach you should take depends on the use case.
+There are two primary ways payments are transacted on Stellar:
+- Using Stellar's payment-related [operations](/docs/learn/fundamentals/transactions/list-of-operations) 
+- [Invoking a function](/docs/learn/fundamentals/contract-development/contract-interactions/overview) on a token contract.
 
-If you want to make a payment of a Stellar asset between two Stellar accounts, use the payment operations. Transaction fees are cheaper when using them compared to those invoking the Stellar asset contract (or SAC).
-
-If you want to make a payment of a Stellar asset between a Stellar account and a contract address, or between two contract addresses, you must use the SAC. Stellar's payment-related operations cannot have contract addresses as their source or destination.
-
-Finally, if you want to make a payment of a contract token (not a Stellar asset), you must use the token's contract. Stellar's payment operations can only be used to transfer Stellar assets.
+The approach you should take depends on the use case:
+  - If you want to make a payment of a Stellar asset between two Stellar accounts, use the payment operations. Transaction fees are cheaper when using them compared to the fees for invoking the token contract for the asset directly which is referred to as the [Stellar Asset Contract](/docs/tokens/stellar-asset-contract#overview).
+  - If you want to make a payment of a Stellar asset between a Stellar account and a contract address, or between two contract addresses, then the asset's contract must be used. Stellar's payment-related operations cannot have contract addresses as their source or destination.
+  - If you want to make a payment of a contract token (not a Stellar asset), you must use the token's contract. Stellar's payment operations can only be used to transfer Stellar assets.
 
 To learn more about the differences between Stellar assets and contract tokens, see the [Tokens](../../../../docs/tokens) overview.
 
-Additionally, there are two main options to interact with the Stellar network: the [Horizon API](../../../data/apis/horizon/README.mdx) and [Stellar RPC](../../../data/apis/rpc/README.mdx). Generally speaking, you should use RPC unless you need features that only Horizon provides. If your use case is limited to making payments, RPC should be sufficient. Regardless, each payment example will be broken down to show how to perform such payments with either option.
-
 <Alert>
 
-In the following code samples, proper error checking is omitted for brevity. However, you should _always_ validate your results, as there are many ways that requests can fail. You should refer to the guide on [Error Handling](../../../data/apis/horizon/api-reference/errors/error-handling.mdx) for tips on error management strategies.
+In the following code samples, proper error checking is omitted for brevity. However, you should _always_ validate your results, as there are many ways that requests can fail.
 
 </Alert>
 
-## Using the Payment Operation
+## Using Payments Example
+This example highlights the approach mentioned for transacting payments using operations and assets and using the [Stellar RPC](../../../data/apis/rpc/README.mdx) with [Stellar Client SDKs](/docs/tools/sdks/client-sdks#overview) to perform all actions needed. 
 
 ### Send a Payment
+Lets demonstrate a payment of an asset on Stellar. We will build a transaction with a payment operation to send 10 Lummens from a sender account to a receiver account, sign it as the sender account, and submit it to the network.
+- Submitting the transaction to the SDF-maintained public testnet instance of Stellar RPC server. 
+- When submitting transactions to the RPC server it's possible that you will not receive a response from the server due to network conditions. 
+  - In such a situation it's impossible to determine the status of your transaction. 
+  - Highlights a recommendation to always save a transaction (or transaction encoded in XDR format) in a variable or a database and resubmit it if you don't know its status. 
+  - The transaction in serialized XDR format is idempotent meaning if the transaction has already been successfully applied to the ledger, RPC will simply return the saved result and not attempt to submit the transaction again. 
+  - Only in cases where a transaction's status is unknown (and thus will have a chance of being included into a ledger) will a resubmission to the network occur.
 
-When sending payments on Stellar, you build a transaction with a payment operation, sign it, and submit it to the network. Stellar stores and communicates transaction data in a binary format called [XDR](../../../learn/fundamentals/data-format/xdr.mdx), which is optimized for network performance but unreadable to the human eye. Luckily, [Horizon API](../../../data/apis/horizon/README.mdx), [Stellar RPC](../../../data/apis/rpc/README.mdx), and the [Stellar SDKs](../../../tools/sdks/README.mdx) convert XDRs into friendlier formats. Here’s how you might send 10 lumens to an account:
-
-#### Using the Stellar RPC
-
+<Details summary="Click to view payment sending code">
 <CodeExample>
-
 ```js
-import * as StellarSdk from "stellar-sdk";
+// send_payment.js
 
-// Initialize Soroban RPC server for testnet
-const rpc = new StellarSdk.rpc.Server("https://soroban-testnet.stellar.org");
+/*
+Pre-requisites:
+1. [nvm](https://github.com/nvm-sh/nvm) utility installed to manage node version.
+2. setup local example project:
+  nvm install 20
+  nvm use 20
+  mkdir stellar-payments
+  cd stellar-payments
+  npm init -y
+  npm install --save @stellar/stellar-sdk 
+*/
 
-// Initalize the source account's secret key and destination account ID.
-// The source account is the one that will send the payment, and the destination account
-// is the one that will receive the payment.
-const sourceKeys = StellarSdk.Keypair.fromSecret(
-  "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4"
-);
-const destinationId =
-  "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5";
+import * as StellarSdk from '@stellar/stellar-sdk';
+import fs from 'fs';
+const rpcServer = new StellarSdk.rpc.Server("https://soroban-testnet.stellar.org");
 
-// First, check to make sure that the destination account exists.
-try {
-  await rpc.getAccount(destinationId);
-} catch (error) {
-  console.error("Error checking destination account:", error);
-  throw error;
+async function sendPayments() {
+  const { Keypair } = StellarSdk;
+  const senderKeyPair = Keypair.random();
+  const recipientKeyPair = Keypair.random();
+  let senderAccount;
+
+  try {
+    // Request airdrop for the sender account - this creates, funds and returns the Account object
+    senderAccount = await rpcServer.requestAirdrop(senderKeyPair.publicKey());
+    console.log("Sender Account funded with airdrop");
+    console.log("Sender Account ID:", senderAccount.accountId());
+    console.log("Sender Sequence number:", senderAccount.sequence.toString());
+    fs.writeFileSync("sender_public.key", senderAccount.accountId());
+
+    console.log("\n\n");
+
+    await rpcServer.requestAirdrop(recipientKeyPair.publicKey());
+    console.log("Recipient Account funded with airdrop");
+    console.log("Recipient Account ID:", recipientKeyPair.publicKey());
+
+  } catch (err) {
+    console.error("Airdrop / Account loading failed:", err);
+    return;
+  }
+
+  // Now call sendPayment with the funded account, in a loop of once every 30 seconds
+  while (true) {
+    console.log("\n\nSending payment...");
+    await sendPayment(senderKeyPair, senderAccount, recipientKeyPair.publicKey());
+    await new Promise(resolve => setTimeout(resolve, 30000)); // wait for 30 seconds
+  }
 }
 
-// Now we also load the source account to build the transaction.
-let sourceAccount: StellarSdk.Account;
-try {
-  sourceAccount = await rpc.getAccount(sourceKeys.publicKey());
-} catch (error) {
-  console.error("Error checking source account:", error);
-  throw error;
-}
-
-// The next step is to parametrize and build the transaction object:
-// Using the source account we just loaded we begin to assemble the transaction.
-// We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
-// We also set the network passphrase to TESTNET.
-const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
-  fee: StellarSdk.BASE_FEE,
-  networkPassphrase: StellarSdk.Networks.TESTNET,
-})
-  // We then add a payment operation to the transaction oject.
-  // This operation will send 10 XLM to the destination account.
-  // Obs.: Not specifying a explicit source account here means that the
-  // operation will use the source account of the whole transaction, which we specified above.
-  .addOperation(
-    StellarSdk.Operation.payment({
-      destination: destinationId,
-      asset: StellarSdk.Asset.native(),
-      amount: "10",
-    })
-  )
-  // We include an optional memo which oftentimes is used to identify the transaction
-  // when working with pooled accounts or to facilitate reconciliation.
-  .addMemo(StellarSdk.Memo.id("1234567890"))
-  // Finally, we set a timeout for the transaction.
-  // This means that the transaction will not be valid anymore after 180 seconds.
-  .setTimeout(180)
-  .build();
-
-
-// We sign the transaction with the source account's secret key.
-transaction.sign(sourceKeys);
-
-// Now we can send the transaction to the network.
-// The sendTransaction method immediately returns a reply with the transaction hash
-// and the status "PENDING". This means the transaction was received and is being processed.
-const sendTransactionResponse = await rpc.sendTransaction(transaction);
-
-// Here we check the status of the transaction as there are
-// a possible outcomes after sending a transaction that would have
-// to be handled accordingly, such as "DUPLICATE" or "TRY_AGAIN_LATER".
-if (sendTransactionResponse.status !== "PENDING") {
-  throw new Error(
-    `Failed to send transaction, status: ${sendTransactionResponse.status}`
-  );
-}
-
-// Here we poll the transaction status to await for its final result.
-// We can use the transaction hash to poll the transaction status later.
-const finalStatus = await rpc.pollTransaction(sendTransactionResponse.hash, {
-  sleepStrategy: (_iter: number) => 500,
-  attempts: 5,
-});
-
-// The pollTransaction method will return the final status of the transaction
-// after the specified number of attempts or when the transaction is finalized.
-// We then check the final status of the transaction and handle it accordingly.
-switch (finalStatus.status) {
-  case StellarSdk.rpc.Api.GetTransactionStatus.FAILED:
-  case StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND:
-    throw new Error(`Transaction failed with status: ${finalStatus.status}`);
-  case StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS:
-    console.log("Success! Results:", finalStatus);
-    break;
-}
-
-```
-
-</CodeExample>
-
-The key differences when using RPC instead of Horizon:
-
-1. **Instant submission**: `rpc.sendTransaction()` returns immediately with a "PENDING" status
-2. **Active polling required**: You must poll `rpc.pollTransaction()` to get the final result
-3. **Polling configuration**: You can customize polling intervals and retry attempts
-4. **Status handling**: Check for SUCCESS, FAILED, or NOT_FOUND status in the final result
-
-#### Using the Horizon API
-
-<CodeExample>
-
-```js
-import * as StellarSdk from "stellar-sdk";
-
-// Initialize Horizon server for testnet
-const server = new StellarSdk.Horizon.Server(
-  "https://horizon-testnet.stellar.org"
-);
-
-// Initalize the source account's secret key and destination account ID.
-// The source account is the one that will send the payment, and the destination account
-// is the one that will receive the payment.
-
-const sourceKeys = StellarSdk.Keypair.fromSecret(
-  "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4"
-);
-const destinationId =
-  "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5";
-
-// First, check to make sure that the destination account exists.
-try {
-  await server.loadAccount(destinationId);
-} catch (error) {
-  console.error("Error checking destination account:", error);
-  throw error;
-}
-
-// Now we also load the source account to build the transaction.
-let sourceAccount: StellarSdk.Account;
-try {
-  sourceAccount = await server.loadAccount(sourceKeys.publicKey());
-} catch (error) {
-  console.error("Error checking source account:", error);
-  throw error;
-}
-
-// The next step is to parametrize and build the transaction object:
-// Using the source account we just loaded we begin to assemble the transaction.
-// We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
-// We also set the network passphrase to TESTNET.
-const transaction = new StellarSdk.TransactionBuilder(sourceAccount, {
+async function sendPayment(sender, senderAccount, recipient) {
+  // The next step is to parametrize and build the transaction object:
+  // Using the source account we just loaded we begin to assemble the transaction.
+  // We set the fee to the base fee, which is 100 stroops (0.00001 XLM).
+  // We also set the network passphrase to TESTNET.
+  const transaction = new StellarSdk.TransactionBuilder(senderAccount, {
     fee: StellarSdk.BASE_FEE,
     networkPassphrase: StellarSdk.Networks.TESTNET,
   })
-  // We then add a payment operation to the transaction oject.
-  // This operation will send 10 XLM to the destination account.
-  // Obs.: Not specifying a explicit source account here means that the
-  // operation will use the source account of the whole transaction, which we specified above.
-  .addOperation(
-    StellarSdk.Operation.payment({
-      destination: destinationId,
-      asset: StellarSdk.Asset.native(),
-      amount: "10",
-    })
-  )
-  // We include an optional memo which oftentimes is used to identify the transaction
-  // when working with pooled accounts or to facilitate reconciliation.
-  .addMemo(StellarSdk.Memo.id("1234567890"))
-  // Finally, we set a timeout for the transaction.
-  // This means that the transaction will not be valid anymore after 180 seconds.
-  .setTimeout(180)
-  .build();
-
-
-// We sign the transaction with the source account's secret key.
-transaction.sign(sourceKeys);
-
-// Now we can send the transaction to the network.
-// The sendTransaction method returns a promise that resolves with the transaction result.
-// The result will contain the transaction hash and other details.
-try {
-  const result = await server.submitTransaction(transaction);
-  console.log("Success! Results:", result);
-} catch (error) {
-  console.error("Something went wrong!", error);
-}
-
-```
-
-```java
-Server server = new Server("https://horizon-testnet.stellar.org");
-
-KeyPair source = KeyPair.fromSecretSeed("SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4");
-KeyPair destination = KeyPair.fromAccountId("GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5");
-
-// First, check to make sure that the destination account exists.
-// You could skip this, but if the account does not exist, you will be charged
-// the transaction fee when the transaction fails.
-// It will throw HttpResponseException if account does not exist or there was another error.
-server.accounts().account(destination.getAccountId());
-
-// If there was no error, load up-to-date information on your account.
-AccountResponse sourceAccount = server.accounts().account(source.getAccountId());
-
-// Start building the transaction.
-Transaction transaction = new Transaction.Builder(sourceAccount, Network.TESTNET)
-        .addOperation(new PaymentOperation.Builder(destination.getAccountId(), new AssetTypeNative(), "10").build())
-        // A memo allows you to add your own metadata to a transaction. It's
-        // optional and does not affect how Stellar treats the transaction.
-        .addMemo(Memo.text("Test Transaction"))
-        // Wait a maximum of three minutes for the transaction
-        .setTimeout(180)
-        // Set the amount of lumens you're willing to pay per operation to submit your transaction
-        .setBaseFee(Transaction.MIN_BASE_FEE)
-        .build();
-// Sign the transaction to prove you are actually the person sending it.
-transaction.sign(source);
-
-// And finally, send it off to Stellar!
-try {
-  SubmitTransactionResponse response = server.submitTransaction(transaction);
-  System.out.println("Success!");
-  System.out.println(response);
-} catch (Exception e) {
-  System.out.println("Something went wrong!");
-  System.out.println(e.getMessage());
-  // If the result is unknown (no response body, timeout etc.) we simply resubmit
-  // already built transaction:
-  // SubmitTransactionResponse response = server.submitTransaction(transaction);
-}
-```
-
-```go
-package main
-
-import (
-    "github.com/stellar/go/keypair"
-    "github.com/stellar/go/network"
-    "github.com/stellar/go/txnbuild"
-    "github.com/stellar/go/clients/horizonclient"
-    "fmt"
-)
-
-func main () {
-    source := "SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4"
-    destination := "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5"
-    client := horizonclient.DefaultTestNetClient
-
-    // Make sure destination account exists
-    destAccountRequest := horizonclient.AccountRequest{AccountID: destination}
-    destinationAccount, err := client.AccountDetail(destAccountRequest)
-    if err != nil {
-        panic(err)
-    }
-
-    fmt.Println("Destination Account", destinationAccount)
-
-    // Load the source account
-    sourceKP := keypair.MustParseFull(source)
-    sourceAccountRequest := horizonclient.AccountRequest{AccountID: sourceKP.Address()}
-    sourceAccount, err := client.AccountDetail(sourceAccountRequest)
-    if err != nil {
-        panic(err)
-    }
-
-    // Build transaction
-    tx, err := txnbuild.NewTransaction(
-      txnbuild.TransactionParams{
-        SourceAccount:        &sourceAccount,
-        IncrementSequenceNum: true,
-        BaseFee:              txnbuild.MinBaseFee,
-        Preconditions: txnbuild.Preconditions{
-          TimeBounds: txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
-        },
-        Operations: []txnbuild.Operation{
-          &txnbuild.Payment{
-            Destination: destination,
-            Amount:      "10",
-            Asset:       txnbuild.NativeAsset{},
-          },
-        },
-      },
+    // We then add a payment operation to the transaction oject.
+    // This operation will send 10 XLM to the destination account.
+    // Obs.: Not specifying a explicit source account here means that the
+    // operation will use the source account of the whole transaction, which we specified above.
+    .addOperation(
+      StellarSdk.Operation.payment({
+        destination: recipient,
+        asset: StellarSdk.Asset.native(),
+        amount: "10",
+      })
     )
-
-    if err != nil {
-        panic(err)
-    }
-
-    // Sign the transaction to prove you are actually the person sending it.
-    tx, err = tx.Sign(network.TestNetworkPassphrase, sourceKP)
-    if err != nil {
-        panic(err)
-    }
-
-    // And finally, send it off to Stellar!
-    resp, err := horizonclient.DefaultTestNetClient.SubmitTransaction(tx)
-    if err != nil {
-        panic(err)
-    }
-
-    fmt.Println("Successful Transaction:")
-    fmt.Println("Ledger:", resp.Ledger)
-    fmt.Println("Hash:", resp.Hash)
-}
-```
-
-```python
-from stellar_sdk import Asset, Keypair, Network, Server, TransactionBuilder
-from stellar_sdk.exceptions import NotFoundError, BadResponseError, BadRequestError
-
-server = Server("https://horizon-testnet.stellar.org")
-source_key = Keypair.from_secret("SCZANGBA5YHTNYVVV4C3U252E2B6P6F5T3U6MM63WBSBZATAQI3EBTQ4")
-destination_id = "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5"
-
-# First, check to make sure that the destination account exists.
-# You could skip this, but if the account does not exist, you will be charged
-# the transaction fee when the transaction fails.
-try:
-    server.load_account(destination_id)
-except NotFoundError:
-    # If the account is not found, surface an error message for logging.
-    raise Exception("The destination account does not exist!")
-
-# If there was no error, load up-to-date information on your account.
-source_account = server.load_account(source_key.public_key)
-
-# Let's fetch base_fee from network
-base_fee = server.fetch_base_fee()
-
-# Start building the transaction.
-transaction = (
-    TransactionBuilder(
-        source_account=source_account,
-        network_passphrase=Network.TESTNET_NETWORK_PASSPHRASE,
-        base_fee=base_fee,
-    )
-        # Because Stellar allows transaction in many currencies, you must specify the asset type.
-        # Here we are sending Lumens.
-        .append_payment_op(destination=destination_id, asset=Asset.native(), amount="10")
-        # A memo allows you to add your own metadata to a transaction. It's
-        # optional and does not affect how Stellar treats the transaction.
-        .add_text_memo("Test Transaction")
-        # Wait a maximum of three minutes for the transaction
-        .set_timeout(10)
-        .build()
-)
-
-# Sign the transaction to prove you are actually the person sending it.
-transaction.sign(source_key)
-
-try:
-    # And finally, send it off to Stellar!
-    response = server.submit_transaction(transaction)
-    print(f"Response: {response}")
-except (BadRequestError, BadResponseError) as err:
-    print(f"Something went wrong!\n{err}")
-```
-
-</CodeExample>
-
-#### Step-by-Step Breakdown
-
-What exactly happened there? Let’s break it down.
-
-1. Confirm that the account ID (aka the _public key_) you are sending to actually exists by loading the associated account data from the Stellar network. It's okay to skip this step, but it gives you an opportunity to avoid making a transaction that will inevitably fail.
-
-<CodeExample>
-
-```js
-// Using RPC
-try {
-  const destinationAccount = await rpc.getAccount(destinationId);
-  /* validate the account */
-} catch (error) {
-  console.error("Error checking the destination account:", error);
-  throw error;
-}
-
-// Using Horizon
-try {
-  const destinationAccount = await server.loadAccount(destinationId);
-  /* validate the account */
-} catch (error) {
-  console.error("Error checking the destination account:", error);
-  throw error;
-}
-```
-
-```java
-server.accounts().account(destination.getAccountId());
-```
-
-```go
-destAccountRequest := horizonclient.AccountRequest{AccountID: destination}
-destinationAccount, err := client.AccountDetail(destAccountRequest)
-if err != nil {
-    panic(err)
-}
-fmt.Println("Destination Account", destinationAccount)
-```
-
-```python
-server.load_account(destination_id)
-```
-
-</CodeExample>
-
-2. Load data for the account you are sending from. An account can only perform one transaction at a time and has something called a [sequence number](../../../learn/glossary.mdx#sequence-number), which helps Stellar verify the order of transactions. A transaction’s sequence number needs to match the account’s sequence number, so you need to get the account’s current sequence number from the network.
-
-<CodeExample>
-
-```js
-// Using RPC
-let sourceAccount: StellarSdk.Account;
-try {
-  sourceAccount = await rpc.getAccount(sourceKeys.publicKey());
-  /* validate the account */
-} catch (error) {
-  console.error("Error checking source account:", error);
-  throw error;
-}
-/* use sourceAccount to build transaction */
-
-
-
-// Using Horizon
-let sourceAccount: StellarSdk.Account;
-try {
-  sourceAccount = await server.loadAccount(sourceKeys.publicKey());
-  /* validate the account */
-} catch (error) {
-  console.error("Error checking source account:", error);
-  throw error;
-}
-/* use sourceAccount to build transaction */
-```
-
-```java
-AccountResponse sourceAccount = server.accounts().account(source.getAccountId());
-```
-
-```go
-sourceKP := keypair.MustParseFull(source)
-sourceAccountRequest := horizonclient.AccountRequest{AccountID: sourceKP.Address()}
-sourceAccount, err := client.AccountDetail(sourceAccountRequest)
-if err != nil {
-  panic(err)
-}
-```
-
-```python
-source_account = server.load_account(source_key.public_key)
-```
-
-</CodeExample>
-
-The SDK will automatically increment the account’s sequence number when you build a transaction, so you won’t need to retrieve this information again if you want to perform a second transaction.
-
-3. Start building a transaction. This requires an account object, not just an account ID, because it will increment the account’s sequence number.
-
-<CodeExample>
-
-```js
-const transaction = new StellarSdk.TransactionBuilder(sourceAccount);
-```
-
-```java
-Transaction transaction = new Transaction.Builder(sourceAccount, Network.TESTNET)
-```
-
-```go
-tx, err := txnbuild.NewTransaction(
-  txnbuild.TransactionParams{
-    SourceAccount:        &sourceAccount,
-    IncrementSequenceNum: true,
-    BaseFee:              MinBaseFee,
-    Preconditions: txnbuild.Preconditions{
-      TimeBounds: txnbuild.NewInfiniteTimeout(), // Use a real timeout in production!
-    },
-    ...
-  },
-)
-
-if err != nil {
-    panic(err)
-}
-```
-
-```python
-transaction = TransactionBuilder(
-    source_account=source_account,
-    network_passphrase=Network.TESTNET_NETWORK_PASSPHRASE,
-    base_fee=base_fee
-)
-```
-
-</CodeExample>
-
-4. Add the payment operation to the account. Note that you need to specify the type of asset you are sending: Stellar’s network currency is the [lumen](https://www.stellar.org/lumens), but you can send any asset issued on the network. We'll cover sending non-lumen assets [below](#transacting-in-other-currencies). For now, though, we’ll stick to lumens, which are called “native” assets in the SDK:
-
-<CodeExample>
-
-```js
-.addOperation(StellarSdk.Operation.payment({
-  destination: destinationId,
-  asset: StellarSdk.Asset.native(),
-  amount: "10"
-}))
-```
-
-```java
-.addOperation(new PaymentOperation.Builder(destination.getAccountId(), new AssetTypeNative(), "10").build())
-```
-
-```go
-Operations: []txnbuild.Operation{
-    &txnbuild.Payment{
-      Destination: destination,
-      Amount:      "10",
-      Asset:       txnbuild.NativeAsset{},
-    },
-  },
-```
-
-```python
-.append_payment_op(destination=destination_id, asset=Asset.native(), amount="10")
-```
-
-</CodeExample>
-
-You should also note that the amount is a string rather than a number. When working with extremely small fractions or large values, [floating point math can introduce small inaccuracies](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems). Since not all systems have a native way to accurately represent extremely small or large decimals, Stellar uses strings as a reliable way to represent the exact amount across any system.
-
-5. Optionally, you can add your own metadata, called a [memo](../../../learn/fundamentals/transactions/operations-and-transactions.mdx#memo), to a transaction. Stellar doesn’t do anything with this data, but you can use it for any purpose you’d like. Many exchanges require memos for incoming transactions because they use a single Stellar account for all their users and rely on the memo to differentiate between internal user accounts.
-
-<CodeExample title="Add a Memo">
-
-```js
-.addMemo(StellarSdk.Memo.text('Test Transaction'))
-```
-
-```java
-.addMemo(Memo.text("Test Transaction"));
-```
-
-```go
-Memo: txnbuild.MemoText("Test Transaction")
-```
-
-```python
-.add_text_memo("Test Transaction")
-```
-
-</CodeExample>
-
-6. Now that the transaction has all the data it needs, you have to cryptographically sign it using your secret key. This proves that the data actually came from you and not someone impersonating you.
-
-<CodeExample>
-
-```js
-transaction.sign(sourceKeys);
-```
-
-```java
-transaction.sign(source);
-```
-
-```go
-tx, err = tx.Sign(network.TestNetworkPassphrase, sourceKP)
-if err != nil {
-    panic(err)
-}
-```
-
-```python
-transaction.sign(source_key)
-```
-
-</CodeExample>
-
-7. And finally, submit it to the Stellar network!
-
-<CodeExample>
-
-```js
-// Using RPC - requires polling for final status
-let sendTransactionResponse: StellarSdk.rpc.Api.SendTransactionResponse;
-try {
-  sendTransactionResponse = await rpc.sendTransaction(transaction);
+    // We include an optional memo which oftentimes is used to identify the transaction
+    // when working with pooled accounts or to facilitate reconciliation.
+    .addMemo(StellarSdk.Memo.id("1234567890"))
+    // Finally, we set a timeout for the transaction.
+    // This means that the transaction will not be valid anymore after 180 seconds.
+    .setTimeout(180)
+    .build();
+
+
+  // We sign the transaction with the source account's secret key.
+  transaction.sign(sender);
+
+  // Now we can send the transaction to the network.
+  // The sendTransaction method immediately returns a reply with the transaction hash
+  // and the status "PENDING". This means the transaction was received and is being processed.
+  const sendTransactionResponse = await rpcServer.sendTransaction(transaction);
+
+  // Here we check the status of the transaction as there are
+  // a possible outcomes after sending a transaction that would have
+  // to be handled accordingly, such as "DUPLICATE" or "TRY_AGAIN_LATER".
   if (sendTransactionResponse.status !== "PENDING") {
-    throw sendTransactionResponse;
+    throw new Error(
+      `Failed to send transaction, status: ${sendTransactionResponse.status}`
+    );
   }
-} catch (error) {
-  console.error("Error sending transaction:", error);
-  throw error;
-}
 
-try {
-  const finalStatus = await rpc.pollTransaction(sendTransactionResponse.hash, {
-    sleepStrategy: (_iter: number) => 500,
-    attempts: 5,
+  console.log("Payment Transaction submitted, hash:", sendTransactionResponse.hash);
+
+  // Here we poll the transaction status to await for its final result.
+  // We can use the transaction hash to poll the transaction status later.
+  const finalStatus = await rpcServer.pollTransaction(sendTransactionResponse.hash, {
+    sleepStrategy: (_iter) => 500,
+    attempts: 10,
   });
+
+  // The pollTransaction method will return the final status of the transaction
+  // after the specified number of attempts or when the transaction is finalized.
+  // We then check the final status of the transaction and handle it accordingly.
   switch (finalStatus.status) {
     case StellarSdk.rpc.Api.GetTransactionStatus.FAILED:
+      console.error("Transaction failed, status:", finalStatus.status);
+      if (finalStatus.resultXdr) {
+        console.error("Transaction Result XDR (decoded):", JSON.stringify(finalStatus.resultXdr, null, 2));
+      }
+
+      throw new Error(`Transaction failed with status: ${finalStatus.status}`);
     case StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND:
       throw new Error(`Transaction failed with status: ${finalStatus.status}`);
     case StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS:
-      console.log("Success! Results:", finalStatus);
+      console.log("Success! Committed on Ledger:", finalStatus.ledger);
       break;
   }
-} catch (error) {
-  console.error("Error polling transaction status:", error);
-  throw error;
 }
 
-
-// Using Horizon - returns final status immediately
-try {
-  const result = await server.submitTransaction(transaction);
-  console.log("Success! Results:", result);
-} catch (error) {
-  console.error("Something went wrong!", error);
-}
-```
-
-```java
-server.submitTransaction(transaction);
-```
-
-```go
-resp, err := horizonclient.DefaultTestNetClient.SubmitTransaction(tx)
-if err != nil {
-    panic(err)
-}
-```
-
-```python
-server.submit_transaction(transaction)
-```
-
-</CodeExample>
-
-In this example, we're submitting the transaction to either the SDF-maintained public testnet instance of Horizon (the Stellar API) or to a Stellar RPC server. When submitting transactions to either a Horizon server or RPC server — which is what most people do — it's possible that you will not receive a response from the server due to a bug, network conditions, etc. In such a situation it's impossible to determine the status of your transaction.
-
-That's why you should always save a built transaction (or transaction encoded in XDR format) in a variable or a database and resubmit it if you don't know its status. If the transaction has already been successfully applied to the ledger, both Horizon and RPC will simply return the saved result and not attempt to submit the transaction again. Only in cases where a transaction's status is unknown (and thus will have a chance of being included into a ledger) will a resubmission to the network occur.
-
-### Receive a Payment
-
-You don’t actually need to do anything to receive payments into a Stellar account: if a payer makes a successful transaction to send assets to you, those assets will automatically be added to your account.
-
-However, you may want to keep an eye out for incoming payments. A simple program that watches the network for payments and prints each one might look like:
-
-#### Using the Stellar RPC
-
-<Alert>
-With the upcoming release of Whisk, Protocol 23, native payments for assets will also emit smart contract events, which will allow for the use the Stellar RPC to stream payments for native assets. The process will then be similar to how the example under section [Stellar Asset Contract (SAC) -> Receive a Payment](#receive-a-payment-1) works. For now, you can use the Horizon API to stream payments for native assets.
-
-</Alert>
-
-#### Using Horizon
-
-<CodeExample title="Receive Payments">
-
-```js
-var StellarSdk = require("stellar-sdk");
-
-var server = new StellarSdk.Horizon.Server(
-  "https://horizon-testnet.stellar.org",
-);
-var accountId = "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF";
-
-// Create an API call to query payments involving the account.
-var payments = server.payments().forAccount(accountId);
-
-// If some payments have already been handled, start the results from the
-// last seen payment. (See below in `handlePayment` where it gets saved.)
-var lastToken = loadLastPagingToken();
-if (lastToken) {
-  payments.cursor(lastToken);
-}
-
-// `stream` will send each recorded payment, one by one, then keep the
-// connection open and continue to send you new payments as they occur.
-payments.stream({
-  onmessage: function (payment) {
-    // Record the paging token so we can start from here next time.
-    savePagingToken(payment.paging_token);
-
-    // The payments stream includes both sent and received payments. We only
-    // want to process received payments here.
-    if (payment.to !== accountId) {
-      return;
-    }
-
-    // In Stellar’s API, Lumens are referred to as the “native” type. Other
-    // asset types have more detailed information.
-    var asset;
-    if (payment.asset_type === "native") {
-      asset = "lumens";
-    } else {
-      asset = payment.asset_code + ":" + payment.asset_issuer;
-    }
-
-    console.log(payment.amount + " " + asset + " from " + payment.from);
-  },
-
-  onerror: function (error) {
-    console.error("Error in payment stream");
-  },
-});
-
-function savePagingToken(token) {
-  // In most cases, you should save this to a local database or file so that
-  // you can load it next time you stream new payments.
-}
-
-function loadLastPagingToken() {
-  // Get the last paging token from a local database or file
-}
-```
-
-```java
-Server server = new Server("https://horizon-testnet.stellar.org");
-KeyPair account = KeyPair.fromAccountId("GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF");
-
-// Create an API call to query payments involving the account.
-PaymentsRequestBuilder paymentsRequest = server.payments().forAccount(account.getAccountId());
-
-// If some payments have already been handled, start the results from the
-// last seen payment. (See below in `handlePayment` where it gets saved.)
-String lastToken = loadLastPagingToken();
-if (lastToken != null) {
-  paymentsRequest.cursor(lastToken);
-}
-
-// `stream` will send each recorded payment, one by one, then keep the
-// connection open and continue to send you new payments as they occur.
-paymentsRequest.stream(new EventListener<OperationResponse>() {
-  @Override
-  public void onEvent(OperationResponse payment) {
-    // Record the paging token so we can start from here next time.
-    savePagingToken(payment.getPagingToken());
-
-    // The payments stream includes both sent and received payments. We only
-    // want to process received payments here.
-    if (payment instanceof PaymentOperationResponse) {
-      if (!((PaymentOperationResponse) payment).getTo().equals(account.getAccountId()) {
-        return;
-      }
-
-      String amount = ((PaymentOperationResponse) payment).getAmount();
-
-      Asset asset = ((PaymentOperationResponse) payment).getAsset();
-      String assetName;
-      if (asset.equals(new AssetTypeNative())) {
-        assetName = "lumens";
-      } else {
-        StringBuilder assetNameBuilder = new StringBuilder();
-        assetNameBuilder.append(((AssetTypeCreditAlphaNum) asset).getCode());
-        assetNameBuilder.append(":");
-        assetNameBuilder.append(((AssetTypeCreditAlphaNum) asset).getIssuer());
-        assetName = assetNameBuilder.toString();
-      }
-
-      StringBuilder output = new StringBuilder();
-      output.append(amount);
-      output.append(" ");
-      output.append(assetName);
-      output.append(" from ");
-      output.append(((PaymentOperationResponse) payment).getFrom());
-      System.out.println(output.toString());
-    }
-  }
-
-  @Override
-  public void onFailure(Optional<Throwable> optional, Optional<Integer> optional1) {
-
-  }
+sendPayments().catch((error) => {
+  console.error("Error executing sendPayments function:", error);
+  process.exit(1);
 });
 ```
-
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-    "time"
-
-    "github.com/stellar/go/clients/horizonclient"
-    "github.com/stellar/go/protocols/horizon/operations"
-)
-
-func main() {
-    client := horizonclient.DefaultTestNetClient
-    opRequest := horizonclient.OperationRequest{ForAccount: "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF", Cursor: "now"}
-
-    ctx, cancel := context.WithCancel(context.Background())
-    go func() {
-        // Stop streaming after 60 seconds.
-        time.Sleep(60 * time.Second)
-        cancel()
-    }()
-
-    printHandler := func(op operations.Operation) {
-        fmt.Println(op)
-    }
-    err := client.StreamPayments(ctx, opRequest, printHandler)
-    if err != nil {
-        fmt.Println(err)
-    }
-
-}
-```
-
-```python
-from stellar_sdk import Server
-
-def load_last_paging_token():
-    # Get the last paging token from a local database or file
-    return "now"
-
-def save_paging_token(paging_token):
-    # In most cases, you should save this to a local database or file so that
-    # you can load it next time you stream new payments.
-    pass
-
-server = Server("https://horizon-testnet.stellar.org")
-account_id = "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF"
-
-# Create an API call to query payments involving the account.
-payments = server.payments().for_account(account_id)
-
-# If some payments have already been handled, start the results from the
-# last seen payment. (See below in `handle_payment` where it gets saved.)
-last_token = load_last_paging_token()
-if last_token:
-    payments.cursor(last_token)
-
-# `stream` will send each recorded payment, one by one, then keep the
-# connection open and continue to send you new payments as they occur.
-for payment in payments.stream():
-    # Record the paging token so we can start from here next time.
-    save_paging_token(payment["paging_token"])
-
-    # We only process `payment`, ignore `create_account` and `account_merge`.
-    if payment["type"] != "payment":
-        continue
-
-    # The payments stream includes both sent and received payments. We
-    # only want to process received payments here.
-    if payment['to'] != account_id:
-        continue
-
-    # In Stellar’s API, Lumens are referred to as the “native” type. Other
-    # asset types have more detailed information.
-    if payment["asset_type"] == "native":
-        asset = "Lumens"
-    else:
-        asset = f"{payment['asset_code']}:{payment['asset_issuer']}"
-    print(f"{payment['amount']} {asset} from {payment['from']}")
-```
-
 </CodeExample>
+</Details>
 
-There are two main parts to this program. First, you create a query for payments involving a given account. Like most queries in Stellar, this could return a huge number of items, so the API returns paging tokens, which you can use later to start your query from the same point where you previously left off. In the example above, the functions to save and load paging tokens are left blank, but in a real application, you’d want to save the paging tokens to a file or database so you can pick up where you left off in case the program crashes or the user closes it.
+### Monitoring Payments as event stream
 
+Leverage the latest [Protocol 23 (Whisk)](https://stellar.org/blog/developers/introducing-whisk-stellar-protocol-23) to capture payment activity as pure events. These events can be efficiently monitored using the RPC server's `getEvents` method, which provides server-side filtering and real-time payment detection.
+
+The RPC approach offers several advantages:
+- **Server-side event topic filtering**: Filter for specific events using topic patterns
+- **Efficient polling**: Use cursors and pagination for reliable event processing
+- **Unified event model**: supports [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md), all asset movements on the network are emitted as events with standardized topic names to indicate the type of movement (e.g., "transfer" for payments)
+- **Better error handling**: RPC stateless HTTP polling is more resilient than persistent streaming protocols like SSE or WebSockets
+
+Demonstrate near real-time monitoring of transactions from the Stellar network by establishing an asynchronous listener to consume events from RPC and filter them by topic for just our example payments generated by our previous payments script.
+
+<Details summary="Click to view payment monitoring code">
 <CodeExample>
-
 ```js
-var payments = server.payments().forAccount(accountId);
-var lastToken = loadLastPagingToken();
-if (lastToken) {
-  payments.cursor(lastToken);
+// monitor_payment.js
+
+import * as StellarSdk from '@stellar/stellar-sdk';
+import fs from 'fs';
+
+async function monitorPayments() {
+    // Initialize RPC server for testnet
+    const rpcServer = new StellarSdk.rpc.Server("https://soroban-testnet.stellar.org");
+
+    // One-time initialization - everything encapsulated here
+    const monitoredFromAccount = fs.readFileSync("sender_public.key", "utf-8").trim();
+
+    // create our payment event topic filter values
+    const transferTopicFilter = StellarSdk.xdr.ScVal.scvSymbol("transfer").toXDR('base64');
+    const fromTopicFilter = StellarSdk.nativeToScVal(
+        StellarSdk.Address.fromString(monitoredFromAccount),
+        { type: "address" }
+    ).toXDR('base64');
+
+    // Get starting ledger
+    const latestLedger = await rpcServer.getLatestLedger();
+    console.log(`Starting payment monitoring from ledger ${latestLedger.sequence} and from account ${monitoredFromAccount}`);
+    let currentStartLedger = latestLedger.sequence;
+    let currentCursor;
+
+    while (true) {
+        // Query for payments from our monitored account
+        const eventsResponse = await rpcServer.getEvents({
+            startLedger: currentStartLedger,
+            cursor: currentCursor,
+            filters: [
+                {
+                    type: "contract",
+                    topics: [
+                        [
+                            transferTopicFilter,
+                            fromTopicFilter,
+                            "*", // to (any address)
+                            "*" // asset (any asset)
+                        ]
+                    ]
+                }
+            ],
+            limit: 10
+        });
+
+        // Process any events found
+        console.log(`Found ${eventsResponse.events.length} payment(s):`);
+
+        for (const event of eventsResponse.events) {
+            console.log("\n--- Payment Received ---");
+            console.log(`Ledger: ${event.ledger}`);
+            console.log(`Transaction Hash: ${event.txHash}`);
+            console.log(`Closed At: ${event.ledgerClosedAt}`);
+
+            // Decode addresses from topics
+            try {
+                const fromAddress = StellarSdk.scValToNative(event.topic[1]);
+                const toAddress = StellarSdk.scValToNative(event.topic[2]);
+                console.log(`Transfer: ${fromAddress} → ${toAddress}`);
+            } catch (error) {
+                console.log(`From/To: Unable to decode addresses`, error);
+                continue;
+            }
+
+            // Decode transfer amount from the event data
+            try {
+
+                // Protocol 23+ unified events model per CAP-0067
+                // https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md
+                // Event value field is scMap with {amount: i128, to_muxed_id: u64|bytes|string} (when muxed info present)
+                let amount = "n/a";
+                for (const entry of event.value.map()) {
+                    if (StellarSdk.scValToNative(entry.key()) === "amount") {
+                        amount = StellarSdk.scValToBigInt(entry.val());
+                    }
+                }
+                console.log(`Amount: ${amount.toString()} stroops (${(Number(amount) / 10000000).toFixed(7)} XLM)`);
+            } catch (error) {
+                console.log(`Failed to decode transfer amount:`, error);
+            }
+            // Decode asset from topics[3] (sep0011_asset string)
+            if (event.topic.length > 3) {
+                const asset = StellarSdk.scValToNative(event.topic[3]);
+                console.log(`Asset: ${asset}`);
+            }
+        }
+
+        // Update cursor to drive next query
+        currentCursor = eventsResponse.cursor;
+        currentStartLedger = null;
+
+        // Wait 5 seconds before next iteration
+        await new Promise(resolve => setTimeout(resolve, 5000));
+    }
 }
-```
 
-```java
-PaymentsRequestBuilder paymentsRequest = server.payments().forAccount(account.getAccountId());
-String lastToken = loadLastPagingToken();
-if (lastToken != null) {
-  paymentsRequest.cursor(lastToken);
-}
-```
-
-```go
-client := horizonclient.DefaultTestNetClient
-opRequest := horizonclient.OperationRequest{ForAccount: "GC2BKLYOOYPDEFJKLKY6FNNRQMGFLVHJKQRGNSSRRGSMPGF32LHCQVGF", Cursor: "now"}
-```
-
-```python
-payments = server.payments().for_account(account_id)
-last_token = load_last_paging_token()
-if last_token:
-    payments.cursor(last_token)
+// Start the application
+monitorPayments().catch(error => {
+    console.error("Failed during payment monitoring:", error);
+});
 ```
 
 </CodeExample>
+</Details>
 
-Second, the results of the query are streamed. This is the easiest way to watch for payments or other transactions. Each existing payment is sent through the stream, one by one. Once all existing payments have been sent, the stream stays open and new payments are sent as they are made.
+### Running Your Payment Pipeline with RPC
 
-Try it out: Run this program, and then, in another window, create and submit a payment. You should see this program log the payment.
-
+1. **Run the payment submission script** in one terminal. Leave it running, it will submit a payment once every 30 seconds.
+<Details summary="Click for command to run the payments">
 <CodeExample>
-
-```js
-payments.stream({
-  onmessage: function (payment) {
-    // handle a payment
-  },
-});
-```
-
-```java
-paymentsRequest.stream(new EventListener<OperationResponse>() {
-  @Override
-  public void onEvent(OperationResponse payment) {
-    // Handle a payment
-  }
-});
-```
-
-```go
-ctx, cancel := context.WithCancel(context.Background())
-go func() {
-    // Stop streaming after 60 seconds.
-    time.Sleep(60 * time.Second)
-    cancel()
-}()
-
-printHandler := func(op operations.Operation) {
-    fmt.Println(op)
-}
-err := client.StreamPayments(ctx, opRequest, printHandler)
-if err != nil {
-    fmt.Println(err)
-}
-```
-
-```python
-for payment in payments.stream():
-    # handle a payment
-```
-
-</CodeExample>
-
-You can also request payments in groups or pages. Once you’ve processed each page of payments, you’ll need to request the next one until there are none left.
-
-<CodeExample>
-
-```js
-payments.call().then(function handlePage(paymentsPage) {
-  paymentsPage.records.forEach(function (payment) {
-    // handle a payment
-  });
-  return paymentsPage.next().then(handlePage);
-});
-```
-
-```java
-Page<OperationResponse> page = payments.execute();
-
-for (OperationResponse operation : page.getRecords()) {
-    // handle a payment
-}
-
-page = page.getNextPage();
-```
-
-```python
-payments_current = payments.call()
-payments_next = payments.next()
-```
-
-</CodeExample>
-
-## Stellar Asset Contract (SAC) Payments
-
-When sending payments using Stellar Asset Contracts, you invoke smart contract functions instead of using payment operations. SAC payments utilize the `invokeHostFunction` operation to call contract methods like `transfer`, which provides the same payment functionality but through contract logic. This approach offers additional flexibility and programmability while maintaining compatibility with Stellar's asset system.
-
-In the example below, we're using SAC as a smart contract interface for the native asset, so the end result is the same as if a native payment operation had been executed. However, the same process can be applied for any smart contract transfer involving standardized contract tokens that follow the [contract token interface](../../../tokens/token-interface.mdx). This makes SAC payments a unified approach for handling both native assets and contract tokens through a consistent contract-based interface.
-
-Here's how you might send 10 lumens using a SAC:
-
-<Alert>
-  To use the RPC example below you should first generate the contract bindings so the
-  client can be used accordingly. This can be achieved through the [Stellar
-  CLI](../../../tools/cli/README.mdx).
-
-E.g.: Generating the typescript bindings for the `sac` contract of a given asset:
 
 ```bash
- stellar contract bindings typescript --network=testnet --contract-id=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC --output-dir=./bindings
-```
-
-</Alert>
-
-### Send a Payment
-
-<CodeExample>
-
-```js
-import {
-  Account,
-  Asset,
-  Keypair,
-  Networks,
-  TransactionBuilder,
-} from "stellar-sdk";
-import { Client } from "sac";
-import { Server } from "stellar-sdk/rpc";
-
-// Initialize Soroban RPC server for testnet
-const rpc = new Server("https://soroban-testnet.stellar.org");
-
-// Initalize the source account's secret key and destination account ID.
-// The source account is the one that will send the payment, and the destination account
-// is the one that will receive the payment.
-const sourceKeys = Keypair.fromSecret(
-  "SAMAJBEGN2743SLFDSBSVRCTQ7AC33XFZHWJVCJ2UMOIVH4MUJ7WWHEJ",
-);
-const destinationId =
-  "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5";
-
-// First, check to make sure that the destination account exists.
-try {
-  await rpc.getAccount(destinationId);
-} catch (error) {
-  console.error("Error checking destination account:", error);
-  throw error;
-}
-
-// Now we also load the source account to build the transaction.
-try {
-  await rpc.getAccount(sourceKeys.publicKey());
-} catch (error) {
-  console.error("Error checking source account:", error);
-  throw error;
-}
-
-// Now we initialize the Stellar Asset Contract (SAC) client.
-// The client needs the RPC endpoint, network passphrase, contract ID for the asset,
-// and your account's public key. A signing function can also be provided to automatically
-// handle transaction signing when invoking contract methods with this client.
-//
-// In this case, we are using the native asset contract ID for the testnet.
-// The contract ID is derived from the native asset, which is represented by `Asset.native()`.
-// The `contractId` method will return the contract ID for the native asset on the specified network.
-const xlmClient = new Client({
-  rpcUrl: "https://soroban-testnet.stellar.org",
-  networkPassphrase: Networks.TESTNET,
-  contractId: Asset.native().contractId(Networks.TESTNET),
-  publicKey: sourceKeys.publicKey(),
-  signTransaction: async (txXdr) => {
-    const tx = await TransactionBuilder.fromXDR(txXdr, Networks.TESTNET);
-    tx.sign(sourceKeys);
-    return { signedTxXdr: tx.toXDR(), signerAddress: sourceKeys.publicKey() };
-  },
-});
-
-// Now, using the client, we assemble a soroban transaction to invoke the transfer
-// function of the native asset contract. The client will automatically
-// bundle the operation and simulate the transaction before providing us
-// with an assembled transaction object that we can sign and send.
-let assembledTx;
-try {
-  assembledTx = await xlmClient.transfer({
-    to: destinationId,
-    amount: BigInt(10_0000000), // Amount in stroops (1 XLM = 10,000,000 stroops)
-    from: sourceKeys.publicKey(),
-  });
-} catch (error) {
-  console.error("Error assembling the transaction:", error);
-  throw error;
-}
-
-// The assembled transaction is ready to be signed and sent. It already includes
-// a function that allows us to perform the signing and sending in one step. It will
-// use the signTransaction function we provided to the client to sign the transaction or
-// alternatively, receive a custom one just for this transaction.
-try {
-  const result = await assembledTx.signAndSend();
-  console.log("Transaction successful:", result.getTransactionResponse?.txHash);
-} catch (error) {
-  console.error("Error during transaction processing:", error);
-  throw error;
-}
+// js
+node send_payment.js
 ```
 
 </CodeExample>
+</Details>
 
-#### Step-by-Step Breakdown
-
-What exactly happened in the SAC payment example? Let's break it down:
-
-1. Import the generated contract client from the CLI-produced bindings. This client provides typed methods for interacting with the Stellar Asset Contract.
-
+2. **Run the payment monitor script** in a separate terminal.
+<Details summary="Click for command to run the payments monitor">
 <CodeExample>
 
-```js
-import { Client } from "sac";
+```bash
+// js
+node monitor_payments.js
 ```
 
 </CodeExample>
+</Details>
 
-2. Initialize the SAC client with connection details and a custom signing function. The client needs the RPC endpoint, network passphrase, contract ID for the asset, and your account's public key. A signing function can also be provided to automatically handle transaction signing when invoking contract methods with this client.
+3. **Observe the payment events** as they're detected and displayed on console.
 
-<CodeExample>
+## Summary
 
-```js
-const xlmClient = new Client({
-  rpcUrl: "https://soroban-testnet.stellar.org",
-  networkPassphrase: Networks.TESTNET,
-  contractId: Asset.native().contractId(Networks.TESTNET),
-  publicKey: sourceKeys.publicKey(),
-  signTransaction: async (txXdr) => {
-    const tx = await TransactionBuilder.fromXDR(txXdr, Networks.TESTNET);
-    tx.sign(sourceKeys);
-    return {
-      signedTxXdr: tx.toXDR(),
-      signerAddress: sourceKeys.publicKey(),
-    };
-  },
-});
-```
+- Payments from transaction operations or contract invocations on Stellar network can be monitored by leveraging the unified events model as of [Protocol 23 (Whisk)](https://stellar.org/blog/developers/introducing-whisk-stellar-protocol-23) and the RPC `getEvents` method.
 
-</CodeExample>
+  - **Payments are 'transfer' events**: the [unified events model](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md) ensures whether a payment happened through an operation or contract invocation it will result in the same 'transfer' event being emitted.
+  - **Event Type**: `"contract"` denotes payments are an application level event rather than 'diagnostic' or 'system' event.
+  - **Transfer Topics Model**: an array of four topics, specified in [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md) and summarized:
+    - `topic[0]` = Event name 'transfer' determines the next 3 topics
+    - `topic[1]` = Transfer Sender address
+    - `topic[2]` = Transfer Recipient address
+    - `topic[3]` = Asset identifier
 
-3. Initiate the transfer by calling the contract's `transfer` method. This returns an assembled transaction ready for signing and submission.
-
-<CodeExample>
-
-```js
-xlmClient.transfer({
-  to: destinationId,
-  amount: BigInt(10_0000000), // Amount in stroops (1 XLM = 10,000,000 stroops)
-  from: sourceKeys.publicKey(),
-});
-```
-
-</CodeExample>
-
-4. Sign and submit the transaction using `signAndSend()`. The client handles simulation, signing (using your provided function), submission to the network, and polling for the final result.
-
-<CodeExample>
-
-```js
-try {
-  const result = await assembledTx.signAndSend();
-  console.log("Transaction successful:", result.getTransactionResponse?.txHash);
-} catch (error) {
-  console.error("Error during transaction processing:", error);
-  throw error;
-}
-```
-
-</CodeExample>
-
-### Receive a Payment
-
-You don't need to do anything special to receive SAC payments into a Stellar account: if a payer makes a successful contract transfer to you, those assets will automatically be added to your account.
-
-However, you may want to monitor for incoming SAC payments. Since SAC payments generate contract events rather than traditional payment operations, you'll need to watch for contract events instead of using Horizon's payment streams. Here's how you can monitor for incoming Smart Contract transfers:
-
-<CodeExample>
-
-```js
-import { Server } from "stellar-sdk/rpc";
-import { xdr, Asset, Networks, Address } from "stellar-sdk";
-
-// Initialize Soroban RPC server for testnet
-const rpc = new Server("https://soroban-testnet.stellar.org");
-
-// Get the native XLM contract ID for testnet
-const contractId = Asset.native().contractId(Networks.TESTNET);
-
-// The address we want to monitor for incoming payments
-const monitoredAddress = new Address(
-  "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5"
-);
-
-// Paging state for event polling (similar to useSubscription hook)
-let lastLedgerStart: number | undefined;
-let pagingToken: string | undefined;
-
-async function pollForTransfers() {
-  // Set starting ledger if not set (get the latest ledger as starting point)
-  if (!lastLedgerStart) {
-    const latestLedger = await rpc.getLatestLedger();
-    lastLedgerStart = latestLedger.sequence;
-  }
-  console.log(`> Monitoring transfers for ledger: ${lastLedgerStart}`);
-
-  // Get events for "transfer" topic from the native asset contract
-  const response = await rpc.getEvents({
-    startLedger: !pagingToken ? lastLedgerStart : undefined,
-    cursor: pagingToken,
-    filters: [
-      {
-        contractIds: [contractId],
-        // Filter for transfer events to the monitored address
-        // Using wildcards (*) to match any sender and asset
-        // Event structure: ["transfer", fromAddress, toAddress, assetName]
-        topics: [
-          [
-            xdr.ScVal.scvSymbol("transfer").toXDR("base64"),
-            "*",
-            monitoredAddress.toScVal().toXDR("base64"),
-            "*",
-          ],
-        ],
-        type: "contract",
-      },
-    ],
-    limit: 10,
-  });
-
-  // Update paging tokens for next poll
-  pagingToken = undefined;
-  if (response.latestLedger) {
-    lastLedgerStart = response.latestLedger;
-  }
-
-  // Process events and check for payments to our monitored address
-  if (response.events) {
-    response.events.forEach((event) => {
-      try {
-        const topics = event.topic;
-        console.log(
-          `Processing event: ${event.txHash} at ledger ${event.ledger}`
-        );
-        if (topics && topics.length >= 3) {
-          // Extract recipient address from event topics
-          const toAddress = Address.fromScAddress(
-            topics[2].address()
-          ).toString();
-
-          // Check if the payment is to our monitored address
-          if (toAddress === monitoredAddress.toString()) {
-            console.log("PAYMENT RECEIVED!");
-            console.log(`  Transaction: ${event.txHash}`);
-            console.log(`  Ledger: ${event.ledger}`);
-            console.log(
-              `  Sender: ${Address.fromScAddress(
-                topics[1].address()
-              ).toString()}`
-            );
-            console.log(`  Amount: ${event.value.i128().lo().toBigInt()}`);
-          }
-        }
-      } catch (error) {
-        console.error("Error processing event:", error);
-      } finally {
-        // Update paging token for next poll
-        pagingToken = event.pagingToken;
-      }
-    });
-  }
-
-  // Continue polling after 4 seconds
-  setTimeout(pollForTransfers, 4000);
-}
-
-// Start monitoring for payment events
-console.log(`Starting payment monitor for: ${monitoredAddress}`);
-pollForTransfers();
-
-```
-
-</CodeExample>
-
-#### Step-by-Step Breakdown
-
-What exactly happened in the SAC receive payment example? Let's break it down:
-
-1. Set up the RPC connection and get the contract ID for the asset you want to monitor. For native XLM, we use the built-in contract ID.
-
-<CodeExample>
-
-```js
-const rpc = new Server("https://soroban-testnet.stellar.org");
-const contractId = Asset.native().contractId(Networks.TESTNET);
-const monitoredAddress = new Address(
-  "GA2C5RFPE6GCKMY3US5PAB6UZLKIGSPIUKSLRB6Q723BM2OARMDUYEJ5",
-);
-```
-
-</CodeExample>
-
-2. Initialize the polling system by getting the latest ledger sequence as a starting point for monitoring events.
-
-<CodeExample>
-
-```js
-if (!lastLedgerStart) {
-  const latestLedger = await rpc.getLatestLedger();
-  lastLedgerStart = latestLedger.sequence;
-}
-```
-
-</CodeExample>
-
-3. Query contract events using specific filters for transfer events. The filter targets the contract ID and listens for "transfer" events where your address is the recipient. The topics array defines the event structure: the first element is the event name ("transfer"), the second is the sender (wildcard "_" to match any), the third is the recipient (your monitored address), and the fourth is the asset (wildcard "_" for any asset).
-
-<CodeExample>
-
-```js
-const response = await rpc.getEvents({
-  startLedger: !pagingToken ? lastLedgerStart : undefined,
-  cursor: pagingToken,
-  filters: [
-    {
-      contractIds: [contractId],
-      // Topics filter structure: ["event_name", "from_address", "to_address", "asset"]
-      // Using wildcards (*) allows matching any value in that position
-      topics: [
-        [
-          xdr.ScVal.scvSymbol("transfer").toXDR("base64"), // Event name: "transfer"
-          "*", // From: any address
-          monitoredAddress.toScVal().toXDR("base64"), // To: our monitored address
-          "*", // Asset: any asset
-        ],
-      ],
-      type: "contract",
-    },
-  ],
-  limit: 10,
-});
-```
-
-</CodeExample>
-
-4. Process the events by extracting transfer details from the event topics and values, then continue polling for new events after a short delay.
-
-<CodeExample>
-
-```js
-response.events.forEach((event) => {
-  const topics = event.topic;
-  if (topics && topics.length >= 3) {
-    const toAddress = Address.fromScAddress(topics[2].address()).toString();
-
-    if (toAddress === monitoredAddress.toString()) {
-      console.log("PAYMENT RECEIVED!");
-      console.log(`Amount: ${event.value.i128().lo().toBigInt()}`);
-    }
-  }
-});
-
-// Continue polling
-setTimeout(pollForTransfers, 4000);
-```
-
-</CodeExample>
-
-**Key Differences from Classic Payment Monitoring:**
-
-- **Event-based**: Monitors contract events instead of payment operations
-- **RPC Only**: Uses RPC endpoints exclusively, no Horizon support
-- **Topic Filtering**: Uses event topics to filter for specific transfer patterns
-- **Active Polling**: Requires continuous polling rather than streaming
-- **Event Structure**: Extracts payment data from contract event topics and values rather than operation fields
-
-## Transacting in Other Currencies
-
-One of the amazing things about the Stellar network is that you can create, hold, send, receive, and trade any type of asset. Many organizations issue assets on Stellar that represent real-world currencies such as US dollars or Nigerian naira or other cryptocurrencies such as bitcoin or ether.
-
-Each of these redeemable assets — _anchored_ in the Stellar vernacular — is essentially a credit issued by a particular account that represents reserves those accounts hold outside the network. That's why the assets in the example above had both a `code` and an `issuer`: the `issuer` is the public key of the account that created the asset, an account owned by the organization that ultimately honors the credit that asset represents. Additionally, with the introduction of smart contracts, the classic assets can also be represented by a `contract id` [(SAC Interface)](../../../tokens/stellar-asset-contract.mdx)) which allows for more complex interactions and interoperability with the smart contract applications.
-
-Other custom tokens, built entirely with smart contracts are also represented by their own `contract id` and should offer a similar interface for interaction when following the [token interface](https://soroban.stellar.org/docs/reference/interfaces/token-interface).
+- RPC provides precise filtering of Stellar network events and this includes event topics model defined for unified events in [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md). You save time by using the RPC server-side filter capabilities to focus on processing only events relative to your application such as payments from a specific account in this example.
+  - **Wildcards**: The RPC `getEvents` allows to use "\*" to match any value in a topic position
+  - **Server-side Filtering**: RPC `getEvents` applies the filters and only matching events are returned, reducing bandwidth
+  - **Cursor-based Pagination**: RPC `getEvents` retrieves event data efficiently with a paging mechanism

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -317,14 +317,8 @@ func friendbotFund(accountID, friendbotURL string) error {
 	// Construct the URL with account parameter
 	fullURL := friendbotURL + "?addr=" + url.QueryEscape(accountID)
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-
 	// Make HTTP GET request
-	resp, err := client.Get(fullURL)
+	resp, err := http.Get(fullURL)
 	if err != nil {
 		return fmt.Errorf("failed to make friendbot request: %v", err)
 	}
@@ -422,13 +416,7 @@ func sendPayment(ctx context.Context, rpcClient *sdk.Client, sourceAccount txnbu
 func main() {
 	const RPC_URL = "https://soroban-testnet.stellar.org"
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-
-	rpcClient := sdk.NewClient(RPC_URL, httpClient)
+	rpcClient := sdk.NewClient(RPC_URL, nil)
 
 	// Get network info to obtain friendbot URL
 	ctx := context.Background()
@@ -739,13 +727,7 @@ import (
 func main() {
 	const RPC_URL = "https://soroban-testnet.stellar.org"
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-
-	rpcClient := sdk.NewClient(RPC_URL, httpClient)
+	rpcClient := sdk.NewClient(RPC_URL, nil)
 	ctx := context.Background()
 
 	// Load the account we monitor payments FROM (written by send_payment example)

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -74,6 +74,11 @@ async function sendPayments() {
     console.log("Sender Account funded with airdrop");
     console.log("Sender Account ID:", senderAccount.accountId());
     console.log("Sender Sequence number:", senderAccount.sequence.toString());
+
+    // Note - this persistence of sender id to a file on file system is only done for demo purposes.
+    // It shares the created sender account with the payment monitor example which will run next.
+    // Since this example is using file system it therefore is intended to run only on Node.
+    // In a real application the stellar js sdk can be used in browser or Node.
     fs.writeFileSync("sender_public.key", senderAccount.accountId());
 
     console.log("\n\n");
@@ -145,10 +150,7 @@ async function sendPayment(sender, senderAccount, recipient) {
 
   // Here we poll the transaction status to await for its final result.
   // We can use the transaction hash to poll the transaction status later.
-  const finalStatus = await rpcServer.pollTransaction(sendTransactionResponse.hash, {
-    sleepStrategy: (_iter) => 500,
-    attempts: 10,
-  });
+  const finalStatus = await rpcServer.pollTransaction(sendTransactionResponse.hash);
 
   // The pollTransaction method will return the final status of the transaction
   // after the specified number of attempts or when the transaction is finalized.

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -191,15 +191,6 @@ import org.stellar.sdk.operations.PaymentOperation;
 import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse;
 import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse.GetTransactionStatus;
 import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.SendTransactionStatus;
-import org.stellar.sdk.xdr.AccountEntry;
-import org.stellar.sdk.xdr.AccountID;
-import org.stellar.sdk.xdr.LedgerEntry.LedgerEntryData;
-import org.stellar.sdk.xdr.LedgerEntryType;
-import org.stellar.sdk.xdr.LedgerKey;
-import org.stellar.sdk.xdr.LedgerKey.LedgerKeyAccount;
-import org.stellar.sdk.xdr.PublicKey;
-import org.stellar.sdk.xdr.PublicKey.PublicKeyBuilder;
-import org.stellar.sdk.xdr.PublicKeyType;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -211,7 +202,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.List;
 
 public class SendPaymentJavaExample {
   public static void main(String[] args) throws Exception {
@@ -234,8 +224,7 @@ public class SendPaymentJavaExample {
         StandardOpenOption.WRITE);
 
     // Load sender sequence using RPC getLedgerEntries
-    long senderSeq = loadAccountSequenceViaRpc(rpc, sender.getAccountId());
-    Account source = new Account(sender.getAccountId(), senderSeq);
+    Account source = new Account(sender.getAccountId(), rpc.getAccount(sender.getAccountId()).getSequenceNumber());
 
     // do this in a loop, send payment once every 30 seconds
     while (true) {
@@ -278,37 +267,7 @@ public class SendPaymentJavaExample {
     System.out.println("Funded: " + accountId);
   }
 
-  // Use RPC getLedgerEntries to fetch AccountEntry and read seqNum
-  static long loadAccountSequenceViaRpc(SorobanServer rpc, String accountId) throws Exception {
-    // Build LedgerKey for account
-    PublicKey pk = KeyPair.fromAccountId(accountId).getXdrPublicKey();
-
-    PublicKeyBuilder pb = PublicKey.builder();
-    pb.discriminant(PublicKeyType.PUBLIC_KEY_TYPE_ED25519);
-    pb.ed25519(pk.getEd25519());
-    AccountID aid = new AccountID(pb.build());
-
-    LedgerKeyAccount lka = new LedgerKeyAccount();
-    lka.setAccountID(aid);
-
-    LedgerKey key = new LedgerKey();
-    key.setDiscriminant(LedgerEntryType.ACCOUNT);
-    key.setAccount(lka);
-
-    var gle = rpc.getLedgerEntries(List.of(key));
-    if (gle.getEntries() == null || gle.getEntries().isEmpty()) {
-      throw new RuntimeException("Account not found in ledger entries: " + accountId);
-    }
-
-    // Decode first entry's ledger XDR to fetch sequence
-    LedgerEntryData data = gle.getEntries().get(0).parseXdr();
-    if (data.getDiscriminant() != LedgerEntryType.ACCOUNT) {
-      throw new RuntimeException("Unexpected ledger entry type for account.");
-    }
-    AccountEntry acc = data.getAccount();
-    return acc.getSeqNum().getSequenceNumber().getInt64();
-  }
-
+  // Helper: wrap SorobanServer.pollTransaction and enforce failure handling
   static GetTransactionResponse pollTransaction(SorobanServer rpc, String txHash) throws Exception {
     GetTransactionResponse resp = rpc.pollTransaction(txHash);
 

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -174,6 +174,146 @@ sendPayments().catch((error) => {
   process.exit(1);
 });
 ```
+
+```java
+// send_payment.java
+// Java 17, Stellar Java SDK (lightsail-network/java-stellar-sdk)
+
+import org.stellar.sdk.*;
+import org.stellar.sdk.Transaction;
+import org.stellar.sdk.operations.PaymentOperation;
+import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse;
+import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse.GetTransactionStatus;
+import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.SendTransactionStatus;
+import org.stellar.sdk.xdr.*;
+import org.stellar.sdk.xdr.LedgerEntry.LedgerEntryData;
+import org.stellar.sdk.xdr.LedgerKey.LedgerKeyAccount;
+import org.stellar.sdk.xdr.PublicKey.PublicKeyBuilder;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.math.BigDecimal;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class SendPaymentJavaExample {
+  public static void main(String[] args) throws Exception {
+    final String RPC_URL = "https://soroban-testnet.stellar.org";
+    SorobanServer rpc = new SorobanServer(RPC_URL);
+
+    // Generate sender/recipient and fund via Friendbot (testnet)
+    // get the friendbot url from rpc info
+    var info = rpc.getNetwork();
+    System.out.println("Friendbot URL: " + info.getFriendbotUrl()); 
+
+    KeyPair sender = KeyPair.random();
+    KeyPair recipient = KeyPair.random();
+    friendbotFund(sender.getAccountId(), info.getFriendbotUrl());
+    friendbotFund(recipient.getAccountId(), info.getFriendbotUrl());
+
+    // Load sender sequence using RPC getLedgerEntries
+    long senderSeq = loadAccountSequenceViaRpc(rpc, sender.getAccountId());
+    Account source = new Account(sender.getAccountId(), senderSeq);
+
+    // do this in a loop, send payment once every 30 seconds
+    while (true) {
+      // Build classic payment: 10 XLM, memo id, 180s timeout
+      Transaction tx = new TransactionBuilder(source, Network.TESTNET)
+          .setBaseFee(Transaction.MIN_BASE_FEE)
+          .addOperation(PaymentOperation.builder().
+              destination(recipient.getAccountId()).
+              asset(new AssetTypeNative()).
+              amount(new BigDecimal("10")).build())
+          .addMemo(new MemoId(1234567890L))
+          .setTimeout(180)
+          .build();
+
+      tx.sign(sender);
+
+      // Submit via RPC
+      var sendResp = rpc.sendTransaction(tx);
+      if (!SendTransactionStatus.PENDING.equals(sendResp.getStatus())) {
+        throw new RuntimeException("Failed to send transaction, status: " + sendResp.getStatus());
+      }
+      System.out.println("Submitted. Hash: " + sendResp.getHash());
+
+      // Poll final status (throws on FAILED/NOT_FOUND)
+      var finalResp = pollTransaction(rpc, sendResp.getHash());
+      System.out.println("Success! Committed on ledger: " + finalResp.getLedger());
+      Thread.sleep(30000L); // wait 30s
+    }
+  }
+
+  // Fund account with Friendbot (testnet)
+  static void friendbotFund(String accountId, String friendbotUrl) throws Exception {
+    OkHttpClient http = new OkHttpClient.Builder().build();
+    String url = friendbotUrl + "?addr=" + URLEncoder.encode(accountId, StandardCharsets.UTF_8);
+    
+    Request req = new Request.Builder().url(url).build();
+    Response res = http.newCall(req).execute();
+
+    if (res.code() / 100 != 2) {
+      throw new RuntimeException("Friendbot funding failed: " + res.code() + " " + res.body().string());
+    }
+    System.out.println("Funded: " + accountId);
+  }
+
+  // Use RPC getLedgerEntries to fetch AccountEntry and read seqNum
+  static long loadAccountSequenceViaRpc(SorobanServer rpc, String accountId) throws Exception {
+    // Build LedgerKey for account
+    PublicKey pk = KeyPair.fromAccountId(accountId).getXdrPublicKey();
+
+    PublicKeyBuilder pb = PublicKey.builder();
+    pb.discriminant(PublicKeyType.PUBLIC_KEY_TYPE_ED25519);
+    pb.ed25519(pk.getEd25519());
+    AccountID aid = new AccountID(pb.build());
+
+    LedgerKeyAccount lka = new LedgerKeyAccount();
+    lka.setAccountID(aid);
+
+    LedgerKey key = new LedgerKey();
+    key.setDiscriminant(LedgerEntryType.ACCOUNT);
+    key.setAccount(lka);
+   
+    var gle = rpc.getLedgerEntries(List.of(key));
+    if (gle.getEntries() == null || gle.getEntries().isEmpty()) {
+      throw new RuntimeException("Account not found in ledger entries: " + accountId);
+    }
+
+    // Decode first entry's ledger XDR to fetch sequence
+    LedgerEntryData data = gle.getEntries().get(0).parseXdr();
+    if (data.getDiscriminant() != LedgerEntryType.ACCOUNT) {
+      throw new RuntimeException("Unexpected ledger entry type for account.");
+    }
+    AccountEntry acc = data.getAccount();
+    return acc.getSeqNum().getSequenceNumber().getInt64();
+  }
+
+  // Helper: wrap SorobanServer.pollTransaction and enforce failure handling
+  static GetTransactionResponse pollTransaction(SorobanServer rpc, String txHash) throws Exception {
+    GetTransactionResponse resp = rpc.pollTransaction(txHash);
+   
+    if (GetTransactionStatus.SUCCESS.equals(resp.getStatus())) {
+      return resp;
+    }
+    if (GetTransactionStatus.FAILED.equals(resp.getStatus())) {
+      if (resp.getResultXdr() != null) {
+        System.err.println("Failed TX, Result XDR (base64): " + resp.getResultXdr());
+      }
+      throw new RuntimeException("Transaction failed.");
+    }
+    if (GetTransactionStatus.NOT_FOUND.equals(resp.getStatus())) {
+      throw new RuntimeException("Transaction not found.");
+    }
+    throw new RuntimeException("Unexpected status: " + resp.getStatus());
+  }
+}
+
+```
+
 </CodeExample>
 </Details>
 
@@ -267,6 +407,7 @@ async function monitorPayments() {
                 for (const entry of event.value.map()) {
                     if (StellarSdk.scValToNative(entry.key()) === "amount") {
                         amount = StellarSdk.scValToBigInt(entry.val());
+                        break;
                     }
                 }
                 console.log(`Amount: ${amount.toString()} stroops (${(Number(amount) / 10000000).toFixed(7)} XLM)`);
@@ -295,6 +436,113 @@ monitorPayments().catch(error => {
 });
 ```
 
+```java
+// monitor_payment.java
+import org.stellar.sdk.SorobanServer;
+import org.stellar.sdk.Address;
+import org.stellar.sdk.scval.Scv;
+import org.stellar.sdk.xdr.*;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class MonitorPaymentsJavaExample {
+  public static void main(String[] args) throws Exception {
+    final String RPC_URL = "https://soroban-testnet.stellar.org";
+    SorobanServer rpc = new SorobanServer(RPC_URL);
+
+    // Load the account we monitor payments FROM (written by send_payment example)
+    String monitoredFromAccount = Files.readString(Paths.get("sender_public.key"), StandardCharsets.UTF_8).trim();
+
+    // Build topic filters using SDK helpers (base64 XDR via toXdrBase64())
+    String transferTopicFilter = Scv.toSymbol("transfer").toXdrBase64();
+    String fromTopicFilter = Scv.toAddress(monitoredFromAccount).toXdrBase64();
+
+    // Starting point: latest ledger
+    var latest = rpc.getLatestLedger();
+    Long startLedger = latest.getSequence();
+    String cursor = null;
+    System.out.printf("Starting payment monitoring from ledger %d and from account %s%n", startLedger, monitoredFromAccount);
+
+    while (true) {
+      // Build request: type "contract", topics [[transfer, from, "*", "*"]]
+      var filter = new org.stellar.sdk.responses.sorobanrpc.GetEventsRequest.Filter();
+      filter.setType("contract");
+      filter.setTopics(Collections.singletonList(Arrays.asList(transferTopicFilter, fromTopicFilter, "*", "*")));
+
+      var req = new org.stellar.sdk.responses.sorobanrpc.GetEventsRequest();
+      req.setStartLedger(startLedger);
+      req.setCursor(cursor);
+      req.setFilters(Collections.singletonList(filter));
+      req.setLimit(10);
+
+      var eventsResp = rpc.getEvents(req);
+      var events = eventsResp.getEvents();
+      System.out.println("Found " + events.size() + " payment(s):");
+
+      for (var ev : events) {
+        System.out.println("\n--- Payment Received ---");
+        System.out.println("Ledger: " + ev.getLedger());
+        System.out.println("Transaction Hash: " + ev.getTxHash());
+        System.out.println("Closed At: " + ev.getLedgerClosedAt());
+
+        List<ScVal> topics = ev.getTopic();
+        if (topics.size() < 3) {
+          System.out.println("Invalid event, not enough topics.");
+          continue;
+        }
+
+        try {
+          String fromAddr = Scv.fromAddress(topics.get(1)).toString();
+          String toAddr = Scv.fromAddress(topics.get(2)).toString();
+          System.out.println("Transfer: " + fromAddr + " → " + toAddr);
+        } catch (Exception e) {
+          System.out.println("From/To: Unable to decode addresses: " + e.getMessage());
+        }
+
+        try {
+          // value is an SCV_MAP with k:amount -> v:SCV_I128
+          ScVal v = ev.getValue();
+          String amountStr = null;
+          
+          var map = Scv.fromMap(v);
+          for (var e : map.entrySet()) {
+            String key = new String(Scv.fromString(e.getKey()));
+            if ("amount".equals(key)) {
+              SCVal amountVal = e.getValue();
+              amountStr = Scv.fromInt128(amountVal).toString();
+              break;
+            }
+          }
+          
+          if (amountStr != null) {
+            java.math.BigInteger stroops = new java.math.BigInteger(amountStr);
+            double xlm = stroops.doubleValue() / 10000000.0;
+            System.out.printf("Amount: %s stroops (%.7f XLM)%n", stroops.toString(), xlm);
+          }
+        } catch (Exception e) {
+          System.out.println("Failed to decode transfer amount: " + e.getMessage());
+        }
+
+        try {
+          System.out.println("Asset: " + topics.get(3).toString());
+        } catch (Exception ex) {
+          System.out.println("Asset: Unable to decode asset" + ex.getMessage();
+        }
+      }
+
+      // pagination: update cursor and clear startLedger for subsequent calls
+      cursor = eventsResp.getCursor();
+      startLedger = null;
+      Thread.sleep(5000L);
+    }
+  }
+}
+
+```
+
 </CodeExample>
 </Details>
 
@@ -305,8 +553,23 @@ monitorPayments().catch(error => {
 <CodeExample>
 
 ```bash
-// js
+# js
 node send_payment.js
+
+# java
+# JRE 17 or higher should be installed - https://adoptium.net/temurin/releases/?version=17&package=jdk
+# download Stellar Java SDK jar, latest release on maven central
+JAR_REPO='https://repo1.maven.org/maven2/network/lightsail/stellar-sdk'
+JAR_VERSION="$( \
+  curl -fsSL "$JAR_REPO/maven-metadata.xml" \
+  | awk -F'[<>]' '/<release>/{print $3; exit}' \
+)"
+echo "Latest Stellar SDK Version: $JAR_VERSION" 
+JAR_FILE="stellar-sdk-$JAR_VERSION-uber.jar" 
+curl -fsSL -o "$JAR_FILE" "$JAR_REPO/$JAR_VERSION/$JAR_FILE" 
+
+javac -cp "$JAR_FILE" SendPaymentJavaExample.java
+java -cp ".:$JAR_FILE" SendPaymentJavaExample
 ```
 
 </CodeExample>
@@ -317,8 +580,12 @@ node send_payment.js
 <CodeExample>
 
 ```bash
-// js
+# js
 node monitor_payments.js
+
+# java
+javac -cp "$JAR_FILE" MonitorPaymentsJavaExample.java
+java -cp ".:$JAR_FILE" MonitorPaymentsJavaExample
 ```
 
 </CodeExample>

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -176,19 +176,30 @@ sendPayments().catch((error) => {
 ```
 
 ```java
-// send_payment.java
+// SendPaymentExample.java
 // Java 17, Stellar Java SDK (lightsail-network/java-stellar-sdk)
 
-import org.stellar.sdk.*;
+import org.stellar.sdk.Account;
+import org.stellar.sdk.AssetTypeNative;
+import org.stellar.sdk.KeyPair;
+import org.stellar.sdk.MemoId;
+import org.stellar.sdk.Network;
+import org.stellar.sdk.SorobanServer;
 import org.stellar.sdk.Transaction;
+import org.stellar.sdk.TransactionBuilder;
 import org.stellar.sdk.operations.PaymentOperation;
 import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse;
 import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse.GetTransactionStatus;
 import org.stellar.sdk.responses.sorobanrpc.SendTransactionResponse.SendTransactionStatus;
-import org.stellar.sdk.xdr.*;
+import org.stellar.sdk.xdr.AccountEntry;
+import org.stellar.sdk.xdr.AccountID;
 import org.stellar.sdk.xdr.LedgerEntry.LedgerEntryData;
+import org.stellar.sdk.xdr.LedgerEntryType;
+import org.stellar.sdk.xdr.LedgerKey;
 import org.stellar.sdk.xdr.LedgerKey.LedgerKeyAccount;
+import org.stellar.sdk.xdr.PublicKey;
 import org.stellar.sdk.xdr.PublicKey.PublicKeyBuilder;
+import org.stellar.sdk.xdr.PublicKeyType;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -197,6 +208,9 @@ import okhttp3.Response;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 
 public class SendPaymentJavaExample {
@@ -207,12 +221,17 @@ public class SendPaymentJavaExample {
     // Generate sender/recipient and fund via Friendbot (testnet)
     // get the friendbot url from rpc info
     var info = rpc.getNetwork();
-    System.out.println("Friendbot URL: " + info.getFriendbotUrl()); 
+    System.out.println("Friendbot URL: " + info.getFriendbotUrl());
 
     KeyPair sender = KeyPair.random();
     KeyPair recipient = KeyPair.random();
     friendbotFund(sender.getAccountId(), info.getFriendbotUrl());
     friendbotFund(recipient.getAccountId(), info.getFriendbotUrl());
+    Files.writeString(Paths.get("sender_public.key"),
+        sender.getAccountId(),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE);
 
     // Load sender sequence using RPC getLedgerEntries
     long senderSeq = loadAccountSequenceViaRpc(rpc, sender.getAccountId());
@@ -223,10 +242,8 @@ public class SendPaymentJavaExample {
       // Build classic payment: 10 XLM, memo id, 180s timeout
       Transaction tx = new TransactionBuilder(source, Network.TESTNET)
           .setBaseFee(Transaction.MIN_BASE_FEE)
-          .addOperation(PaymentOperation.builder().
-              destination(recipient.getAccountId()).
-              asset(new AssetTypeNative()).
-              amount(new BigDecimal("10")).build())
+          .addOperation(PaymentOperation.builder().destination(recipient.getAccountId()).asset(new AssetTypeNative())
+              .amount(new BigDecimal("10")).build())
           .addMemo(new MemoId(1234567890L))
           .setTimeout(180)
           .build();
@@ -251,7 +268,7 @@ public class SendPaymentJavaExample {
   static void friendbotFund(String accountId, String friendbotUrl) throws Exception {
     OkHttpClient http = new OkHttpClient.Builder().build();
     String url = friendbotUrl + "?addr=" + URLEncoder.encode(accountId, StandardCharsets.UTF_8);
-    
+
     Request req = new Request.Builder().url(url).build();
     Response res = http.newCall(req).execute();
 
@@ -277,7 +294,7 @@ public class SendPaymentJavaExample {
     LedgerKey key = new LedgerKey();
     key.setDiscriminant(LedgerEntryType.ACCOUNT);
     key.setAccount(lka);
-   
+
     var gle = rpc.getLedgerEntries(List.of(key));
     if (gle.getEntries() == null || gle.getEntries().isEmpty()) {
       throw new RuntimeException("Account not found in ledger entries: " + accountId);
@@ -292,10 +309,9 @@ public class SendPaymentJavaExample {
     return acc.getSeqNum().getSequenceNumber().getInt64();
   }
 
-  // Helper: wrap SorobanServer.pollTransaction and enforce failure handling
   static GetTransactionResponse pollTransaction(SorobanServer rpc, String txHash) throws Exception {
     GetTransactionResponse resp = rpc.pollTransaction(txHash);
-   
+
     if (GetTransactionStatus.SUCCESS.equals(resp.getStatus())) {
       return resp;
     }
@@ -437,16 +453,25 @@ monitorPayments().catch(error => {
 ```
 
 ```java
-// monitor_payment.java
-import org.stellar.sdk.SorobanServer;
-import org.stellar.sdk.Address;
-import org.stellar.sdk.scval.Scv;
-import org.stellar.sdk.xdr.*;
+// MonitorPaymentExample.java
+// Java 17, Stellar Java SDK (lightsail-network/java-stellar-sdk)
 
+import org.stellar.sdk.SorobanServer;
+import org.stellar.sdk.responses.sorobanrpc.GetLatestLedgerResponse;
+
+import org.stellar.sdk.requests.sorobanrpc.EventFilterType;
+import org.stellar.sdk.requests.sorobanrpc.GetEventsRequest;
+import org.stellar.sdk.scval.Scv;
+import org.stellar.sdk.xdr.SCSymbol;
+import org.stellar.sdk.xdr.SCVal;
+
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class MonitorPaymentsJavaExample {
   public static void main(String[] args) throws Exception {
@@ -461,75 +486,72 @@ public class MonitorPaymentsJavaExample {
     String fromTopicFilter = Scv.toAddress(monitoredFromAccount).toXdrBase64();
 
     // Starting point: latest ledger
-    var latest = rpc.getLatestLedger();
-    Long startLedger = latest.getSequence();
+    GetLatestLedgerResponse latest = rpc.getLatestLedger();
+    Long startLedger = latest.getSequence().longValue();
     String cursor = null;
-    System.out.printf("Starting payment monitoring from ledger %d and from account %s%n", startLedger, monitoredFromAccount);
+    System.out.printf("Starting payment monitoring from ledger %d and from account %s%n", startLedger,
+        monitoredFromAccount);
 
     while (true) {
-      // Build request: type "contract", topics [[transfer, from, "*", "*"]]
-      var filter = new org.stellar.sdk.responses.sorobanrpc.GetEventsRequest.Filter();
-      filter.setType("contract");
-      filter.setTopics(Collections.singletonList(Arrays.asList(transferTopicFilter, fromTopicFilter, "*", "*")));
 
-      var req = new org.stellar.sdk.responses.sorobanrpc.GetEventsRequest();
-      req.setStartLedger(startLedger);
-      req.setCursor(cursor);
-      req.setFilters(Collections.singletonList(filter));
-      req.setLimit(10);
+      GetEventsRequest.EventFilter eventFilter = GetEventsRequest.EventFilter.builder()
+          .type(EventFilterType.CONTRACT)
+          .topic(Arrays.asList(transferTopicFilter, fromTopicFilter, "*", "*"))
+          .build();
 
-      var eventsResp = rpc.getEvents(req);
+      GetEventsRequest.PaginationOptions paginationOptions = GetEventsRequest.PaginationOptions.builder()
+          .limit(10L)
+          .cursor(cursor)
+          .build();
+
+      GetEventsRequest getEventsRequest = GetEventsRequest.builder()
+          .startLedger(startLedger)
+          .filter(eventFilter)
+          .pagination(paginationOptions)
+          .build();
+
+      var eventsResp = rpc.getEvents(getEventsRequest);
       var events = eventsResp.getEvents();
       System.out.println("Found " + events.size() + " payment(s):");
 
       for (var ev : events) {
         System.out.println("\n--- Payment Received ---");
         System.out.println("Ledger: " + ev.getLedger());
-        System.out.println("Transaction Hash: " + ev.getTxHash());
+        System.out.println("Transaction Hash: " + ev.getTransactionHash());
         System.out.println("Closed At: " + ev.getLedgerClosedAt());
 
-        List<ScVal> topics = ev.getTopic();
+        List<String> topics = ev.getTopic();
         if (topics.size() < 3) {
           System.out.println("Invalid event, not enough topics.");
           continue;
         }
 
         try {
-          String fromAddr = Scv.fromAddress(topics.get(1)).toString();
-          String toAddr = Scv.fromAddress(topics.get(2)).toString();
+          String fromAddr = Scv.fromAddress(SCVal.fromXdrBase64(topics.get(1))).toString();
+          String toAddr = Scv.fromAddress(SCVal.fromXdrBase64(topics.get(2))).toString();
           System.out.println("Transfer: " + fromAddr + " → " + toAddr);
         } catch (Exception e) {
           System.out.println("From/To: Unable to decode addresses: " + e.getMessage());
         }
 
         try {
-          // value is an SCV_MAP with k:amount -> v:SCV_I128
-          ScVal v = ev.getValue();
-          String amountStr = null;
-          
-          var map = Scv.fromMap(v);
-          for (var e : map.entrySet()) {
-            String key = new String(Scv.fromString(e.getKey()));
-            if ("amount".equals(key)) {
-              SCVal amountVal = e.getValue();
-              amountStr = Scv.fromInt128(amountVal).toString();
-              break;
-            }
-          }
-          
-          if (amountStr != null) {
-            java.math.BigInteger stroops = new java.math.BigInteger(amountStr);
-            double xlm = stroops.doubleValue() / 10000000.0;
-            System.out.printf("Amount: %s stroops (%.7f XLM)%n", stroops.toString(), xlm);
+          // the event value is a map with key of Symbol for 'amount' to i128 value
+          Map<SCVal, SCVal> map = Scv.fromMap(SCVal.fromXdrBase64(ev.getValue()));
+          SCVal amount = map.get(Scv.toSymbol("amount"));
+
+          if (amount != null) {
+            String amountStr = Scv.fromInt128(amount).toString();
+            BigDecimal raw = new BigDecimal(amountStr);
+            System.out.printf("Token Amount Transferred: (%.7f)%n", raw.scaleByPowerOfTen(-7));
           }
         } catch (Exception e) {
           System.out.println("Failed to decode transfer amount: " + e.getMessage());
         }
 
         try {
-          System.out.println("Asset: " + topics.get(3).toString());
+          System.out.println("Asset: " + new String(Scv.fromString(SCVal.fromXdrBase64(topics.get(3)))));
         } catch (Exception ex) {
-          System.out.println("Asset: Unable to decode asset" + ex.getMessage();
+          System.out.println("Asset: Unable to decode asset" + ex.getMessage());
         }
       }
 
@@ -540,7 +562,6 @@ public class MonitorPaymentsJavaExample {
     }
   }
 }
-
 ```
 
 </CodeExample>
@@ -560,16 +581,12 @@ node send_payment.js
 # JRE 17 or higher should be installed - https://adoptium.net/temurin/releases/?version=17&package=jdk
 # download Stellar Java SDK jar, latest release on maven central
 JAR_REPO='https://repo1.maven.org/maven2/network/lightsail/stellar-sdk'
-JAR_VERSION="$( \
-  curl -fsSL "$JAR_REPO/maven-metadata.xml" \
-  | awk -F'[<>]' '/<release>/{print $3; exit}' \
-)"
-echo "Latest Stellar SDK Version: $JAR_VERSION" 
+JAR_VERSION="2.0.0" # replace with latest version if needed
 JAR_FILE="stellar-sdk-$JAR_VERSION-uber.jar" 
 curl -fsSL -o "$JAR_FILE" "$JAR_REPO/$JAR_VERSION/$JAR_FILE" 
 
-javac -cp "$JAR_FILE" SendPaymentJavaExample.java
-java -cp ".:$JAR_FILE" SendPaymentJavaExample
+javac -cp "$JAR_FILE" SendPaymentExample.java
+java -cp ".:$JAR_FILE" SendPaymentExample
 ```
 
 </CodeExample>
@@ -584,8 +601,8 @@ java -cp ".:$JAR_FILE" SendPaymentJavaExample
 node monitor_payments.js
 
 # java
-javac -cp "$JAR_FILE" MonitorPaymentsJavaExample.java
-java -cp ".:$JAR_FILE" MonitorPaymentsJavaExample
+javac -cp "$JAR_FILE" MonitorPaymentExample.java
+java -cp ".:$JAR_FILE" MonitorPaymentExample
 ```
 
 </CodeExample>

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -323,10 +323,7 @@ async function monitorPayments() {
 
     // create our payment event topic filter values
     const transferTopicFilter = StellarSdk.xdr.ScVal.scvSymbol("transfer").toXDR('base64');
-    const fromTopicFilter = StellarSdk.nativeToScVal(
-        StellarSdk.Address.fromString(monitoredFromAccount),
-        { type: "address" }
-    ).toXDR('base64');
+    const fromTopicFilter = StellarSdk.nativeToScVal(monitoredFromAccount,{ type: "address" }).toXDR('base64');
 
     // Get starting ledger
     const latestLedger = await rpcServer.getLatestLedger();

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -45,18 +45,7 @@ Lets demonstrate a payment of an asset on Stellar. We will build a transaction w
 <CodeExample>
 ```js
 // send_payment.js
-
-/*
-Pre-requisites:
-1. [nvm](https://github.com/nvm-sh/nvm) utility installed to manage node version.
-2. setup local example project:
-  nvm install 20
-  nvm use 20
-  mkdir stellar-payments
-  cd stellar-payments
-  npm init -y
-  npm install --save @stellar/stellar-sdk 
-*/
+// follow the https://github.com/stellar/js-stellar-sdk?tab=readme-ov-file#installation
 
 import * as StellarSdk from '@stellar/stellar-sdk';
 import fs from 'fs';
@@ -263,7 +252,7 @@ public class SendPaymentJavaExample {
     Request req = new Request.Builder().url(url).build();
     Response res = http.newCall(req).execute();
 
-    if (res.code() / 100 != 2) {
+    if (res.code() != 200) {
       throw new RuntimeException("Friendbot funding failed: " + res.code() + " " + res.body().string());
     }
     System.out.println("Funded: " + accountId);
@@ -499,6 +488,7 @@ Demonstrate near real-time monitoring of transactions from the Stellar network b
 <CodeExample>
 ```js
 // monitor_payment.js
+// follow the https://github.com/stellar/js-stellar-sdk?tab=readme-ov-file#installation
 
 import * as StellarSdk from '@stellar/stellar-sdk';
 import fs from 'fs';
@@ -1103,12 +1093,12 @@ go build -o monitor monitor/monitor.go
 - Payments from transaction operations or contract invocations on Stellar network can be monitored by leveraging the unified events model as of [Protocol 23 (Whisk)](https://stellar.org/blog/developers/introducing-whisk-stellar-protocol-23) and the RPC `getEvents` method.
 
   - **Payments are 'transfer' events**: the [unified events model](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md) ensures whether a payment happened through an operation or contract invocation it will result in the same 'transfer' event being emitted.
-  - **Event Type**: `"contract"` denotes payments are an application level event rather than 'diagnostic' or 'system' event.
+  - **Event Type**: `"contract"` denotes payments are an application level event rather than 'system' event.
   - **Transfer Topics Model**: an array of four topics, specified in [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md) and summarized:
     - `topic[0]` = Event name 'transfer' determines the next 3 topics
     - `topic[1]` = Transfer Sender address
     - `topic[2]` = Transfer Recipient address
-    - `topic[3]` = Asset identifier
+    - `topic[3]` = Asset identifier (only present for Stellar Assets, through their built-in contracts (SAC))
 
 - RPC provides precise filtering of Stellar network events and this includes event topics model defined for unified events in [CAP-67](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md). You save time by using the RPC server-side filter capabilities to focus on processing only events relative to your application such as payments from a specific account in this example.
   - **Wildcards**: The RPC `getEvents` allows to use "\*" to match any value in a topic position

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -372,22 +372,15 @@ async function monitorPayments() {
 
             // Decode transfer amount from the event data
             try {
-
                 // Protocol 23+ unified events model per CAP-0067
                 // https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md
                 // Event value field is scMap with {amount: i128, to_muxed_id: u64|bytes|string} (when muxed info present)
-                let amount = "n/a";
-                for (const entry of event.value.map()) {
-                    if (StellarSdk.scValToNative(entry.key()) === "amount") {
-                        amount = StellarSdk.scValToBigInt(entry.val());
-                        break;
-                    }
-                }
+                const amount = StellarSdk.scValToNative(event.value)["amount"];
                 console.log(`Amount: ${amount.toString()} stroops (${(Number(amount) / 10000000).toFixed(7)} XLM)`);
             } catch (error) {
                 console.log(`Failed to decode transfer amount:`, error);
             }
-            // Decode asset from topics[3] (sep0011_asset string)
+            // Decode asset from topics[3], this is only present in events from SAC tokens
             if (event.topic.length > 3) {
                 const asset = StellarSdk.scValToNative(event.topic[3]);
                 console.log(`Asset: ${asset}`);
@@ -504,7 +497,10 @@ public class MonitorPaymentsJavaExample {
         }
 
         try {
-          System.out.println("Asset: " + new String(Scv.fromString(SCVal.fromXdrBase64(topics.get(3)))));
+          if (topics.size() > 3) {
+            // Decode asset from topics[3], this is only present in events from SAC tokens
+            System.out.println("Asset: " + new String(Scv.fromString(SCVal.fromXdrBase64(topics.get(3)))));
+          }
         } catch (Exception ex) {
           System.out.println("Asset: Unable to decode asset" + ex.getMessage());
         }

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -291,6 +291,207 @@ public class SendPaymentJavaExample {
 
 ```
 
+```go
+// sender.go
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/txnbuild"
+	sdk "github.com/stellar/stellar-rpc/client"
+	"github.com/stellar/stellar-rpc/protocol"
+)
+
+// friendbotFund funds an account using the Stellar testnet friendbot
+func friendbotFund(accountID, friendbotURL string) error {
+	// Construct the URL with account parameter
+	fullURL := friendbotURL + "?addr=" + url.QueryEscape(accountID)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	// Make HTTP GET request
+	resp, err := client.Get(fullURL)
+	if err != nil {
+		return fmt.Errorf("failed to make friendbot request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check if response is successful (2xx status code)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("friendbot funding failed: %d", resp.StatusCode)
+	}
+
+	fmt.Printf("Funded: %s\n", accountID)
+	return nil
+}
+
+// check panics if there's an error
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SignAndSend builds, signs, and submits a transaction with the given operations
+func SignAndSend(
+	ctx context.Context,
+	client *sdk.Client,
+	account txnbuild.Account,
+	signers []*keypair.Full,
+	operations ...txnbuild.Operation,
+) protocol.GetTransactionResponse {
+	// Build, sign, and submit the transaction
+	tx, err := txnbuild.NewTransaction(
+		txnbuild.TransactionParams{
+			SourceAccount:        account,
+			IncrementSequenceNum: true,
+			BaseFee:              txnbuild.MinBaseFee,
+			Preconditions: txnbuild.Preconditions{
+				TimeBounds: txnbuild.NewInfiniteTimeout(),
+			},
+			Operations: operations,
+		},
+	)
+	check(err)
+
+	for _, signer := range signers {
+		tx, err = tx.Sign(network.TestNetworkPassphrase, signer)
+		check(err)
+	}
+
+	txnB64, err := tx.Base64()
+	check(err)
+
+	txSendResp, err := client.SendTransaction(ctx,
+		protocol.SendTransactionRequest{Transaction: txnB64})
+	check(err)
+
+	for i := range 5 {
+		txResp, err := client.GetTransaction(ctx,
+			protocol.GetTransactionRequest{Hash: txSendResp.Hash})
+		check(err)
+
+		switch txResp.Status {
+		case "NOT_FOUND":
+		case "SUCCESS":
+			return txResp
+		case "FAILED":
+			panic(fmt.Errorf("transaction failed: %s",
+				strings.Join(txResp.DiagnosticEventsXDR, "\n")))
+		}
+
+		// Increase delay for each polling request
+		time.Sleep(time.Duration(i) * time.Second)
+	}
+
+	panic(fmt.Errorf("transaction never found: %s", txSendResp.Hash))
+}
+
+// sendPayment creates and submits a payment transaction using the helper function
+func sendPayment(ctx context.Context, rpcClient *sdk.Client, sourceAccount txnbuild.Account, signerKP *keypair.Full, destinationAddr string) error {
+	// Create payment operation
+	paymentOp := txnbuild.Payment{
+		Destination: destinationAddr,
+		Amount:      "10",
+		Asset:       txnbuild.NativeAsset{},
+	}
+
+	// Use the helper function to build, sign, and submit
+	fmt.Printf("Submitting payment of 10 XLM to %s...\n", destinationAddr)
+
+	txResp := SignAndSend(ctx, rpcClient, sourceAccount, []*keypair.Full{signerKP}, &paymentOp)
+
+	fmt.Printf("Success! Committed on ledger: %d\n", txResp.Ledger)
+	return nil
+}
+
+func main() {
+	const RPC_URL = "https://soroban-testnet.stellar.org"
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	rpcClient := sdk.NewClient(RPC_URL, httpClient)
+
+	// Get network info to obtain friendbot URL
+	ctx := context.Background()
+	networkInfo, err := rpcClient.GetNetwork(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get network info: %v", err))
+	}
+
+	fmt.Printf("Friendbot URL: %s\n", networkInfo.FriendbotURL)
+
+	// Generate sender and recipient keypairs
+	sender, err := keypair.Random()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to generate sender keypair: %v", err))
+	}
+
+	recipient, err := keypair.Random()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to generate recipient keypair: %v", err))
+	}
+
+	// Fund accounts via friendbot
+	err = friendbotFund(sender.Address(), networkInfo.FriendbotURL)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to fund sender: %v", err))
+	}
+
+	err = friendbotFund(recipient.Address(), networkInfo.FriendbotURL)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to fund recipient: %v", err))
+	}
+
+	// Save sender public key to file
+	err = os.WriteFile("sender_public.key", []byte(sender.Address()), 0644)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to write sender public key: %v", err))
+	}
+
+	// Load sender account info
+	senderAccount, err := rpcClient.LoadAccount(ctx, sender.Address())
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get sender account: %v", err))
+	}
+
+	// Payment loop - send payment every 30 seconds
+	for {
+		err := sendPayment(ctx, rpcClient, senderAccount, sender, recipient.Address())
+		if err != nil {
+			panic(fmt.Sprintf("Payment failed: %v", err))
+		}
+
+		fmt.Println("Waiting 30 seconds before next payment...")
+		time.Sleep(30 * time.Second)
+
+		// Reload account to get updated sequence number
+		senderAccount, err = rpcClient.LoadAccount(ctx, sender.Address())
+		if err != nil {
+			panic(fmt.Sprintf("Failed to reload sender account: %v", err))
+		}
+	}
+}
+```
+
 </CodeExample>
 </Details>
 
@@ -515,6 +716,344 @@ public class MonitorPaymentsJavaExample {
 }
 ```
 
+```go
+// monitor.go
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stellar/go/strkey"
+	"github.com/stellar/go/xdr"
+	sdk "github.com/stellar/stellar-rpc/client"
+	"github.com/stellar/stellar-rpc/protocol"
+)
+
+func main() {
+	const RPC_URL = "https://soroban-testnet.stellar.org"
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	rpcClient := sdk.NewClient(RPC_URL, httpClient)
+	ctx := context.Background()
+
+	// Load the account we monitor payments FROM (written by send_payment example)
+	senderKeyBytes, err := os.ReadFile("sender_public.key")
+	if err != nil {
+		panic(fmt.Sprintf("Failed to read sender_public.key: %v", err))
+	}
+	monitoredFromAccount := strings.TrimSpace(string(senderKeyBytes))
+
+	fmt.Printf("Starting payment monitoring from account: %s\n", monitoredFromAccount)
+
+	// Get latest ledger as starting point
+	latestLedger, err := rpcClient.GetLatestLedger(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get latest ledger: %v", err))
+	}
+
+	startLedger := latestLedger.Sequence
+	var cursor string
+
+	fmt.Printf("Starting payment monitoring from ledger %d\n", startLedger)
+
+	for {
+		err := monitorPayments(ctx, rpcClient, monitoredFromAccount, &startLedger, &cursor)
+		if err != nil {
+			fmt.Printf("Error monitoring payments: %v\n", err)
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func monitorPayments(ctx context.Context, client *sdk.Client, fromAccount string, startLedger *uint32, cursor *string) error {
+	// Create a simple event filter for contract events
+	eventFilter := protocol.EventFilter{
+		EventType: protocol.EventTypeSet{protocol.EventTypeContract: nil},
+		// We'll filter by topics in the processing logic instead
+	}
+
+	// Create request
+	request := protocol.GetEventsRequest{
+		Filters: []protocol.EventFilter{eventFilter},
+	}
+
+	// Set startLedger only on first call
+	if *startLedger != 0 {
+		request.StartLedger = *startLedger
+	}
+
+	// Set cursor for pagination
+	if *cursor != "" {
+		parsedCursor, err := protocol.ParseCursor(*cursor)
+		if err != nil {
+			return fmt.Errorf("failed to parse cursor: %v", err)
+		}
+		request.Pagination = &protocol.PaginationOptions{
+			Cursor: &parsedCursor,
+			Limit:  10,
+		}
+	} else {
+		request.Pagination = &protocol.PaginationOptions{
+			Limit: 10,
+		}
+	}
+
+	// Get events
+	eventsResp, err := client.GetEvents(ctx, request)
+	if err != nil {
+		return fmt.Errorf("failed to get events: %v", err)
+	}
+
+	// Filter events that match our criteria
+	relevantEvents := []protocol.EventInfo{}
+	for _, event := range eventsResp.Events {
+		if isPaymentEvent(event, fromAccount) {
+			relevantEvents = append(relevantEvents, event)
+		}
+	}
+
+	fmt.Printf("Found %d payment(s):\n", len(relevantEvents))
+
+	// Process relevant events
+	for _, event := range relevantEvents {
+		err := processPaymentEvent(event)
+		if err != nil {
+			fmt.Printf("Error processing event: %v\n", err)
+			continue
+		}
+	}
+
+	// Update pagination
+	*cursor = eventsResp.Cursor
+	*startLedger = 0 // Clear start ledger for subsequent calls
+
+	return nil
+}
+
+func isPaymentEvent(event protocol.EventInfo, fromAccount string) bool {
+	// Check if this is a transfer event by looking at the first topic
+	if len(event.TopicXDR) < 2 {
+		return false
+	}
+
+	// Try to decode the first topic to see if it's "transfer"
+	if isTransferTopic(event.TopicXDR[0]) && isFromAccount(event.TopicXDR[1], fromAccount) {
+		return true
+	}
+
+	return false
+}
+
+func isTransferTopic(topicXDR string) bool {
+	xdrBytes, err := base64.StdEncoding.DecodeString(topicXDR)
+	if err != nil {
+		return false
+	}
+
+	var scVal xdr.ScVal
+	err = scVal.UnmarshalBinary(xdrBytes)
+	if err != nil {
+		return false
+	}
+
+	return scVal.Type == xdr.ScValTypeScvSymbol &&
+		scVal.Sym != nil &&
+		string(*scVal.Sym) == "transfer"
+}
+
+func isFromAccount(topicXDR, expectedAccount string) bool {
+	decodedAddr, err := decodeAddressFromXDR(topicXDR)
+	return err == nil && decodedAddr == expectedAccount
+}
+
+func createTransferTopicFilter() (string, error) {
+	// Create "transfer" symbol and encode to base64 XDR
+	symbol := xdr.ScSymbol("transfer")
+	scVal := xdr.ScVal{
+		Type: xdr.ScValTypeScvSymbol,
+		Sym:  &symbol,
+	}
+
+	// Use XDR marshaling to base64
+	xdrBytes, err := scVal.MarshalBinary()
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(xdrBytes), nil
+}
+
+func createAddressTopicFilter(accountID string) (string, error) {
+	// Convert address string to AccountId
+	accountKey, err := xdr.AddressToAccountId(accountID)
+	if err != nil {
+		return "", err
+	}
+
+	// Create SCAddress for account
+	scAddr := xdr.ScAddress{
+		Type:      xdr.ScAddressTypeScAddressTypeAccount,
+		AccountId: &accountKey,
+	}
+
+	scVal := xdr.ScVal{
+		Type:    xdr.ScValTypeScvAddress,
+		Address: &scAddr,
+	}
+
+	// Use XDR marshaling to base64
+	xdrBytes, err := scVal.MarshalBinary()
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(xdrBytes), nil
+}
+
+func processPaymentEvent(event protocol.EventInfo) error {
+	fmt.Println("\n--- Payment Received ---")
+	fmt.Printf("Ledger: %d\n", event.Ledger)
+	fmt.Printf("Transaction Hash: %s\n", event.TransactionHash)
+	fmt.Printf("Closed At: %s\n", event.LedgerClosedAt)
+
+	// Parse topics
+	if len(event.TopicXDR) < 3 {
+		fmt.Println("Invalid event, not enough topics.")
+		return nil
+	}
+
+	// Decode from and to addresses
+	fromAddr, err := decodeAddressFromXDR(event.TopicXDR[1])
+	if err != nil {
+		fmt.Printf("From/To: Unable to decode from address: %v\n", err)
+	} else {
+		toAddr, err := decodeAddressFromXDR(event.TopicXDR[2])
+		if err != nil {
+			fmt.Printf("From/To: Unable to decode to address: %v\n", err)
+		} else {
+			fmt.Printf("Transfer: %s → %s\n", fromAddr, toAddr)
+		}
+	}
+
+	// Decode amount from event value
+	if event.ValueXDR != "" {
+		amount, err := decodeAmountFromXDR(event.ValueXDR)
+		if err != nil {
+			fmt.Printf("Failed to decode transfer amount: %v\n", err)
+		} else {
+			fmt.Printf("Token Amount Transferred: %.7f\n", float64(amount)/10000000) // Scale by 10^7
+		}
+	}
+
+	// Decode asset if available
+	if len(event.TopicXDR) > 3 {
+		asset, err := decodeAssetFromXDR(event.TopicXDR[3])
+		if err != nil {
+			fmt.Printf("Asset: Unable to decode asset: %v\n", err)
+		} else {
+			fmt.Printf("Asset: %s\n", asset)
+		}
+	}
+
+	return nil
+}
+
+func decodeAddressFromXDR(base64XDR string) (string, error) {
+	xdrBytes, err := base64.StdEncoding.DecodeString(base64XDR)
+	if err != nil {
+		return "", err
+	}
+
+	var scVal xdr.ScVal
+	err = scVal.UnmarshalBinary(xdrBytes)
+	if err != nil {
+		return "", err
+	}
+
+	if scVal.Type != xdr.ScValTypeScvAddress || scVal.Address == nil {
+		return "", fmt.Errorf("not an address type")
+	}
+
+	switch scVal.Address.Type {
+	case xdr.ScAddressTypeScAddressTypeAccount:
+		if scVal.Address.AccountId == nil {
+			return "", fmt.Errorf("account ID is nil")
+		}
+		return scVal.Address.AccountId.Address(), nil
+	case xdr.ScAddressTypeScAddressTypeContract:
+		if scVal.Address.ContractId == nil {
+			return "", fmt.Errorf("contract ID is nil")
+		}
+		return strkey.MustEncode(strkey.VersionByteContract, scVal.Address.ContractId[:]), nil
+	default:
+		return "", fmt.Errorf("unknown address type")
+	}
+}
+
+func decodeAmountFromXDR(base64XDR string) (int64, error) {
+	xdrBytes, err := base64.StdEncoding.DecodeString(base64XDR)
+	if err != nil {
+		return 0, err
+	}
+
+	var scVal xdr.ScVal
+	err = scVal.UnmarshalBinary(xdrBytes)
+	if err != nil {
+		return 0, err
+	}
+
+	// The value should be a map containing an "amount" key
+	if scVal.Type != xdr.ScValTypeScvMap || scVal.Map == nil {
+		return 0, fmt.Errorf("value is not a map")
+	}
+
+	// Look for the "amount" key in the map
+	for _, pair := range **scVal.Map {
+		if pair.Key.Type == xdr.ScValTypeScvSymbol && pair.Key.Sym != nil && string(*pair.Key.Sym) == "amount" {
+			// Found the amount key, extract the value
+			if pair.Val.Type == xdr.ScValTypeScvI128 && pair.Val.I128 != nil {
+				// Convert I128 to int64 (simplified - just use the low part for now)
+				return int64(pair.Val.I128.Lo), nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("amount not found in map")
+}
+
+func decodeAssetFromXDR(base64XDR string) (string, error) {
+	xdrBytes, err := base64.StdEncoding.DecodeString(base64XDR)
+	if err != nil {
+		return "", err
+	}
+
+	var scVal xdr.ScVal
+	err = scVal.UnmarshalBinary(xdrBytes)
+	if err != nil {
+		return "", err
+	}
+
+	if scVal.Type == xdr.ScValTypeScvString && scVal.Str != nil {
+		return string(*scVal.Str), nil
+	}
+
+	return "", fmt.Errorf("not a string type")
+}
+```
+
 </CodeExample>
 </Details>
 
@@ -538,6 +1077,16 @@ curl -fsSL -o "$JAR_FILE" "$JAR_REPO/$JAR_VERSION/$JAR_FILE"
 
 javac -cp "$JAR_FILE" SendPaymentExample.java
 java -cp ".:$JAR_FILE" SendPaymentExample
+
+# go
+mkdir -p payments_example/sender
+cd payments_example
+go mod init payments_example
+go get github.com/stellar/go@latest
+go get github.com/stellar/stellar-rpc@latest 
+# save sender.go code to sender/sender.go file
+go build -o sender sender/sender.go
+./sender
 ```
 
 </CodeExample>
@@ -554,6 +1103,12 @@ node monitor_payments.js
 # java
 javac -cp "$JAR_FILE" MonitorPaymentExample.java
 java -cp ".:$JAR_FILE" MonitorPaymentExample
+
+# go
+mkdir -p payments_example/monitor
+# save monitor.go code to monitor/monitor.go file
+go build -o monitor monitor/monitor.go
+./monitor
 ```
 
 </CodeExample>

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -10,16 +10,16 @@ import Details from "@theme/Details";
 
 ## Payments Overview
 
-A payment constitutes the transfer of a token from one account to another. On Stellar network a token can be either a Stellar asset or a contract token.
+A payment constitutes the transfer of a token from one account to another. On Stellar network a token can be either a Stellar asset or a custom contract token which follows the [SEP-41 token standard](/docs/tokens/stellar-asset-contract#overview).
 
 There are two primary ways payments are transacted on Stellar:
 - Using Stellar's payment-related [operations](/docs/learn/fundamentals/transactions/list-of-operations) 
 - [Invoking a function](/docs/learn/fundamentals/contract-development/contract-interactions/overview) on a token contract.
 
 The approach you should take depends on the use case:
-  - If you want to make a payment of a Stellar asset between two Stellar accounts, use the payment operations. Transaction fees are cheaper when using them compared to the fees for invoking the token contract for the asset directly which is referred to as the [Stellar Asset Contract](/docs/tokens/stellar-asset-contract#overview).
+  - If you want to make a payment of a Stellar asset between two Stellar accounts, use the payment operations. Transaction fees are cheaper when using them compared to the fees for invoking the asset's token contract directly which is referred to as the [Stellar Asset Contract](/docs/tokens/stellar-asset-contract#overview).
   - If you want to make a payment of a Stellar asset between a Stellar account and a contract address, or between two contract addresses, then the asset's contract must be used. Stellar's payment-related operations cannot have contract addresses as their source or destination.
-  - If you want to make a payment of a contract token (not a Stellar asset), you must use the token's contract. Stellar's payment operations can only be used to transfer Stellar assets.
+  - If you want to make a payment of a custom contract token which is not a Stellar asset but follows the [SEP-41 token standard](/docs/tokens/stellar-asset-contract#overview), you must use the token's contract. Stellar's payment operations can only be used to transfer Stellar assets.
 
 To learn more about the differences between Stellar assets and contract tokens, see the [Tokens](../../../../docs/tokens) overview.
 
@@ -343,8 +343,7 @@ async function monitorPayments() {
                         [
                             transferTopicFilter,
                             fromTopicFilter,
-                            "*", // to (any address)
-                            "*" // asset (any asset)
+                            "**", // filter will match on any 'to' address and any token(SAC or SEP-41)
                         ]
                     ]
                 }
@@ -451,17 +450,15 @@ public class MonitorPaymentsJavaExample {
         monitoredFromAccount);
 
     while (true) {
-
+      // filter will match on any 'to' address and any token(SAC or SEP-41)
       GetEventsRequest.EventFilter eventFilter = GetEventsRequest.EventFilter.builder()
           .type(EventFilterType.CONTRACT)
-          .topic(Arrays.asList(transferTopicFilter, fromTopicFilter, "*", "*"))
+          .topic(Arrays.asList(transferTopicFilter, fromTopicFilter, "**"))
           .build();
-
       GetEventsRequest.PaginationOptions paginationOptions = GetEventsRequest.PaginationOptions.builder()
           .limit(10L)
           .cursor(cursor)
           .build();
-
       GetEventsRequest getEventsRequest = GetEventsRequest.builder()
           .startLedger(startLedger)
           .filter(eventFilter)


### PR DESCRIPTION
Rewrite the the payments guide with clear, single tracked example of both sending paymebns and monitoring payment activity.

the guide goes into latest concepts to accomplish payments processing:
-  using rpc getEvents
-  using unified events model, p23
- removing all references to horizon

this is the pr preview link specifically to the [send and receive guide](https://developers-pr1788.previews.kube001.services.stellar-ops.com/docs/build/guides/transactions/send-and-receive-payments).

I've tested all example code locally to verify. 

The original guide expressed examples in four languages: js, java, go, python. This currently has just js, I will backfill the other 3 languages into examples. Wanted to get the overall guide up for review now as the other language snippets don't impact the main article.

Closes #1748 

