### PR TITLE
Remove deprecated command flag for generating global identity

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -280,7 +280,7 @@ When you deploy a smart contract to a network, you need to specify an identity t
 Let's configure an identity called `alice`. You can use any name you want, but it might be nice to have some named identities that you can use for testing, such as [`alice`, `bob`, and `carol`](https://en.wikipedia.org/wiki/Alice_and_Bob). Notice that the account will be funded using [Friendbot](../../../learn/fundamentals/networks.mdx#friendbot).
 
 ```sh
-stellar keys generate --global alice --network testnet --fund
+stellar keys generate alice --network testnet --fund
 ```
 
 You can see the public key of `alice` with:


### PR DESCRIPTION
Updated command for generating a funded identity, removed the `--global` flag, since it is deprecated as the funded identity is now created at the global level by default.

The info I got while running the command with the `--global` flag.

```zsh
⚠️ Flag --global is deprecated: global config is always used
✅ Key saved with alias bene in "/Users/bene/.config/stellar/identity/bene.toml"
✅ Account bene funded on "Test SDF Network ; September 2015"
```