### PR TITLE
docs: update URL to new Scaffold Stellar site

### DIFF
--- a/docs/tools/scaffold-stellar.mdx
+++ b/docs/tools/scaffold-stellar.mdx
@@ -7,7 +7,7 @@ sidebar_position: 45
 
 **Scaffold Stellar** is a developer toolkit for building decentralized applications (dApps) and smart contracts on the Stellar blockchain. It helps you go from idea to working full-stack dApp faster — by providing CLI tools, reusable contract templates, a smart contract registry, and a modern frontend.
 
-Visit the [Scaffold Stellar](https://scaffoldstellar.com) homepage for guides, docs, and more.
+Visit the [Scaffold Stellar](https://scaffoldstellar.org) homepage for guides, docs, and more.
 
 ## Prerequisites
 


### PR DESCRIPTION
The current Scaffold Stellar site is now on https://scaffoldstellar.org/ - this updates the docs to reflect that.