### PR TITLE
Add bug bounty opt-out notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,7 @@ export const CODE_LANGS = {
 [prism]: https://github.com/FormidableLabs/prism-react-renderer
 [open-in-github-codespaces]: https://github.com/codespaces/new?repo=stellar/stellar-docs&editor=web
 [open-in-code-anywhere]: https://app.codeanywhere.com/#https://github.com/stellar/stellar-docs
+
+---
+
+> **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.


### PR DESCRIPTION
Adds a note that this repo is not in scope for the SDF bug bounty program.