### PR TITLE
Testnet reset dates updated

### DIFF
--- a/docs/networks/README.mdx
+++ b/docs/networks/README.mdx
@@ -59,7 +59,7 @@ Testnet and Futurenet are reset periodically to the genesis ledger to declutter 
 
 Futurenet resets are on a less regular cadence than Testnet resets and don't have a set schedule.
 
-Testnet resets typically happen 2-4 times per year at 17:00 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](http://dashboard.stellar.org/) and through several developer community channels.
+Testnet resets typically happen 2-4 times per year at 17:00 UTC and are announced at least two weeks in advance on the [Stellar Dashboard](https://dashboard.stellar.org/) and through several developer community channels.
 
 Here are the scheduled 2026 dates:
 


### PR DESCRIPTION
The dates are updated to reflect the current intention of changing the testnet reset schedule. The March 18 reset has been cancelled, and we might move to a bi-annual reset.