### PR TITLE
fix history ledgers displaying its table incorrectly

### DIFF
--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/bronze/history-ledgers.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/bronze/history-ledgers.mdx
@@ -17,7 +17,7 @@ description: ""
 
 ## Column Details
 
-| Name | Description | Data Type | Domain Values | Required? | Notes |
+| Name | Description | Data Type | Domain Values | Required? | Notes |  |
 | --- | --- | --- | --- | --- | --- | --- |
 | sequence | The sequence number that corresponds to the individual ledgers. As ledgers are written to the network, the sequence is incremented by 1 | integer |  | Yes |  |
 | ledger_hash | The hex-encoded SHA-256 hash that represents the ledger's XDR-encoded form | string |  | Yes |  |


### PR DESCRIPTION
**before:**

<img width="1196" height="792" alt="before" src="https://github.com/user-attachments/assets/7f79e340-39f3-426c-bb70-1b684fb9b25e" />

**after:**

<img width="1192" height="792" alt="after" src="https://github.com/user-attachments/assets/74992c61-8d33-4d4b-8578-4552e93ca12a" />
