### PR TITLE
Update `Stellar-ledger-entries.x` to use `v25` instead of `v22` in the url

### DIFF
--- a/docs/data/apis/rpc/api-reference/methods/getLedgerEntries.mdx
+++ b/docs/data/apis/rpc/api-reference/methods/getLedgerEntries.mdx
@@ -12,13 +12,13 @@ import rpcSpec from "@site/static/stellar-rpc.openrpc.json";
 
 # Building ledger keys
 
-The Stellar ledger is, on some level, essentially a key-value store. The keys are instances of [`LedgerKey`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger-entries.x#L600) and the values are instances of [`LedgerEntry`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger-entries.x#L560). An interesting product of the store's internal design is that the key is a _subset_ of the entry: we'll see more of this later.
+The Stellar ledger is, on some level, essentially a key-value store. The keys are instances of [`LedgerKey`](https://github.com/stellar/stellar-xdr/blob/v25.0/Stellar-ledger-entries.x#L588) and the values are instances of [`LedgerEntry`](https://github.com/stellar/stellar-xdr/blob/v25.0/Stellar-ledger-entries.x#L548). An interesting product of the store's internal design is that the key is a _subset_ of the entry: we'll see more of this later.
 
 The `getLedgerEntries` method returns the "values" (or "entries") for a given set of "keys". Ledger keys come in a lot of forms, and we'll go over the commonly used ones on this page alongside tutorials on how to build and use them.
 
 ## Types of `LedgerKey`s
 
-The source of truth should always be the XDR defined in the protocol. `LedgerKey`s are a union type defined in [Stellar-ledger-entries.x](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger-entries.x#L600). There are 10 different forms a ledger key can take:
+The source of truth should always be the XDR defined in the protocol. `LedgerKey`s are a union type defined in [Stellar-ledger-entries.x](https://github.com/stellar/stellar-xdr/blob/v25.0/Stellar-ledger-entries.x#L588). There are 10 different forms a ledger key can take:
 
 1. **Account:** holistically defines a Stellar account, including its balance, signers, etc. (see [Accounts](../../../../../learn/fundamentals/stellar-data-structures/accounts.mdx))
 2. **Trustline:** defines a balance line to a non-native asset issued on the network (see [`changeTrustOp`](../../../../../learn/fundamentals/transactions/list-of-operations.mdx#change-trust))
@@ -423,7 +423,7 @@ Now, finally we have a `LedgerKey` that correspond to the Wasm byte-code that ha
 }
 ```
 
-Then you can inspect them accordingly. Each of the above entries follows the XDR for that `LedgerEntryData` structure precisely. For example, the `AccountEntry` is in [`Stellar-ledger-entries.x#L191`](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger-entries.x#L191) and you can use `.seqNum()` to access its current sequence number, as we've shown. In JavaScript, you can see the appropriate methods in the [type definition](https://github.com/stellar/js-stellar-base/blob/6930a70d7fbde675514b5933baff605d97453ba7/types/curr.d.ts#L3034).
+Then you can inspect them accordingly. Each of the above entries follows the XDR for that `LedgerEntryData` structure precisely. For example, the `AccountEntry` is in [`Stellar-ledger-entries.x#L190`](https://github.com/stellar/stellar-xdr/blob/v25.0/Stellar-ledger-entries.x#L190) and you can use `.seqNum()` to access its current sequence number, as we've shown. In JavaScript, you can see the appropriate methods in the [type definition](https://github.com/stellar/js-stellar-base/blob/6930a70d7fbde675514b5933baff605d97453ba7/types/curr.d.ts#L3034).
 
 ## Viewing and understanding XDR
 


### PR DESCRIPTION
I was relying on [the getLedgerEntries doc](https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getLedgerEntries) for getLedgerEntries api endpoint then I realized it was missing the following three for `config setting` because the link was using the old version `v22` instead of `v25`

```
CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0 = 14,
CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0 = 15,
CONFIG_SETTING_SCP_TIMING = 16
```
