### PR TITLE
Bump minimum memory requirements for RPC

### DIFF
--- a/docs/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/docs/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -9,7 +9,7 @@ The RPC service can be installed on bare metal or a virtual machine. It is nativ
 
 | Node Type | CPU | RAM | Disk | AWS SKU | Google Cloud SKU |
 | --- | --- | --- | --- | --- | --- |
-| Stellar RPC | 2 vCPU | 8GB | 250 GB persistent volume >= 3K IOPS | [c5.xlarge] | [n4-highcpu-4] |
+| Stellar RPC | 2 vCPU | 10GB | 250 GB persistent volume >= 3K IOPS | [c5.xlarge] | [n4-highcpu-4] |
 
 _\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, 20GB + 20GB per retention day_ _\* RAM/CPU: Assuming RPC will serve up to 1000 requests per second. For deployments expecting 1000-10000+ requests per second to Stellar RPC, we recommend at least 16GB of RAM and at least a quad core CPU with a 2.4GHz clock speed._
 


### PR DESCRIPTION
RPCs appear to OOM during catchup on mainnet with 8GB.