### PR TITLE
Docs: fixed incorrect filename in example command

### DIFF
--- a/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
+++ b/docs/build/smart-contracts/getting-started/deploy-increment-contract.mdx
@@ -35,7 +35,7 @@ If the contract has not been build yet, run the build command `stellar contract 
 stellar contract upload \
   --network testnet \
   --source-account alice \
-  --wasm target/wasm32v1-none/release/soroban_increment_contract.wasm
+  --wasm target/wasm32v1-none/release/increment.wasm
 ```
 
 </TabItem>
@@ -46,7 +46,7 @@ stellar contract upload \
 stellar contract upload `
   --network testnet `
   --source-account alice `
-  --wasm target/wasm32v1-none/release/soroban_increment_contract.wasm
+  --wasm target/wasm32v1-none/release/increment.wasm
 ```
 
 </TabItem>


### PR DESCRIPTION
On [step 4](https://developers.stellar.org/docs/build/smart-contracts/getting-started/deploy-increment-contract) of the smart contracts getting started guide, it references a file named "soroban_increment_contract.wasm" in a command. This is inconsistent with the previous steps as the contract we build is named "increment.wasm" so this command doesn't run. This PR just changes the filename in this example to "increment.wasm".

Minor aside, but I think the mismatch might stem from a difference in naming conventions in this guide and naming conventions in the [soroban-examples](https://github.com/stellar/soroban-examples/) folder (it seems these all follow a "soroban-[contract purpose]-contract" pattern, including the increment example in this folder).