### PR TITLE
Fix command for configuring testing apt repo

### DIFF
--- a/docs/validators/admin-guide/installation.mdx
+++ b/docs/validators/admin-guide/installation.mdx
@@ -41,7 +41,7 @@ echo "deb [signed-by=/etc/apt/keyrings/SDF.asc] https://apt.stellar.org $(lsb_re
 Optionally you can add testing repository. This is not recommended for production systems but may be useful for non-production systems using testnet:
 
 ```bash
-echo "deb [signed-by=/etc/apt/keyrings/SDF.asc] https://apt.stellar.org $(lsb_release -cs) stable" | sudo tee -a /etc/apt/sources.list.d/SDF.list
+echo "deb [signed-by=/etc/apt/keyrings/SDF.asc] https://apt.stellar.org $(lsb_release -cs) stable testing" | sudo tee -a /etc/apt/sources.list.d/SDF.list
 ```
 
 ### Install packages


### PR DESCRIPTION
Fixes the command for configuring the SDF apt testing repo (note pre-fix that the command was identical to the non-testing repo)