### PR TITLE
Update x402 page with Coinbase facilitator and demo source code

### DIFF
--- a/docs/build/apps/x402.mdx
+++ b/docs/build/apps/x402.mdx
@@ -28,22 +28,32 @@ Freighter Mobile does not currently support x402; use the Freighter browser exte
 
 :::
 
-## x402 Facilitator
+## x402 Facilitators
 
-The [OpenZeppelin Relayer x402 Plugin for x402](https://github.com/OpenZeppelin/relayer-plugin-x402-facilitator) implements the x402 Facilitator API so you can serve x402 payments directly from a Relayer instance. The x402 Facilitator leverages the OpenZeppelin Relayer Framework. It works with the [Coinbase x402](https://github.com/coinbase/x402) ecosystem and exposes the expected `/verify`, `/settle`, and `/supported` endpoints under the Relayer plugin router.
+A facilitator is a server that verifies and settles x402 payments on behalf of resource servers. Two facilitator options are available for Stellar.
 
-### How to Use
+### Coinbase x402 Facilitator
+
+The [Coinbase x402 facilitator](https://www.x402.org/) is active for Stellar on testnet with sponsored fees enabled. You can check the currently supported networks and configuration at the [facilitator supported endpoint](https://www.x402.org/facilitator/supported).
+
+To use the Coinbase facilitator on testnet, set your facilitator URL to: `https://www.x402.org/facilitator`
+
+### OpenZeppelin Relayer x402 Plugin
+
+The [OpenZeppelin Relayer x402 Plugin](https://github.com/OpenZeppelin/relayer-plugin-x402-facilitator) implements the x402 Facilitator API so you can serve x402 payments directly from a Relayer instance. The x402 Facilitator leverages the OpenZeppelin Relayer Framework. It works with the [Coinbase x402](https://github.com/coinbase/x402) ecosystem and exposes the expected `/verify`, `/settle`, and `/supported` endpoints under the Relayer plugin router.
+
+#### How to Use
 
 The x402 facilitator Service is now live on Testnet and Mainnet. Under the hood, the plugin leverages OpenZeppelin Channels to submit transactions onchain via a managed Relayer and Facilitator setup.
 
-#### Testnet
+##### Testnet
 
 To use the facilitator on testnet, you will need:
 
 - An API Key (Relayer Service). Generate your testnet API key here: https://channels.openzeppelin.com/testnet/gen
 - Facilitator URL. Use the following facilitator endpoint in your configuration: `https://channels.openzeppelin.com/x402/testnet`
 
-#### Mainnet
+##### Mainnet
 
 To use the Facilitator on mainnet, you will need:
 
@@ -58,6 +68,7 @@ This version supports x402 v2 specification. For x402 v1 support, please use a p
 
 ## Resources
 
+- **x402 Stellar Demo** — A monorepo containing a facilitator service, paywall server, and React client demonstrating the x402 payment flow on Stellar. Includes high-throughput mode with channel accounts for parallel transaction submission. [View on GitHub](https://github.com/stellar/x402-stellar)
 - **x402 Starter Template** — A starter template for building payment-enabled applications with x402. Simplified scaffolding demonstrating x402 payment protocol integration with browser wallet support; use it as a foundation for micropayment-enabled services, SaaS applications, or any project that needs frictionless web payments. [View on GitHub](https://github.com/ElliotFriend/x402/tree/stellar-browser-wallet-example/examples/typescript/fullstack/browser-wallet-example)
 - **Economic Load Balancer** — An intelligent multi-chain payment router that automatically selects the most cost-efficient network for high-frequency AI agent micropayments. [View on GitHub](https://github.com/marcelosalloum/x402/tree/x402-hackathon)
 
@@ -71,7 +82,7 @@ This version supports x402 v2 specification. For x402 v1 support, please use a p
 
 ## Learn more
 
-- [x402 Demo](https://stellar.org/x402-demo) — A demo site for an x402 transaction on Stellar
+- [x402 Demo](https://stellar.org/x402-demo) — A demo site for an x402 transaction on Stellar ([source code](https://github.com/stellar/x402-stellar))
 - [x402 protocol (Coinbase Developer Platform)](https://docs.cdp.coinbase.com/x402) — Official x402 protocol overview and spec
 - [x402 protocol specification](https://www.x402.org/) — x402 Specification and Whitepaper
 - [Coinbase x402 GitHub](https://github.com/coinbase/x402) — Official x402 Protocol GitHub Repo


### PR DESCRIPTION
## Summary
- Add Coinbase x402 facilitator info (active on Stellar testnet with sponsored fees) and link to the [supported endpoint](https://www.x402.org/facilitator/supported)
- Add [x402-stellar demo source code](https://github.com/stellar/x402-stellar) to Resources and Learn more sections
- Restructure the Facilitators section to cover both Coinbase and OpenZeppelin options

## Test plan
- [ ] Verify all new links resolve correctly
- [ ] Confirm page renders properly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)