### PR TITLE
Add Alchemy as a new RPC provider

### DIFF
--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -22,7 +22,7 @@ These providers allow access to the Futurenet, Testnet and Mainnet network.
 | [Lightsail Network - Quasar\*](https://quasar.lightsail.network/) | ❌ | ❌ | ✅ | ❌ | ✅ |
 | [Uniblock](https://www.uniblock.dev/) | ❌ | ✅ | ✅ | ❌ | ❌ |
 | [Exaion](https://crypto.exaion.com) | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Alchemy](https://www.alchemy.com/) | ❌ | ✅ | ✅ | ✅ | ❌ |
+| [Alchemy](https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=stellar) | ❌ | ✅ | ✅ | ✅ | ❌ |
 
 \*_RPC Archive is a new option for those looking to retrieve full ledger history. Currently only the [getLedgers](./api-reference/methods/getLedgers.mdx) RPC method supports this feature. You can choose one of the providers above, or create your own getLedgers archive by following [these steps](./admin-guide/data-lake-integration.mdx)._
 


### PR DESCRIPTION
Alchemy is live with their RPC node service. Adding to the provider list