### PR TITLE
Update data lake providers

### DIFF
--- a/docs/data/indexers/build-your-own/galexie/providers.mdx
+++ b/docs/data/indexers/build-your-own/galexie/providers.mdx
@@ -9,7 +9,7 @@ These providers allow access to the Futurenet, Testnet and Mainnet network.
 
 | Provider | Futurenet | Testnet | Mainnet | URI |
 | --- | --- | --- | --- | --- |
-| [AWS Public Blockchain\*](https://registry.opendata.aws/aws-public-blockchain/) | ❌ | ✅ | ✅ | `s3://aws-public-blockchain/v1.1/stellar/ledgers/`|
+| [AWS Public Blockchain\*](https://registry.opendata.aws/aws-public-blockchain/) | ❌ | ✅ | ✅ | `s3://aws-public-blockchain/v1.1/stellar/ledgers/` |
 | [Lightsail Network - Quasar](https://quasar.lightsail.network/) | ❌ | ❌ | ✅ | `https://galexie.lightsail.network/v1/` |
 
 \*AWS Public Blockchain populated by Goldsky


### PR DESCRIPTION
AWS supports a testnet data lake as well

Both testnet and mainnet are listed under the URI if a developer were to list the contents of the bucket: 

```
aws s3 ls s3://aws-public-blockchain/v1.1/stellar/ledgers/ --no-sign-request
                           PRE pubnet/
                           PRE testnet/

```