### PR TITLE
remove --id from stellar cli deploy command

### DIFF
--- a/docs/build/smart-contracts/example-contracts/deployer.mdx
+++ b/docs/build/smart-contracts/example-contracts/deployer.mdx
@@ -359,7 +359,7 @@ Then the deployer contract may be invoked with the Wasm hash value above.
 <TabItem value="unix" label="macOS/Linux">
 
 ```sh
-stellar contract invoke --alias 1 -- deploy \
+stellar contract invoke --id 1 -- deploy \
     --deployer CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
     --salt 123 \
     --wasm_hash 7792a624b562b3d9414792f5fb5d72f53b9838fef2ed9a901471253970bc3b15 \
@@ -370,7 +370,7 @@ stellar contract invoke --alias 1 -- deploy \
 <TabItem value="windows" label="Windows (PowerShell)">
 
 ```powershell
-stellar contract invoke --alias 1 -- deploy `
+stellar contract invoke --id 1 -- deploy `
     --deployer CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM
     --salt 123 `
     --wasm_hash 7792a624b562b3d9414792f5fb5d72f53b9838fef2ed9a901471253970bc3b15 `
@@ -387,7 +387,7 @@ And then invoke the deployed test contract using the identifier returned from th
 
 ```sh
 stellar contract invoke \
-    --alias ead19f55aec09bfcb555e09f230149ba7f72744a5fd639804ce1e934e8fe9c5d \
+    --id ead19f55aec09bfcb555e09f230149ba7f72744a5fd639804ce1e934e8fe9c5d \
     -- \
     value
 ```
@@ -397,7 +397,7 @@ stellar contract invoke \
 
 ```powershell
 stellar contract invoke `
-    --alias ead19f55aec09bfcb555e09f230149ba7f72744a5fd639804ce1e934e8fe9c5d `
+    --id ead19f55aec09bfcb555e09f230149ba7f72744a5fd639804ce1e934e8fe9c5d `
     -- `
     value
 ```


### PR DESCRIPTION
https://developers.stellar.org/docs/build/smart-contracts/example-contracts/deployer#run-the-contract

current doc shows a cli command with `--id`

<img width="887" height="126" alt="Screenshot 2025-12-17 at 10 29 43 AM" src="https://github.com/user-attachments/assets/36875be3-14c9-4488-af03-4c778b9be739" />

but when I added `--id`, I got a warning

<img width="1512" height="106" alt="Screenshot 2025-12-17 at 10 20 00 AM" src="https://github.com/user-attachments/assets/7287e5e7-471b-47fc-aeef-0ee270c955b4" />
