### PR TITLE
Update examples in the send/receive from C accounts guide

### DIFF
--- a/docs/build/guides/transactions/send-and-receive-c-accounts.mdx
+++ b/docs/build/guides/transactions/send-and-receive-c-accounts.mdx
@@ -29,24 +29,54 @@ That's the main difference between receiving from customers using G or Contract 
 
 **Receiving from a G address**
 
-Using Horizon's `accounts/{acc_id}/transactions` endpoint ([example](https://horizon-testnet.stellar.org/accounts/GBLVHX33XGOBDOXK7ERDL34NVH6WW7VTT2OBAHPJ7G3D423HBG5NOMY7/transactions))
+Using Horizon's `accounts/{acc_id}/transactions` endpoint
 
 The memo field will be present in the response.
 
 **Example response from a G address:**
 
 ```json
+...
 {
-  "memo": "123456789",
-  "memo_bytes": "MTIzNDU2Nzg5",
-  "source_account": "GCNG5JXJY3LNRMXCX23RIGKTURQACTSV5LL6NKL535BYRGOGWUX6J45Y",
-  "memo_type": "text"
-}
+   "memo":"12345",
+   "memo_bytes":"MTIzNDU=",
+   "_links":{
+      "self":{
+         "..."
+      },
+      "id":"05e11abd0d70776d62f1e3c7c2ba6a08f88641bb226d6be783b8e850bc70b345",
+      "paging_token":"4097295721172992",
+      "successful":true,
+      "hash":"05e11abd0d70776d62f1e3c7c2ba6a08f88641bb226d6be783b8e850bc70b345",
+      "ledger":953976,
+      "created_at":"2026-02-10T23:49:33Z",
+      "source_account":"GB5FM5GICRYGBFMEGPMYEFDZQHGUYF75Z7WNB2JL5A3A57HIB4CP3TCL",
+      "source_account_sequence":"4021081526501377",
+      "fee_account":"GB5FM5GICRYGBFMEGPMYEFDZQHGUYF75Z7WNB2JL5A3A57HIB4CP3TCL",
+      "fee_charged":"100",
+      "max_fee":"100",
+      "operation_count":1,
+      "envelope_xdr":"AAAAAgAAAAB6...sKa6KzAKWP/BabMM",
+      "result_xdr":"AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=",
+      "fee_meta_xdr":"AAAAAgAAAAMAD...AAAAQAAAAAAAAAAAAAAAAAAAA==",
+      "memo_type":"text",
+      "signatures":[
+         "7pD5p6H9ivnGNj1WO4CVW9HWQx2uPAv0xwpIDqsdXMALO4pqb2GwwBFXNc3+dZb0+9n5YrCmuiswClj/wWmzDA=="
+      ],
+      "preconditions":{
+         "timebounds":{
+            "min_time":"0",
+            "max_time":"1770767550"
+         }
+      }
+   }
+},
+...
 ```
 
 **Receiving from a Contract Account**
 
-Using Horizon's `accounts/{acc_id}/payments` endpoint ([example](https://horizon-testnet.stellar.org/accounts/GBLVHX33XGOBDOXK7ERDL34NVH6WW7VTT2OBAHPJ7G3D423HBG5NOMY7/payments))
+Using Horizon's `accounts/{acc_id}/payments` endpoint
 
 After the transaction is processed, this payment detail will be present in the '/payments' endpoint, under a section called 'asset_balance_changes', which will present the encoded ID and the underlying G-address separately.
 
@@ -55,18 +85,58 @@ It is important to note the 'asset_balance_changes' section only supports Stella
 **Example response from a Contract Account:**
 
 ```json
+...,
 {
-  "asset_balance_changes": [
-    {
-      "asset_type": "native",
-      "type": "transfer",
-      "from": "CBP4GFAK4GDKCMVLNIHRZPEAPT7CFYTBKICOXCVMP2FEN3QFKCRZ27KS",
-      "to": "GBLVHX33XGOBDOXK7ERDL34NVH6WW7VTT2OBAHPJ7G3D423HBG5NOMY7",
-      "amount": "1.0000000",
-      "destination_muxed_id": "123456789"
-    }
-  ]
-}
+   "_links":{
+      ...
+   },
+   "id":"258816945460609125",
+   "paging_token":"258816945460609025",
+   "transaction_successful":true,
+   "source_account":"GBFB3VVWWJUOS2WPIXLKEPK2B5LNIA6UY43FARXY4H3LCFCT2KESVS6A",
+   "type":"invoke_host_function",
+   "type_i":24,
+   "created_at":"2025-12-12T02:48:28Z",
+   "transaction_hash":"5fcb052da40a6570e983ebf48d11e037b159964d27d7a77111e241ff82a7e58",
+   "function":"HostFunctionTypeHostFunctionTypeInvokeContract",
+   "parameters":[
+      {
+         "value":"AAAAEgAAAAGt785ZruUpaPdgYdSUwlJbdWWfpClqZfSZ7ynlZHfklg==",
+         "type":"Address"
+      },
+      {
+         "value":"AAAADwAAAAh0cmFuc2Zlcg==",
+         "type":"Sym"
+      },
+      {
+         "value":"AAAAEgAAAAE9m2qWxXmeXBEUPeloYrEu8eZsK1yvbKfUgWuBEu+IYw==",
+         "type":"Address"
+      },
+      {
+         "value":"AAAAEgAAAAIAAAAAAAAAezLeBRB7Xvlp9tNUC1vK3+K4158NprSAUc3gng6hBtBY",
+         "type":"Address"
+      },
+      {
+         "value":"AAAACgAAAAAAAAAAAAAAAAABhqA=",
+         "type":"I128"
+      }
+   ],
+   "address":"",
+   "salt":"",
+   "asset_balance_changes":[
+      {
+         "asset_type":"credit_alphanum4",
+         "asset_code":"USDC",
+         "asset_issuer":"GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+         "type":"transfer",
+         "from":"CA6ZW2UWYV4Z4XARCQ66S2DCWEXPDZTMFNOK63FH2SAWXAIS56EGHGH5",
+         "to":"GB5FM5GICRYGBFMEGPMYEFDZQHGUYF75Z7WNB2JL5A3A57HIB4CP3TCL",
+         "amount":"0.0100000",
+         "destination_muxed_id":"123"
+      }
+   ]
+},
+...
 ```
 
 For a detailed code example, see the section 'Monitoring Payments -> Using the Horizon API' of [this repository's examples](https://github.com/fazzatti/c-address-payment-examples#monitoring-payments).

--- a/docs/build/guides/transactions/send-and-receive-c-accounts.mdx
+++ b/docs/build/guides/transactions/send-and-receive-c-accounts.mdx
@@ -29,9 +29,7 @@ That's the main difference between receiving from customers using G or Contract 
 
 **Receiving from a G address**
 
-Using Horizon's `accounts/{acc_id}/transactions` endpoint
-
-The memo field will be present in the response.
+The memo field will be present in the response of Horizon's [accounts/:account_id/transactions](https://developers.stellar.org/docs/data/apis/horizon/api-reference/get-transactions-by-account-id) endpoint
 
 **Example response from a G address:**
 
@@ -76,9 +74,7 @@ The memo field will be present in the response.
 
 **Receiving from a Contract Account**
 
-Using Horizon's `accounts/{acc_id}/payments` endpoint
-
-After the transaction is processed, this payment detail will be present in the '/payments' endpoint, under a section called 'asset_balance_changes', which will present the encoded ID and the underlying G-address separately.
+The payment details will be present in Horizon's [accounts/:account_id/payments](https://developers.stellar.org/docs/data/apis/horizon/api-reference/get-payments-by-account-id) endpoint, under 'asset_balance_changes', which will present the encoded ID and the underlying G address separately.
 
 It is important to note the 'asset_balance_changes' section only supports Stellar assets and transactions that make use of the `transfer` function in the [Stellar Asset Contract (SAC)](../../../tokens/stellar-asset-contract.mdx).
 

--- a/docs/build/guides/transactions/send-and-receive-c-accounts.mdx
+++ b/docs/build/guides/transactions/send-and-receive-c-accounts.mdx
@@ -29,7 +29,7 @@ That's the main difference between receiving from customers using G or Contract 
 
 **Receiving from a G address**
 
-The memo field will be present in the response of Horizon's [accounts/:account_id/transactions](https://developers.stellar.org/docs/data/apis/horizon/api-reference/get-transactions-by-account-id) endpoint
+The memo field will be present in the response of Horizon's [accounts/:account_id/transactions](../../../data/apis/horizon/api-reference/get-transactions-by-account-id.api.mdx) endpoint
 
 **Example response from a G address:**
 
@@ -74,7 +74,7 @@ The memo field will be present in the response of Horizon's [accounts/:account_i
 
 **Receiving from a Contract Account**
 
-The payment details will be present in Horizon's [accounts/:account_id/payments](https://developers.stellar.org/docs/data/apis/horizon/api-reference/get-payments-by-account-id) endpoint, under 'asset_balance_changes', which will present the encoded ID and the underlying G address separately.
+The payment details will be present in Horizon's [accounts/:account_id/payments](../../../data/apis/horizon/api-reference/get-payments-by-account-id.api.mdx) endpoint, under 'asset_balance_changes', which will present the encoded ID and the underlying G address separately.
 
 It is important to note the 'asset_balance_changes' section only supports Stellar assets and transactions that make use of the `transfer` function in the [Stellar Asset Contract (SAC)](../../../tokens/stellar-asset-contract.mdx).
 


### PR DESCRIPTION
With the testnet reset, links to Horizon were broken. Removed the direct link and added a more detailed example of responses in the page content itself.
