### PR TITLE
add a catch-all `/docs/learn/networks` redirect

### DIFF
--- a/nginx/includes/redirects.conf
+++ b/nginx/includes/redirects.conf
@@ -104,6 +104,7 @@ rewrite ^/docs/category/hosted-deposits-and-withdrawals$ "/platforms/anchor-plat
 rewrite ^/docs/category/build-a-wallet$ "/docs/category/build-a-wallet-with-the-wallet-sdk" permanent;
 rewrite ^/dapps "/docs/learn/interactive" permanent;
 rewrite ^/docs/learn/interactive/dapps "/docs/learn/interactive" permanent;
+rewrite ^/docs/learn/networks(.*)$ "/docs/learn/fundamentals/networks$1" permanent;
 
 # Categorized Encyclopedia redirects
 rewrite ^/docs/learn/smart-contract-internals/authorization(.*)$ "/docs/learn/fundamentals/contract-development/authorization$1" permanent;


### PR DESCRIPTION
The 404 coming from the JS SDK will be redirected. I'll still need to test if the `#friendbot` remains at the end of the URL after the redirect has taken place.

Refs: #1729