### PR TITLE
ℹ How can we best display a clear menu?

### DIFF
--- a/docs/learn/fundamentals/lumens.mdx
+++ b/docs/learn/fundamentals/lumens.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Understanding Lumens, The Native Currency of the Network"
-sidebar_label: Lumens (XLM)
+sidebar_label: Lumens
 description: "Learn about lumens (XLM), the native digital asset of the Stellar network. Understand its role in transactions, network fees, and smart contract rent."
 sidebar_position: 30
 ---

--- a/docs/learn/fundamentals/stellar-ecosystem-proposals.mdx
+++ b/docs/learn/fundamentals/stellar-ecosystem-proposals.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Stellar Ecosystem Proposals (SEPs): Standards for Interoperability & Development"
-sidebar_label: Stellar Ecosystem Proposals (SEPs)
+sidebar_label: Stellar Ecosystem Proposals
 description: "Learn about Stellar Ecosystem Proposals (SEPs), standards that enhance interoperability, improve functionality, and expand the network's capabilities."
 sidebar_position: 80
 ---


### PR DESCRIPTION
I love the new menu design, with intuitive subsections on hover. I've noticed a lot of link changes lately without huge discussion forums, so I wanted to propose something small in this PR. In thinking through the SDEX page now that it has its own Fundamental page, 🙌 I've been playing with headers.

While it makes a ton of sense to have acronyms like SEP in page headers or descriptions for SEO, I'm not so convinced it's the best for page navigation. We already have pretty limited sidebar space, and adding an acronym to navigation looks clunky to me. This change proposes removing abbreviations.

I think this makes things a lot cleaner, while maintaining clarity.[^1] We're mature enough as a project that readers understand what "Stellar Lumens" are without a reference to the arbitrary-ish (second) ticker. And this paves the way for a complementary CAPs page without again tons of jargon sides.

[^1]: For both pages modified, there is an almost-immediate definition of the acronym within the first sentence(s) of the doc. I thought through [doing this](https://github.com/stellar/stellar-docs/pull/723/commits/70a22811433c9d36467614e5af116cadf10448b2) for SCP's page yesterday, and it turned a four-line heading into a manageable two descriptive items. This starts with an older base I've been updating, compared to the existing SCP page which does not include an abbreviation in sidebar or title.
