### PR TITLE
Add Exaion as RPC provider

### DIFF
--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -21,6 +21,7 @@ These providers allow access to the Futurenet, Testnet and Mainnet network.
 | [OnFinality\*](https://onfinality.io/networks/stellar) | ❌ | ❌ | ✅ | ✅ | ✅ |
 | [Lightsail Network - Quasar\*](https://quasar.lightsail.network/) | ❌ | ❌ | ✅ | ❌ | ✅ |
 | [Uniblock](https://www.uniblock.dev/) | ❌ | ✅ | ✅ | ❌ | ❌ |
+| [Exaion](https://crypto.exaion.com) | ❌ | ❌ | ✅ | ✅ |
 
 \*_RPC Archive is a new option for those looking to retrieve full ledger history. Currently only the [getLedgers](./api-reference/methods/getLedgers.mdx) RPC method supports this feature. You can choose one of the providers above, or create your own getLedgers archive by following [these steps](./admin-guide/data-lake-integration.mdx)._
 


### PR DESCRIPTION
I am opening this to add Exaion as a RPC provider and also to discuss the general structure of the service providers in the docs.

Exaion first: https://crypto.exaion.com/protocols/stellar

From the French electricity and already being used behind the scene by real businesses.

---

(I can spin this off into an issue if wanted.)

On the structure. After #2055 we now have a few pages for service providers: API, Analytics, Indexers and Oracles.

I had a hard time to find some providers as I was expected them to be in indexers and they ended up being in Analytics. E.g. SonarX, whose description states that it is an indexer. I was also looking for Quasar and saw that there was a specific page for Galexie provider. Same goes with Dune which I also thought would be listed as an indexer.

After discussing with @chadoh and others, we all seem to have varying definitions on what is an indexer, a data provider, something else.

Hence, I would suggest to flatten and simplify the structure to help users find their way. Have a single Analytics-Indexing section (name to be defined) and have a single provider page for it, with sections if we want to separate concerns.

Reviewing this, I also found some other services which could be added: Zettablock (I read there is a SDF partnership even?), Bitwave (had a SCF), BlockEden, 3xpl, Ginco, Bitquery.

Some products seem to also gain capabilities. e.g. Quicknode shows on their page that indexing like features might be coming soon. Same with validationcloud with their new Mavrik Data x Ai.

I am happy to work on making a proposal. Let me know!

cc @johncanneto 