### PR TITLE
Update Galexie repo links

### DIFF
--- a/docs/build/apps/ingest-sdk/overview.mdx
+++ b/docs/build/apps/ingest-sdk/overview.mdx
@@ -26,7 +26,7 @@ To use this example CDP pipeline for live Stellar network transaction data, you'
 - Docker
 - Google Cloud Platform account:
   - a bucket created in Google Cloud Storage(GCS)
-  - GCP [credentials in workstation environment](https://github.com/stellar/go/blob/master/services/galexie/README.md#set-up-gcp-credentials)
+  - GCP [credentials in workstation environment](../../../data/indexers/build-your-own/galexie/admin_guide/setup.mdx#google-cloud-platform-gcp-credentials)
 
 Our example application is only interested in a small subset of the overall network data model related to asset transfers triggered by Payment operation and defines its own derived data model as the goal of exercise:
 
@@ -62,9 +62,9 @@ There will be open source contributions for implementations on other storage lay
 
 Use Galexie, a new CDP command line program for exporting network metadata to datastores.
 
-- Follow the Galexie setup steps in [Galexie User Guide](https://github.com/stellar/go/blob/master/services/galexie/README.md#setup), to configure specifics of GCS bucket and target network.
+- Follow the Galexie setup steps in [Galexie User Guide](../../../data/indexers/build-your-own/galexie/admin_guide/setup.mdx), to configure specifics of GCS bucket and target network.
 
-- Follow the [Galexie docker runtime instructions](https://github.com/stellar/go/blob/master/services/galexie/README.md#running-galexie) to start the export.
+- Follow the [Galexie docker runtime instructions](../../../data/indexers/build-your-own/galexie/admin_guide/running.mdx) to start the export.
   - For one time export of historical bounded range of ledgers, use `append --start <from_ledger> --end <to_ledger>`
   - For a continuous export of prior ledgers and all new ledgers generated on network, use `append --start <from_ledger>`.
 

--- a/docs/data/indexers/build-your-own/galexie/admin_guide/configuring.mdx
+++ b/docs/data/indexers/build-your-own/galexie/admin_guide/configuring.mdx
@@ -9,7 +9,7 @@ sidebar_position: 20
 
 ### 1. Copy the Sample Configuration
 
-Start with the provided sample file, [`config.example.toml`](https://github.com/stellar/go/blob/master/services/galexie/config.example.toml).
+Start with the provided sample file, [`config.example.toml`](https://github.com/stellar/stellar-galexie/blob/main/config/config.example.toml).
 
 ### 2. Rename and Update the Configuration
 


### PR DESCRIPTION
We recently moved Stellar Galexie from the monorepo into its own repo (https://github.com/stellar/go/issues/5673). I'm updating the links here to reflect that change.

