### PR TITLE
fix: update non fungible library link

### DIFF
--- a/docs/build/smart-contracts/example-contracts/non-fungible-token.mdx
+++ b/docs/build/smart-contracts/example-contracts/non-fungible-token.mdx
@@ -16,7 +16,7 @@ sidebar_position: 142
 
 # Non-Fungible Token
 
-[Source Code](https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/src/non-fungible)
+[Source Code](https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/src/non_fungible)
 
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)][open-in-github-codespaces]
 
@@ -26,7 +26,7 @@ In the world of digital assets, not all tokens are alike. This becomes important
 
 ## Overview
 
-The [non-fungible](https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/src/non-fungible) module provides three different NFT variants that differ in how certain features like ownership tracking, token creation and destruction are handled:
+The [non-fungible](https://github.com/OpenZeppelin/stellar-contracts/tree/main/packages/tokens/src/non_fungible) module provides three different NFT variants that differ in how certain features like ownership tracking, token creation and destruction are handled:
 
 1. **Base**: Contract variant that implements the base logic for the NonFungibleToken interface. Suitable for most use cases.
 2. **Consecutive**: Contract variant for optimized minting of batches of tokens. Builds on top of the base variant, and overrides the necessary functions from the `Base` variant.


### PR DESCRIPTION
The https://developers.stellar.org/docs/build/smart-contracts/example-contracts/non-fungible-token page source links 404, this PR fixes those paths.