### PR TITLE
Rename "Rust on Stellar" section to "Developing Smart Contracts"

### DIFF
--- a/docs/build/smart-contracts/overview.mdx
+++ b/docs/build/smart-contracts/overview.mdx
@@ -17,7 +17,7 @@ For a comprehensive introduction to Stellar smart contracts, view the [Smart Con
 
 Write your first smart contract on Stellar using the [Getting Started Guide](./getting-started/setup.mdx).
 
-## Rust on Stellar
+## Developing Smart Contracts
 
 Stellar smart contracts have several characteristics (such as resource limits, security considerations, and more) that force contracts to use only a narrow subset of the full Rust language and must use specialized libraries for most tasks.
 


### PR DESCRIPTION
The phrase "Rust on Stellar" translates poorly in Google Translate for certain languages (e.g., Hindi interprets "Rust on" as "war on"). Renamed to "Developing Smart Contracts" to avoid confusion.

Fixes #2191