### PR TITLE
fix(getting-started-setup): mv & update key gen

### DIFF
--- a/docs/build/smart-contracts/getting-started/deploy-to-testnet.mdx
+++ b/docs/build/smart-contracts/getting-started/deploy-to-testnet.mdx
@@ -20,6 +20,28 @@ To recap what we've done so far, in [Setup](setup.mdx):
 
 In [Hello World](./hello-world.mdx) we created a `hello-world` project, and learned how to test and build the `HelloWorld` contract. Now we are ready to deploy that contract to Testnet, and interact with it.
 
+## Configure a Source Account
+
+When you deploy a smart contract to a network, you need to specify a source account's keypair that will be used to sign the transactions.
+
+Let's generate a keypair called `alice`. You can use any name you want, but it might be nice to have some named keys that you can use for testing, such as [`alice`, `bob`, and `carol`](https://en.wikipedia.org/wiki/Alice_and_Bob). Notice that the keypair's account will be funded using [Friendbot](../../../networks/README.mdx#friendbot).
+
+```sh
+stellar keys generate alice --network testnet --fund
+```
+
+You can see the public key of `alice` with:
+
+```sh
+stellar keys address alice
+```
+
+You can see all of the keys you generated, along with where on your filesystem their information is stored, with:
+
+```sh
+stellar keys ls -l
+```
+
 ## Deploy
 
 To deploy your HelloWorld contract, run the following command:

--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -255,31 +255,5 @@ echo "source (stellar completion --shell elvish)" >> ~/.elvish/rc.elv
 
 </Tabs>
 
-### Configuring the CLI for Testnet
-
-### Configure an Identity
-
-When you deploy a smart contract to a network, you need to specify an identity that will be used to sign the transactions.
-
-Let's configure an identity called `alice`. You can use any name you want, but it might be nice to have some named identities that you can use for testing, such as [`alice`, `bob`, and `carol`](https://en.wikipedia.org/wiki/Alice_and_Bob). Notice that the account will be funded using [Friendbot](../../../networks/README.mdx#friendbot).
-
-```sh
-stellar keys generate alice --network testnet --fund
-```
-
-You can see the public key of `alice` with:
-
-```sh
-stellar keys address alice
-```
-
-Like the Network configs, the `--global` means that the identity gets stored in `~/.config/stellar/identity/alice.toml`. You can omit the `--global` flag to store the identity in your project's `.stellar/identity` folder instead.
-
-:::info
-
-We previously used `~/.config/soroban` (global) and `.soroban` (local) as the configuration directories. These directories are still supported, but the preferred name is now `~/.config/stellar` and `.stellar` moving forward.
-
-:::
-
 [rust]: https://www.rust-lang.org/
 [stellar cli]: #install-the-stellar-cli


### PR DESCRIPTION
The [Setup](https://developers.stellar.org/docs/build/smart-contracts/getting-started/deploy-to-testnet) step had multiple issues:

- Section "Configuring the CLI for Testnet" was empty
- Extraneous paragraph explaining the `--global` flag, when that flag is no longer used (or available) in the specified command
- Info box about local & global configs and their recent rename is irrelevant, if this is your first interaction with Stellar CLI. You'll just use the as-of-now only-valid global config location, and you won't have any questions about folders you don't have or know about.

Also, I have moved the "Configure an Identity" section to the "Deploy to Testnet" page, where it is actually relevant. Thoughts here:

- Let's keep the Setup page minimal and focused, so it's more useful as a reference page for other projects (for example, we want to link to this page as part of the Scaffold Stellar docs, and generating a keypair is irrelevant in this context)
- The language here has changed. The CLI no longer presents it as "configuring an identity" with `stellar config identity generate`, it's just "generating a keypair" with `stellar keys generate`. I've updated the language to reflect this change.
- Rather than an info box about config locations, I've now added explicit mention of the `stellar keys ls -l` command, so curious learners can see where the config files are stored.