### PR TITLE
remove old wasm target, correct some WebAssmebly spelling/styling

### DIFF
--- a/docs/build/guides/basics/automate-reset-data.mdx
+++ b/docs/build/guides/basics/automate-reset-data.mdx
@@ -356,7 +356,7 @@ Creates a liquidity pool asset, Sets up a trust line for the pool and Deposits i
 
 4. `deployAndInvokeContract(deployer, contractWasmFilePath)`:
 
-Uploads the contract's webAssembly (wasm) code, creates and deploys the contract on the network, invokes the contract function and returns the contract ID and function return values
+Uploads the contract's WebAssembly (Wasm) code, creates and deploys the contract on the network, invokes the contract function and returns the contract ID and function return values
 
 5. `automateSetup()`:
 

--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -27,7 +27,6 @@ To build and develop contracts you need the following prerequisites:
 ## Install Rust
 
 <Tabs groupId="platform" defaultValue={getPlatform()}>
-
 <TabItem value="unix" label="macOS/Linux">
 
 If you use macOS, Linux, or another Unix-like OS, the simplest method to install a Rust toolchain is to install `rustup`. Install `rustup` with the following command.
@@ -39,7 +38,6 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Then restart the terminal.
 
 </TabItem>
-
 <TabItem value="windows" label="Windows">
 
 On Windows, download and run [rustup-init.exe](https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe). You can continue with the default settings by pressing Enter.
@@ -53,32 +51,22 @@ The Stellar CLI uses emojis in its output. To properly render them on Windows, i
 If you're already using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), you can also follow the instructions for Linux.
 
 </TabItem>
-
 <TabItem value="other" label="Other">
 
 For other methods of installing [Rust], see: https://www.rust-lang.org/tools/install
 
 </TabItem>
-
 </Tabs>
 
 ## Install the target
 
-You'll need a "target" for which your smart contract will be compiled. _Which target_ you need will depend on the version of Rust you're using.
-
-For Rust `v1.85.0` or higher, install the `wasm32v1-none` target.
+You'll need a "target" for which your smart contract will be compiled. For Rust `v1.84.0` or higher, install the `wasm32v1-none` target.
 
 ```sh
 rustup target add wasm32v1-none
 ```
 
-For older versions of Rust, install the `wasm32-unknown-unknown` target.
-
-```sh
-rustup target add wasm32-unknown-unknown
-```
-
-You can learn more about the finer points of what these targets do or don't bring to the table, in our page all about the [Stellar Rust dialect](../../../learn/fundamentals/contract-development/rust-dialect.mdx#limited-webassembly-features). This page describes the subset of Rust functionality that is available to you within Stellar smart contract environment.
+You can learn more about the finer points of what this target brings to the table, in our page all about the [Stellar Rust dialect](../../../learn/fundamentals/contract-development/rust-dialect.mdx#limited-webassembly-features). This page describes the subset of Rust functionality that is available to you within Stellar smart contract environment.
 
 ## Configure an editor
 
@@ -105,7 +93,6 @@ The latest stable release is [v{latestVersion}](https://github.com/stellar/stell
 There are a few ways to install the [latest release](https://github.com/stellar/stellar-cli/releases) of Stellar CLI.
 
 <Tabs groupId="platform" defaultValue={getPlatform()}>
-
 <TabItem value="unix" label="macOS">
 
 Install with Homebrew (macOS, Linux):
@@ -119,7 +106,6 @@ Install with cargo from source:
 <StellarCliVersion />
 
 </TabItem>
-
 <TabItem value="linux" label="Linux">
 
 Install with Homebrew (macOS, Linux):
@@ -143,7 +129,6 @@ sudo apt update && sudo apt install -y build-essential
 :::
 
 </TabItem>
-
 <TabItem value="windows" label="Windows">
 
 Using the installer:
@@ -161,7 +146,6 @@ Install with cargo from source:
 <StellarCliVersion />
 
 </TabItem>
-
 </Tabs>
 
 :::info

--- a/docs/learn/fundamentals/contract-development/rust-dialect.mdx
+++ b/docs/learn/fundamentals/contract-development/rust-dialect.mdx
@@ -68,23 +68,17 @@ These container types `Vec` and `Map` should _not_ be used for managing large or
 
 :::
 
-## Limited Webassembly features
+## Limited WebAssembly features
 
-The Webassembly specification has grown significantly since its initial introduction and now supports many _features_ that may or may not be available on a given implementation of Webassembly.
+The WebAssembly specification has grown significantly since its initial introduction and now supports many _features_ that may or may not be available on a given implementation of WebAssembly.
 
-Soroban intentionally limits which Webassembly features it supports, to minimize the security-critical surface area and retain flexibility in choice of Webassembly implementations.
+Soroban intentionally limits which WebAssembly features it supports, to minimize the security-critical surface area and retain flexibility in choice of WebAssembly implementations. As of Rust 1.84, a new target `wasm32v1-none` was added to Rust that intentionally restricts itself to the "WebAssembly 1.0" subset of features, all of which Soroban supports.
 
-The Rust compiler's `wasm32-unknown-unknown` target used to Webassembly that used only a small subset of features, up until Rust 1.81. As of Rust 1.82 the `wasm32-unknown-unknown` target added more features, which meant that Rust 1.82 produced code that might be rejected by Soroban due to accidental use of newer Webassembly features.
-
-As of Rust 1.84, a new target `wasm32v1-none` was added to Rust that intentionally restricts itself to the "Webassembly 1.0" subset of features, all of which Soroban supports.
-
-As a consequence, new Soroban contracts should be built with Rust 1.84 or later, and use the `wasm32v1-none` target, not `wasm32-unknown-unknown`. If the contract needs earlier versions of Rust, or wants to keep using `wasm32-unknown-unknown`, it should restrict itself to Rust 1.81 or earlier.
-
-The stellar CLI automatically detects the Rust version and selects the appropriate target when building contracts for Webassembly.
+New Soroban contracts should be built with Rust `v1.84.0` or later, and use the `wasm32v1-none` target.
 
 :::note
 
-The `wasm32v1-none` target does not, by default, ship with a version of the `std` library at all. This is because the version of `std` that ships with `wasm32-unknown-unknown` is _mostly_ considered a mistake by its designers: for example most of the IO facilities in that version of `std` are stubs that either do nothing or panic when called. When adding the `wasm32v1-none` target, it was decided that these sorts of stubs were not of any benefit to users.
+The `wasm32v1-none` target does not, by default, ship with a version of the `std` library at all. When adding the `wasm32v1-none` target, it was decided that these sorts of stubs were not of any benefit to users.
 
 The `wasm32v1-none` target _does_ include a copy of the `alloc` crate, which contains most of the _containers_ (such as vectors and maps) that are re-exported by `std`. For example, rather than using `std::vec::Vec` one can use `alloc::vec::Vec`, which is the same code under a different name. But as mentioned above in the section on dynamic memory allocation, generally Soroban contracts should avoid `alloc` as well: a crate like `heapless` will usually perform better.
 


### PR DESCRIPTION
- removes the last mentions of the `wasm32-unknown-unknown` target
- corrects a version mistake i made at an earlier time
- fixes some `WebAssembly` spelling/styling nitpicks

Fixes #1815 