### PR TITLE
Add data catalog entry for token_transfers gold table

### DIFF
--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/token-transfer.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/token-transfer.mdx
@@ -1,0 +1,43 @@
+---
+title: Token Transfers
+sidebar_position: 80
+description: ""
+---
+
+<div className="scoped-data-dictionary-table">
+
+## Table Metadata
+
+| Property | Configuration |
+| --- | --- |
+| Natural Key(s) | unique_key |
+| Partition Field(s) | closed_at (MONTH partition) |
+| Clustered Field(s) | N/A |
+| Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.token_transfers) |
+
+## Column Details
+
+| Name | Description | Data Type | Domain Values | Required? | Notes |
+| --- | --- | --- | --- | --- | --- |
+| transaction_hash | A hex-encoded SHA-256 hash of this transaction's XDR-encoded form. | STRING |  | Yes |  |
+| transaction_id | A unique identifier for this transaction. | INTEGER |  | Yes |  |
+| operation_id | Unique identifier for an operation. The operation id is the transaction id + order number. | INTEGER |  | No | Null for fee events, which are emitted at the transaction grain rather than the operation grain |
+| event_topic | The action type applied to the token. | STRING | transfer, mint, burn, clawback, fee | Yes |  |
+| event_type | The operation type that caused the event to be emitted. Check [history-operations](https://developers.stellar.org/docs/data/analytics/hubble/data-catalog/data-dictionary/history-operations#column-details) to get list of operation types. | STRING |  | No |  |
+| from | The source address for the token transfer event amount. The address is the account's public key encoded in base32. All account addresses start with a `G`. | STRING |  | No | Null for mint events where tokens are created without a sender |
+| to | The destination address for the token transfer event amount. The address is the account's public key encoded in base32. All account addresses start with a `G`. | STRING |  | No | Null for burn events where tokens are destroyed without a recipient |
+| asset | The string concatenation of (asset_type, asset_code, asset_issuer). The value of this is 'native' for the native asset/XLM. | STRING |  | Yes |  |
+| asset_type | The identifier for type of asset code, can be an alphanumeric with 4 characters, 12 characters or the native asset to the network, XLM. | STRING |  | Yes | XLM is the native asset to the network. XLM has no asset code or issuer representation and will instead be displayed with an asset type of 'native' |
+| asset_code | The 4 or 12 character code representation of the asset on the network. | STRING |  | No | Asset codes have no guarantees of uniqueness. The combination of asset code, issuer and type represents a distinct asset |
+| asset_issuer | The account address of the original asset issuer that created the asset. | STRING |  | No |  |
+| amount | The float amount of the token calculated by the amount_raw / 10^7. For Soroban contract tokens with custom decimal precision, the decimal metadata is applied instead. | FLOAT |  | Yes |  |
+| amount_raw | The raw number of stroops (smallest non-zero amount unit) of the token. A single stroop is 10^-7 of a single token. | STRING |  | Yes | Data type is string. Fee events can have negative values in the case of a refund; the final net fee paid will always be positive |
+| contract_id | The Soroban contract id associated with the token transfer event. | STRING |  | Yes |  |
+| ledger_sequence | The sequence number of this ledger. It represents the order of the ledger within the Stellar blockchain. Each ledger has a unique sequence number that increments with every new ledger, ensuring that ledgers are processed in the correct order. | INTEGER |  | Yes |  |
+| closed_at | Timestamp in UTC when this ledger closed and committed to the network. Ledgers are expected to close ~every 5 seconds. | TIMESTAMP |  | Yes |  |
+| to_muxed | The multiplexed strkey representation of the `to` address. | STRING |  | No | Only populated when the destination account is a multiplexed account |
+| to_muxed_id | The multiplexed ID used to generate the multiplexed strkey representation of the `to` address. | INTEGER |  | No | Only populated when the destination account is a multiplexed account |
+| is_soroban | Indicates whether the event was executed out of the Soroban smart contract environment (true) or the classic environment (false). | BOOLEAN |  | Yes |  |
+| unique_key | The sha256 of the concatenation of transaction_hash, operation_id, contract_id, to, to_muxed, from, and event_topic for token transfer events. | BYTES |  | Yes |  |
+
+</div>


### PR DESCRIPTION
## Summary
- Adds data dictionary documentation for `dev-hubble.dbt_szwise_sdf_marts.token_transfers` at `docs/data/analytics/hubble/data-catalog/data-dictionary/gold/token-transfer.mdx`
- Documents all 20 columns with descriptions, data types, domain values, required flags, and relevant notes
- Follows the existing MDX format used by other gold-layer data catalog files (e.g., `trade-agg.mdx`, `asset-balances-daily-agg.mdx`)

## Test plan
- [ ] Verify the MDX renders correctly in the Docusaurus site
- [ ] Confirm column descriptions match the dbt model definitions in `stellar-dbt`
- [ ] Confirm sidebar navigation shows the new page under the Gold section

🤖 Generated with [Claude Code](https://claude.com/claude-code)