### PR TITLE
Add network IDs to networks page

### DIFF
--- a/docs/networks/README.mdx
+++ b/docs/networks/README.mdx
@@ -19,7 +19,7 @@ Stellar has three networks: the public network (Mainnet, also called Pubnet or t
 | --- | --- | --- | --- |
 | **Purpose** | Production network | Stable testing environment | Bleeding-edge feature testing |
 | **Network Passphrase** | `Public Global Stellar Network ; September 2015` | `Test SDF Network ; September 2015` | `Test SDF Future Network ; October 2022` |
-| **Network ID** | <code style={{overflow-wrap:'anywhere'}}>7ac33997544e3175d266bd022439b22cdb16508c01163f26e5cb2a3e1045a979</code> | <code style={{overflow-wrap:'anywhere'}}>cee0302d59844d32bdca915c8203dd44b33fbb7edc19051ea37abedf28ecd472</code> | <code style={{overflow-wrap:'anywhere'}}>a3a1c6a78286713e29be0e9785670fa838d13917cd8eaeb4a3579ff1debc7fd5</code> |
+| **Network ID** | <code style={{overflowWrap:'anywhere'}}>7ac33997544e3175d266bd022439b22cdb16508c01163f26e5cb2a3e1045a979</code> | <code style={{overflowWrap:'anywhere'}}>cee0302d59844d32bdca915c8203dd44b33fbb7edc19051ea37abedf28ecd472</code> | <code style={{overflowWrap:'anywhere'}}>a3a1c6a78286713e29be0e9785670fa838d13917cd8eaeb4a3579ff1debc7fd5</code> |
 | **Validator Nodes** | Run by the public | SDF runs three core validator nodes | SDF runs core validator nodes |
 | **Validator** | `core-live-a.stellar.org` `core-live-b.stellar.org` `core-live-c.stellar.org` | `core-live-testnet.stellar.org` | `core-live-futurenet.stellar.org` |
 | **Funding** | Real XLM required from another account | Free via Friendbot | Free via Friendbot |


### PR DESCRIPTION
### What
Document the Network IDs for each network alongside their network passphrases for Mainnet, Testnet, and Futurenet. Remove duplicate passphrase listing and reference the existing section instead.

### Why
Network IDs are used in transaction signing, contract address generation, and hash uniqueness across networks but are not well documented. They show up in a variety of places, like xdr, and auth signing, and are are concept exposed in the contract sdk. They should be discussed.