### PR TITLE
Add a tip pointing people to Scaffold Stellar docs

### DIFF
--- a/docs/build/smart-contracts/getting-started/README.mdx
+++ b/docs/build/smart-contracts/getting-started/README.mdx
@@ -7,6 +7,14 @@ sidebar_position: 20
 
 # Getting Started
 
+:::tip
+
+Start with [Scaffold Stellar](https://scaffoldstellar.org/docs/quick-start) for the fastest path to a working dApp on Stellar. Scaffold Stellar is a toolkit that bundles a CLI, contract templates, a smart contract registry, and a modern frontend for building full-stack dApps.
+
+_Use this getting started guide for a lower-level tour of Stellar smart contract development from the main Stellar CLI._
+
+:::
+
 import DocCardList from "@theme/DocCardList";
 
 Dive into smart contract development with this Getting Started tutorial.


### PR DESCRIPTION
This PR adds a tip/callout to the top of the Getting Started tutorial, directing users to Scaffold Stellar's as a recommended starting point for dApp development.

We have a list of projects built with [Scaffold Stellar](https://scaffoldstellar.org/showcase). Where would be the best place in the docs to include a small showcase of these projects?