### PR TITLE
Horizon ain't deprecated yet

### DIFF
--- a/docs/learn/fundamentals/stellar-stack.mdx
+++ b/docs/learn/fundamentals/stellar-stack.mdx
@@ -37,7 +37,7 @@ SDF does not provide a publicly available RPC endpoint for Mainnet. Developers s
 
 :::warning
 
-Horizon is considered deprecated in favor of Stellar RPC. While it will continue to receive updates to maintain compatiblity with upcoming protocol releases, it won't receive significant new feature development.
+Horizon is nearing end-of-life and will eventually be deprecated in favor of Stellar RPC and [Portfolio APIs](../../data/indexers/README.mdx#portfolio-apis). While it will continue to receive updates to maintain compatibility with upcoming protocol releases, it won't receive new feature development.
 
 :::
 


### PR DESCRIPTION
"deprecated", to my engineering-trained mind, means "there is a better alternative available that you should now switch to."

There is ***no*** viable alternative to Horizon today. We therefore cannot declare it to be deprecated.

When I read that it is _already_ deprecated, it makes me think I can avoid using it in a project. If I cannot realistically avoid using it, at least not without great cost in both engineering research time and infrastructure bills, then the assertion that it is already deprecated will cause me distress.

Once we have good Portfolio API-style indexing services in place, with freemium models appropriate for the whole gamut of hackathon-startups-to-enterprises, then we can consider Horizon to be deprecated. Until then, there's just no other reasonable way to get a whole host of necessary data, such as token balances and circulating supply.

This updates the "Horizon is deprecated" warning to say that it _will_ be deprecated in the future, deep-linking to the "Portfolio APIs" section of the [newly-revamped indexers page][1].

  [1]: https://github.com/stellar/stellar-docs/pull/2055