### PR TITLE
Fix typo: Galaxie -> Galexie

### DIFF
--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend.mdx
@@ -3,7 +3,7 @@ title: BufferedStorageBackend
 sidebar_position: 5
 ---
 
-[BufferedStorageBackend](https://github.com/stellar/go-stellar-sdk/blob/main/ingest/ledgerbackend/buffered_storage_backend.go) is a ledger backend in Stellar [ingest SDK](https://github.com/stellar/go-stellar-sdk/tree/main/ingest) that retrieves ledger metadata from a cloud-based data lake, typically populated by [Galexie](../../../galexie/README.mdx). While Galaxie currently supports only [GCS](../../../galexie/admin_guide/configuring.mdx), `BufferedStorageBackend` is designed to work with any datastore that implements the [datastore interface](https://github.com/stellar/go-stellar-sdk/blob/main/support/datastore/datastore.go). It returns ledger metadata in [XDR](../../../../../../learn/fundamentals/data-format/xdr.mdx) format.
+[BufferedStorageBackend](https://github.com/stellar/go-stellar-sdk/blob/main/ingest/ledgerbackend/buffered_storage_backend.go) is a ledger backend in Stellar [ingest SDK](https://github.com/stellar/go-stellar-sdk/tree/main/ingest) that retrieves ledger metadata from a cloud-based data lake, typically populated by [Galexie](../../../galexie/README.mdx). While Galexie currently supports only [GCS](../../../galexie/admin_guide/configuring.mdx), `BufferedStorageBackend` is designed to work with any datastore that implements the [datastore interface](https://github.com/stellar/go-stellar-sdk/blob/main/support/datastore/datastore.go). It returns ledger metadata in [XDR](../../../../../../learn/fundamentals/data-format/xdr.mdx) format.
 
 ![](/assets/ingest-sdk/bufferedstoragebackend_architecture.png)
 
@@ -18,9 +18,9 @@ sidebar_position: 5
 
 ### Installation & Setup
 
-- Run Galaxie to export ledger data to GCS cloud storage. Follow the [Galaxie admin guide](../../../galexie/README.mdx) for instructions on running Galaxie.
+- Run Galexie to export ledger data to GCS cloud storage. Follow the [Galexie admin guide](../../../galexie/README.mdx) for instructions on running Galexie.
 
-- For purposes of the example code, ensure access to a data lake populated by Galaxie, configured as a GCS bucket. For instructions on creating a data lake, refer to the [Galaxie admin guide](../../../galexie/README.mdx).
+- For purposes of the example code, ensure access to a data lake populated by Galexie, configured as a GCS bucket. For instructions on creating a data lake, refer to the [Galexie admin guide](../../../galexie/README.mdx).
 
 ## Configuration
 


### PR DESCRIPTION
I noticed `Gal*e*xie` was spelled as `Gal*a*xie` in a few places.