### PR TITLE
Add gold layer token transfers data dictionary

### DIFF
--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/token-transfer.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/token-transfer.mdx
@@ -1,0 +1,40 @@
+---
+title: Token Transfers
+sidebar_position: 80
+description: ""
+---
+
+<div className="scoped-data-dictionary-table">
+
+## Table Metadata
+
+| Property | Configuration |
+| --- | --- |
+| Natural Key(s) | N/A |
+| Partition Field(s) | closed_at (DAY partition) |
+| Clustered Field(s) | contract_id, asset |
+| Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.dbt_szwise_sdf_marts.token_transfers) |
+
+## Column Details
+
+| Name | Description | Data Type | Domain Values | Required? | Notes |
+| --- | --- | --- | --- | --- | --- |
+| transaction_hash | A hex-encoded SHA-256 hash of this transaction's XDR-encoded form. | STRING |  | Yes |  |
+| transaction_id | A unique identifier for this transaction. | INTEGER |  | Yes |  |
+| operation_id | A unique identifier for this operation. | INTEGER |  | No |  |
+| event_topic | The action type applied to the token. | STRING |  | Yes |  |
+| from | The source address for the token transfer event amount. | STRING |  | No |  |
+| to | The destination address for the token transfer event amount. | STRING |  | No |  |
+| asset | ID field for the asset code/issuer pair. It is created by concatenating the asset code, ':' and asset_issuer fields. | STRING |  | Yes |  |
+| asset_type | The identifier for type of asset code, can be an alphanumeric with 4 characters, 12 characters or the native asset to the network (XLM). | STRING |  | Yes |  |
+| asset_code | The 4 or 12 character code representation of the asset on the network. | STRING |  | No |  |
+| asset_issuer | The account address of the original asset issuer that created the asset. | STRING |  | No |  |
+| amount | The normalized float amount of the asset. | FLOAT |  | Yes |  |
+| amount_raw | The raw stroop amount of the asset. | STRING |  | Yes |  |
+| contract_id | Soroban contract id. | STRING |  | Yes |  |
+| to_muxed | The multiplexed strkey representation of the `to` address. | STRING |  | No |  |
+| to_muxed_id | The multiplexed ID used to generate the multiplexed strkey representation of the `to` address. | STRING |  | No |  |
+| closed_at | Timestamp in UTC when this ledger closed and committed to the network. Ledgers are expected to close ~every 5 seconds. | TIMESTAMP |  | Yes |  |
+| ledger_sequence | The sequence number of this ledger. It represents the order of the ledger within the Stellar blockchain. Each ledger has a unique sequence number that increments with every new ledger, ensuring that ledgers are processed in the correct order. | INTEGER |  | Yes |  |
+
+</div>


### PR DESCRIPTION
## Summary
- Adds `token-transfer.mdx` to the gold layer data dictionary for `dev-hubble.dbt_szwise_sdf_marts.token_transfers`
- Documents all columns including transaction identifiers, event info, asset fields, amounts, contract ID, muxed address fields, and ledger metadata

## Test plan
- [ ] Verify the new page renders correctly in the docs site
- [ ] Confirm dbt docs link points to the correct model

🤖 Generated with [Claude Code](https://claude.com/claude-code)