### PR TITLE
Updated docs for protocol 25 getLatestLedger endpoint

### DIFF
--- a/i18n/es/docusaurus-plugin-content-docs/current/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
+++ b/i18n/es/docusaurus-plugin-content-docs/current/platforms/anchor-platform/api-reference/platform/rpc/anchor-platform.openrpc.json
@@ -1275,6 +1275,10 @@
               "description": "The domain of the client.",
               "type": "string"
             },
+            "request_client_ip_address": {
+              "description": "The IP address of the client requesting the transaction.",
+              "type": "string"
+            },
             "customers": {
               "description": "The Identification info of the sending and receiving customers. If they were created through [SEP-12](https://stellar.org/protocol/sep-12),\n            this object should contain the SEP-12 customer `id`. Otherwise, the `account` address of the customer.",
               "type": "object",
@@ -1989,6 +1993,10 @@
                   },
                   "client_name": {
                     "description": "The domain of the client.",
+                    "type": "string"
+                  },
+                  "request_client_ip_address": {
+                    "description": "The IP address of the client requesting the transaction.",
                     "type": "string"
                   },
                   "customers": {

--- a/openrpc/src/stellar-rpc/methods/getLatestLedger.json
+++ b/openrpc/src/stellar-rpc/methods/getLatestLedger.json
@@ -8,18 +8,30 @@
     "paramStructure": "by-name",
     "params": [],
     "result": {
-        "name": "getLatestLedgerResult",
+        "name": "getLatestLedgerResponse",
         "schema": {
             "type": "object",
             "properties": {
                 "id": {
                     "$ref": "#/components/schemas/LedgerHash"
                 },
-                "protocolVersion": {
-                    "$ref": "#/components/schemas/ProtocolVersion"
-                },
                 "sequence": {
                     "$ref": "#/components/schemas/LatestLedger"
+                },
+                "closeTime": {
+                    "title": "closeTime",
+                    "description": "The timestamp at which the latest ledger was closed.",
+                    "type": "string"
+                },
+                "headerXdr": {
+                    "title": "headerXdr",
+                    "type": "string",
+                    "description": "The [LedgerHeader](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L74) structure for this ledger (base64-encoded string)."
+                },
+                "metadataXdr": {
+                    "title": "metadataXdr",
+                    "type": "string",
+                    "description": "The [LedgerCloseMeta](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539) union for this ledger (base64-encoded string)."
                 }
             }
         }
@@ -32,9 +44,11 @@
             "result": {
                 "name": "getLatestLedgerResult",
                 "value": {
-                    "id": "c73c5eac58a441d4eb733c35253ae85f783e018f7be5ef974258fed067aabb36",
-                    "protocolVersion": 20,
-                    "sequence": 2539605
+                    "id": "9f3308826b666c11df41693b17eddbb68aea9758be0f67fd5df81f6cf5c48984",
+                    "sequence": 2002985,
+                    "closeTime": "1765223032",
+                    "headerXdr": "AAAAGBVaCGp9GqWZ+BfZOSqt5v/BLzNfuU6wBi3yuCItkCuXmW1RIVSNlHOOxENRa/PRaBpTfW/WXzvkBZkt8YjYxrMAAAAAaTcqeAAAAAAAAAABAAAAANVyadliUPdJbQeb4ug1Ejbv/+jTnC4Gv6uxQh8X/GccAAAAQPp6I5umxPf7dRVo+OHtpgHPcswph8eesf6xFlUUvxtm/AbcgDKF0BPyg7gHuzy9RvnCv5GPkDi/Q6NP5TcqlwZ69ncQ7zxy/qBWkTHZZbEYW4Q8mJt/jHnh1mJgosKVrcBn6psOiLJw02fxji7a/TMHzMYWixkIDOZWBmEsh+kNAB6QKQ3gtrOnZAAAAAABGeTS66QAAAAAAAAAAAAAVzwAAABkAExLQAAAAMjuMwFH65no9K3paxrP75vCHgw88lYhOPg2dmCUGZ5Ibdyeuy2VtFMaA/QlqPOVi+ft3NBSB4Tg4uQQrPAIqtdLm7DKjY28EwWkjJrBh1wu9oAd1DlPuUT28v7MxoO2ODeLkjDUqJCR9uLj3apU0+rlkVaMBK0QREEXiAUPVL81iAAAAAA=",
+                    "metadataXdr": "AAAAAgAAAACfMwiCa2ZsEd9BaTsX7du2iuqXWL4PZ/1d+B9s9cSJhAAAABgVWghqfRqlmfgX2Tkqreb/wS8zX7lOsAYt8rgiLZArl5ltUSFUjZRzjsRDUWvz0WgaU31v1l875AWZLfGI2MazAAAAAGk3KngAAAAAAAAAAQAAAADVcmnZYlD3SW0Hm+LoNRI27//o05wuBr+rsUIfF/xnHAAAAED6eiObpsT3+3UVaPjh7aYBz3LMKYfHnrH+sRZVFL8bZvwG3IAyhdAT8oO4B7s8vUb5wr+Rj5A4v0OjT+U3KpcGevZ3EO88cv6gVpEx2WWxGFuEPJibf4x54dZiYKLCla3AZ+qbDoiycNNn8Y4u2v0zB8zGFosZCAzmVgZhLIfpDQAekCkN4Lazp2QAAAAAARnk0uukAAAAAAAAAAAAAFc8AAAAZABMS0AAAADI7jMBR+uZ6PSt6Wsaz++bwh4MPPJWITj4NnZglBmeSG3cnrstlbRTGgP0JajzlYvn7dzQUgeE4OLkEKzwCKrXS5uwyo2NvBMFpIyawYdcLvaAHdQ5T7lE9vL+zMaDtjg3i5Iw1KiQkfbi492qVNPq5ZFWjAStEERBF4gFD1S/NYgAAAAAAAAAAAAAAAEVWghqfRqlmfgX2Tkqreb/wS8zX7lOsAYt8rgiLZArlwAAAAIAAAAAAAAAAQAAAAAAAAABAAAAAAAAAGQAAAABAAAAAgAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgABhqAAACrRAAMa+wAAAAEAAAAAAAAAAAAAAABpNyqwAAAAA3uMrov3944HR3O4zJjpep28VQWACDR7SdxiTcNRbHbQAAAAAQAAAAEAAAAAA+0oimKONzC713z+Cl8orRHR8/s0JY+JMothA0fY7bYAAAABAAAAAGjXNjfamWlduoNd5Dth2c7Nith9N/Nx7yYgMKjVQd6aAAAAAWVVQUgAAAAAmNGccZBf7IaykO5gUj9NEnyXcAe9QGWlW6s3p+cAKE4AAAAADIRYgAAAAAAAAAABR9jttgAAAEBQXB9k5bd+kWxUqWTnDy75jpTBk7MFcCE50Wrkph/NS+O2i3x69htRnabMxgFhZFU4gZvyk5f67Lf4cHSSLPYBAAAAAQAAAAAAAAAAAAAAAQAAAAB4y3ArkRVFqOebYMz+1DH2fxOgEA20EVcIRjelDusrEwAAAAAAAABk/////wAAAAEAAAAAAAAAAf////sAAAAAAAAAAgAAAAMAHpAoAAAAAAAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgAAAC6PrpT0AAAq0QADGvoAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAekCgAAAAAaTcqcwAAAAAAAAABAB6QKQAAAAAAAAAAA+0oimKONzC713z+Cl8orRHR8/s0JY+JMothA0fY7bYAAAAuj66UkAAAKtEAAxr6AAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAHpAoAAAAAGk3KnMAAAAAAAAABAAAAAAAAAACAAAAAwAekCkAAAAAAAAAAAPtKIpijjcwu9d8/gpfKK0R0fP7NCWPiTKLYQNH2O22AAAALo+ulJAAACrRAAMa+gAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAB6QKAAAAABpNypzAAAAAAAAAAEAHpApAAAAAAAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgAAAC6PrpSQAAAq0QADGvsAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAekCkAAAAAaTcqeAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAABAAAAAAAAAAIAAAAPAAAAA2ZlZQAAAAASAAAAAAAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgAAAAoAAAAAAAAAAAAAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAACVDDZMAAAAAA=="
                 }
             }
         }

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -651,36 +651,31 @@
           "properties": {
             "id": {
               "title": "id",
-              "description": "Hash identifier of the latest ledger (as a hex-encoded string) known to Stellar RPC at the time it handled the request.",
               "type": "string",
               "minLength": 64,
               "maxLength": 64,
-              "pattern": "^[a-f\\d]{64}$"
-            },
-            "protocolVersion": {
-              "title": "protocolVersion",
-              "description": "Stellar Core protocol version associated with the latest ledger.",
-              "type": "number"
+              "pattern": "^[a-f\\d]{64}$",
+              "description": "Hash identifier of the latest ledger (as a hex-encoded string) known to Stellar RPC at the time it handled the request."
             },
             "sequence": {
-              "title": "sequence",
+              "title": "latestLedger",
               "description": "The sequence number of the latest ledger known to Stellar RPC at the time it handled the request.",
               "type": "number"
             },
             "closeTime": {
               "title": "closeTime",
-              "description": "The close time of the latest ledger known to Stellar RPC as a Unix timestamp.",
-              "type": "number"
+              "description": "The timestamp at which the latest ledger was closed.",
+              "type": "string"
             },
             "headerXdr": {
               "title": "headerXdr",
-              "description": "The LedgerHeader of the latest ledger as a base64-encoded XDR string.",
-              "type": "string"
+              "type": "string",
+              "description": "The [LedgerHeader](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L74) structure for this ledger (base64-encoded string)."
             },
             "metadataXdr": {
               "title": "metadataXdr",
-              "description": "The metadata of the latest ledger as a base64-encoded XDR string.",
-              "type": "string"
+              "type": "string",
+              "description": "The [LedgerCloseMeta](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L539) union for this ledger (base64-encoded string)."
             }
           }
         }
@@ -691,15 +686,13 @@
           "description": "Example request to the `getLatestLedger` method.",
           "params": [],
           "result": {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "result": {
-              "id": "2801f973ae68d573fa007e5d7f11b34923aea284ff02cfef2b40105274ba5ec0",
-              "protocolVersion": 24,
-              "sequence": 1791629,
-              "closeTime": "1764165092",
-              "headerXdr": "AAAAGANCgma0welM5Lx3n9p3WLGLmIu3BTD4caEk9Zie4CrbRiisvBZrlZ6k34eJSyzjjIsWm...",
-              "metadataXdr": "AAAAAgAAAAAoAflzrmjVc/oAfl1/EbNJI66ihP8Cz+8rQBBSdLpewAAAABgDQoJmtMHpTOS..."
+            "name": "getLatestLedgerResult",
+            "value": {
+              "id": "9f3308826b666c11df41693b17eddbb68aea9758be0f67fd5df81f6cf5c48984",
+              "sequence": 2002985,
+              "closeTime": "1765223032",
+              "headerXdr": "AAAAGBVaCGp9GqWZ+BfZOSqt5v/BLzNfuU6wBi3yuCItkCuXmW1RIVSNlHOOxENRa/PRaBpTfW/WXzvkBZkt8YjYxrMAAAAAaTcqeAAAAAAAAAABAAAAANVyadliUPdJbQeb4ug1Ejbv/+jTnC4Gv6uxQh8X/GccAAAAQPp6I5umxPf7dRVo+OHtpgHPcswph8eesf6xFlUUvxtm/AbcgDKF0BPyg7gHuzy9RvnCv5GPkDi/Q6NP5TcqlwZ69ncQ7zxy/qBWkTHZZbEYW4Q8mJt/jHnh1mJgosKVrcBn6psOiLJw02fxji7a/TMHzMYWixkIDOZWBmEsh+kNAB6QKQ3gtrOnZAAAAAABGeTS66QAAAAAAAAAAAAAVzwAAABkAExLQAAAAMjuMwFH65no9K3paxrP75vCHgw88lYhOPg2dmCUGZ5Ibdyeuy2VtFMaA/QlqPOVi+ft3NBSB4Tg4uQQrPAIqtdLm7DKjY28EwWkjJrBh1wu9oAd1DlPuUT28v7MxoO2ODeLkjDUqJCR9uLj3apU0+rlkVaMBK0QREEXiAUPVL81iAAAAAA=",
+              "metadataXdr": "AAAAAgAAAACfMwiCa2ZsEd9BaTsX7du2iuqXWL4PZ/1d+B9s9cSJhAAAABgVWghqfRqlmfgX2Tkqreb/wS8zX7lOsAYt8rgiLZArl5ltUSFUjZRzjsRDUWvz0WgaU31v1l875AWZLfGI2MazAAAAAGk3KngAAAAAAAAAAQAAAADVcmnZYlD3SW0Hm+LoNRI27//o05wuBr+rsUIfF/xnHAAAAED6eiObpsT3+3UVaPjh7aYBz3LMKYfHnrH+sRZVFL8bZvwG3IAyhdAT8oO4B7s8vUb5wr+Rj5A4v0OjT+U3KpcGevZ3EO88cv6gVpEx2WWxGFuEPJibf4x54dZiYKLCla3AZ+qbDoiycNNn8Y4u2v0zB8zGFosZCAzmVgZhLIfpDQAekCkN4Lazp2QAAAAAARnk0uukAAAAAAAAAAAAAFc8AAAAZABMS0AAAADI7jMBR+uZ6PSt6Wsaz++bwh4MPPJWITj4NnZglBmeSG3cnrstlbRTGgP0JajzlYvn7dzQUgeE4OLkEKzwCKrXS5uwyo2NvBMFpIyawYdcLvaAHdQ5T7lE9vL+zMaDtjg3i5Iw1KiQkfbi492qVNPq5ZFWjAStEERBF4gFD1S/NYgAAAAAAAAAAAAAAAEVWghqfRqlmfgX2Tkqreb/wS8zX7lOsAYt8rgiLZArlwAAAAIAAAAAAAAAAQAAAAAAAAABAAAAAAAAAGQAAAABAAAAAgAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgABhqAAACrRAAMa+wAAAAEAAAAAAAAAAAAAAABpNyqwAAAAA3uMrov3944HR3O4zJjpep28VQWACDR7SdxiTcNRbHbQAAAAAQAAAAEAAAAAA+0oimKONzC713z+Cl8orRHR8/s0JY+JMothA0fY7bYAAAABAAAAAGjXNjfamWlduoNd5Dth2c7Nith9N/Nx7yYgMKjVQd6aAAAAAWVVQUgAAAAAmNGccZBf7IaykO5gUj9NEnyXcAe9QGWlW6s3p+cAKE4AAAAADIRYgAAAAAAAAAABR9jttgAAAEBQXB9k5bd+kWxUqWTnDy75jpTBk7MFcCE50Wrkph/NS+O2i3x69htRnabMxgFhZFU4gZvyk5f67Lf4cHSSLPYBAAAAAQAAAAAAAAAAAAAAAQAAAAB4y3ArkRVFqOebYMz+1DH2fxOgEA20EVcIRjelDusrEwAAAAAAAABk/////wAAAAEAAAAAAAAAAf////sAAAAAAAAAAgAAAAMAHpAoAAAAAAAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgAAAC6PrpT0AAAq0QADGvoAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAekCgAAAAAaTcqcwAAAAAAAAABAB6QKQAAAAAAAAAAA+0oimKONzC713z+Cl8orRHR8/s0JY+JMothA0fY7bYAAAAuj66UkAAAKtEAAxr6AAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAHpAoAAAAAGk3KnMAAAAAAAAABAAAAAAAAAACAAAAAwAekCkAAAAAAAAAAAPtKIpijjcwu9d8/gpfKK0R0fP7NCWPiTKLYQNH2O22AAAALo+ulJAAACrRAAMa+gAAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAB6QKAAAAABpNypzAAAAAAAAAAEAHpApAAAAAAAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgAAAC6PrpSQAAAq0QADGvsAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAekCkAAAAAaTcqeAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAB15KLcsJwPM/q9+uf9O9NUEpVqLl5/JtFDqLIQrTRzmEAAAABAAAAAAAAAAIAAAAPAAAAA2ZlZQAAAAASAAAAAAAAAAAD7SiKYo43MLvXfP4KXyitEdHz+zQlj4kyi2EDR9jttgAAAAoAAAAAAAAAAAAAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAACVDDZMAAAAAA=="
             }
           }
         }


### PR DESCRIPTION
See related PRs in [stellar-rpc](https://github.com/stellar/stellar-rpc/pull/554) and [go-stellar-sdk](https://github.com/stellar/go-stellar-sdk/pull/5870). This PR extends the example demonstrating what is returned by the getLatestLedger endpoint.

Note that because this PR updates documentation that will only come once the `protocol-25` branch is merged to main, it should not be merged before that.