### PR TITLE
Fix typo in RPCLedgerBackend section

### DIFF
--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/README.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/README.mdx
@@ -7,7 +7,7 @@ A ledger backend is a source of Stellar network ledger data. The ingest SDK supp
 
 1. **[Captive Core](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/captivecore)** – Invokes the `stellar-core` binary as a subprocess which connects to the live Stellar network and fetches network data (i.e., ledgers).
 2. **[BufferedStorageBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend)** – Retrieves ledger metadata from cloud storage.
-3. **[RPCLedgetBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend)** – Retrieves ledger metadata from an RPC server.
+3. **[RPCLedgerBackend](/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend)** – Retrieves ledger metadata from an RPC server.
 
 Each backend has its own setup and configuration requirements, which are covered in the following sections.
 


### PR DESCRIPTION
Summary: Fix typo in [RPCLedgerBackend](https://developers.stellar.org/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends) section of docs 'RPCLedgetBackend' to 'RPCLedgerBackend'

<img width="936" height="305" alt="{1996A729-CACF-4550-ABA6-B5E86D602FF6}" src="https://github.com/user-attachments/assets/be309784-663e-487e-81d3-154193a968f9" />


