### PR TITLE
Add Record Marking Standard (RFC 5531) documentation to XDR page

### DIFF
--- a/docs/learn/fundamentals/data-format/xdr.mdx
+++ b/docs/learn/fundamentals/data-format/xdr.mdx
@@ -230,7 +230,6 @@ In Stellar's usage today each record contains exactly one XDR object, encoded as
 When decoding XDR with the [stellar-cli], streams framed with the record marking can be decoded by specifying the `--input stream-framed`.
 
 [stellar-cli]: ../../../tools/cli/stellar-cli.mdx
-
 [RFC5531s11]: https://www.rfc-editor.org/rfc/rfc5531#section-11
 
 ---


### PR DESCRIPTION
### What
Add a "Record Marking" section to the XDR fundamentals page (`docs/learn/fundamentals/data-format/xdr.mdx`). The new section documents the fragment-based framing format defined in [RFC 5531 Section 11](https://www.rfc-editor.org/rfc/rfc5531#section-11), including the 4-byte header layout (last-fragment bit and 30-bit length), and notes where Stellar uses this framing: history archive bucket/checkpoint files in stellar-core and the `Frame` type in rs-stellar-xdr.

### Why
The XDR docs page explains what XDR is and how to parse it, but omits the record marking layer that wraps XDR objects in files and streams. Developers working with history archives or the Rust XDR library encounter this framing without any reference in the Stellar documentation. Adding this section closes the gap and gives a direct pointer to the RFC.

## Related

- https://github.com/stellar/stellar-core/pull/5136
- https://github.com/stellar/rs-stellar-xdr/pull/495
