### PR TITLE
fix: Link to the cookbook on the site vs the github tree

### DIFF
--- a/docs/tools/cli/install-cli.mdx
+++ b/docs/tools/cli/install-cli.mdx
@@ -80,7 +80,7 @@ echo "source <(stellar completion --shell bash)" >> ~/.bashrc
 
 ## Stellar CLI Cookbook
 
-To understand how to get the most of the Stellar CLI, see the [Stellar CLI Cookbook](./cookbook) for recipes and a collection of resources to teach you how to use the CLI. Examples of recipes included in the CLI cookbook include: send payments, manage contract lifecycle, extend contract instance/storage/wasm, and more.
+To understand how to get the most of the Stellar CLI, see the [Stellar CLI Cookbook](./cookbook/README.mdx) for recipes and a collection of resources to teach you how to use the CLI. Examples of recipes included in the CLI cookbook include: send payments, manage contract lifecycle, extend contract instance/storage/wasm, and more.
 
 ## Video Tutorials
 


### PR DESCRIPTION
I noticed the Install CLI page linked to the github tree of the CLI cookbook, I imagine we'd want to point to the cookbook on the website/docs itself

https://developers.stellar.org/docs/tools/cli/install-cli