### PR TITLE
Fix wrong .wasm filename in Storage tutorial invoke commands

### DIFF
--- a/docs/build/smart-contracts/example-contracts/storage.mdx
+++ b/docs/build/smart-contracts/example-contracts/storage.mdx
@@ -229,7 +229,7 @@ stellar contract deploy `
 
 ```sh
 stellar contract invoke \
-    --wasm target/wasm32v1-none/release/soroban_events_contract.wasm \
+    --wasm target/wasm32v1-none/release/soroban_increment_contract.wasm \
     --id 1 \
     -- \
     increment
@@ -240,7 +240,7 @@ stellar contract invoke \
 
 ```powershell
 stellar contract invoke `
-    --wasm target/wasm32v1-none/release/soroban_events_contract.wasm `
+    --wasm target/wasm32v1-none/release/soroban_increment_contract.wasm `
     --id 1 `
     -- `
     increment


### PR DESCRIPTION
The invoke examples referenced soroban_events_contract.wasm instead of soroban_increment_contract.wasm.