### PR TITLE
add frozen lockfile flag to yarn install commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
       ]
     }
   },
-  "postCreateCommand": "yarn install",
+  "postCreateCommand": "yarn install --frozen-lockfile",
   "waitFor": "postCreateCommand",
   "postStartCommand": "chmod +x ./.devcontainer/post_attach_start.sh",
   "postAttachCommand": "./.devcontainer/post_attach_start.sh && tail -f docs.log"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install App Dependencies
-        run: yarn --prefer-offline
+        run: yarn --prefer-offline --frozen-lockfile
         shell: bash
 
       - name: Copy Files From Stellar CLI

--- a/.github/workflows/crowdin-download-workflow.yml
+++ b/.github/workflows/crowdin-download-workflow.yml
@@ -75,7 +75,7 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Fix permissions for i18n directory
         run: |

--- a/.github/workflows/crowdin-upload-workflow.yml
+++ b/.github/workflows/crowdin-upload-workflow.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
 
       - name: Install Dependencies
-        run: yarn --prefer-offline
+        run: yarn --prefer-offline --frozen-lockfile
 
       - name: Generate CLI Docs
         run: yarn stellar-cli:build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install App Dependencies
-        run: yarn --prefer-offline
+        run: yarn --prefer-offline --frozen-lockfile
 
       - name: Check MDX
         run:  git update-index -g && yarn ci:mdx

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . /app/
 ARG BUILD_TRANSLATIONS="False"
 
 RUN yarn cache clean --all
-RUN yarn install
+RUN yarn install --frozen-lockfile
 RUN du -sh /app/*
 RUN yarn rpcspec:build --no-minify
 RUN yarn stellar-cli:build --no-minify --cli-ref=main


### PR DESCRIPTION
As part of a protection against the shai-hulud worm we want to restrict instances of yarn install to respect the yarn.lock file.