### PR TITLE
Add Galexie providers

### DIFF
--- a/docs/data/indexers/build-your-own/galexie/providers/providers.mdx
+++ b/docs/data/indexers/build-your-own/galexie/providers/providers.mdx
@@ -1,0 +1,19 @@
+---
+sidebar_position: 1000
+title: Galexie Providers
+---
+
+Multiple infrastructure providers have made the Galexie service and data lake available, and offer plans ranging from free to paid access. These providers can be used for development, testing, and production.
+
+These providers allow access to the Futurenet, Testnet and Mainnet network.
+
+| Provider | Futurenet | Testnet | Mainnet | URI |
+| --- | --- | --- | --- | --- |
+| AWS Public Blockchain\* | ❌ | ❌ | ✅ | s3://aws-public-blockchain/v1.1/stellar/ledgers/ |
+| [Lightsail Network - Quasar](https://quasar.lightsail.network/) | ❌ | ❌ | ✅ | galexie.lightsail.network/v1/ |
+
+\*AWS Public Blockchain populated by Goldsky
+
+## Run Your Own Galexie
+
+If you are interested in running your own Galexie service and data lake, please checkout the [Admin Guide](../admin_guide/README.mdx).

--- a/routes.txt
+++ b/routes.txt
@@ -460,6 +460,7 @@
 /docs/data/indexers/build-your-own/galexie/admin_guide/setup
 /docs/data/indexers/build-your-own/galexie/examples
 /docs/data/indexers/build-your-own/galexie/examples/gcs-export
+/docs/data/indexers/build-your-own/galexie/providers
 /docs/data/indexers/build-your-own/ingest-sdk
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide
 /docs/data/indexers/build-your-own/ingest-sdk/developer_guide/architecture


### PR DESCRIPTION
Added overcat (lightsail) and goldsky (aws public blockchain)


* Add Obsrvr's when it is available
* Goldsky will create a testnet (and potentially futurenet?) data lake in the future