### PR TITLE
Updating fee_pool docs to accurately represent what the value is

### DIFF
--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/bronze/history-ledgers.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/bronze/history-ledgers.mdx
@@ -27,7 +27,7 @@ description: ""
 | closed_at | Timestamp in UTC when this ledger closed and committed to the network. Ledgers are expected to close ~every 5 seconds | timestamp |  | Yes |  |
 | id | Unique identifier for the ledger | integer |  | Yes |  |
 | total_coins | Total number of lumens in circulation | integer |  | Yes |  |
-| fee_pool | The sum of all transaction fees | integer |  | Yes |  |
+| fee_pool | The cumulative sum of all transaction fees (in stroops) ever collected by the network as of this ledger's close. This is a running balance stored in the ledger header, not the fees for a single ledger. | integer |  | Yes |  |
 | base_fee | The fee (in stroops) the network charges per operation in a transaction for the given ledger. The minimum base fee is 100, with the ability to increase if transaction demand exceeds ledger capacity. When this occurs, the ledger enters surge pricing | integer |  | Yes | The stroop is the fractional representation of a lumen (XLM). 1 stroop is 0.0000001 XLM. |
 | base_reserve | The reserve (in stroops) the network requires an account to retain as a minimum balance in order to be a valid account on the network. The current minimum reserve is 10 XLM | integer | 5000000 100000000 | Yes | The stroop is the fractional representation of a lumen (XLM). 1 stroop is 0.0000001 XLM. |
 | max_tx_set_size | The maximum number of operations that Stellar validator nodes have agreed to process in a given ledger. Since Protocol 11, ledger capacity has been measured in operations rather than transactions | integer | 50 - original max 500 1000 - current max | Yes |  |

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/daily-fee-stats-agg.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/daily-fee-stats-agg.mdx
@@ -77,7 +77,7 @@ description: ""
 | soroban_total_surge_operation_count | Total operations in Soroban transactions that experienced surge pricing across all ledgers for the day. | INTEGER |  | No |  |
 | soroban_pct_ledgers_in_surge | Percentage of Soroban-containing ledgers that experienced surge pricing for the day. Calculated as 100 \* soroban_surge_ledger_count / soroban_total_ledgers. | FLOAT |  | No |  |
 | total_pct_ledgers_in_surge | Percentage of all ledgers for the day where at least one transaction (Classic or Soroban) experienced surge pricing. | FLOAT |  | No |  |
-| fee_pool | Sum of fee_pool across all ledgers for the day. Represents all fees collected across the network for the day. | INTEGER |  | No |  |
+| fee_pool | The cumulative fee pool balance (in stroops) at the end of the day, taken from the last ledger that closed on that day. This is a running total of all transaction fees ever collected by the network, not the fees for a single day. To see daily fees collected, use total_fee_charged instead. | INTEGER |  | No |  |
 | airflow_start_ts | Timestamp when the Airflow DAG run started. Used for pipeline metadata and debugging. | STRING |  | No |  |
 
 </div>

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/ledger-fee-stats-agg.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/ledger-fee-stats-agg.mdx
@@ -71,7 +71,7 @@ description: ""
 | soroban_surge_operation_count | Total operations in Soroban transactions that experienced surge pricing in the ledger. | INTEGER |  | No |  |
 | soroban_is_surge_ledger | True if any Soroban transaction in the ledger experienced surge pricing. | BOOLEAN |  | No |  |
 | closed_at | Timestamp in UTC when the ledger closed and was committed to the network. Sourced from history_ledgers. | TIMESTAMP |  | No |  |
-| fee_pool | The total fee pool for the ledger, sourced from history_ledgers. | INTEGER |  | No |  |
+| fee_pool | The cumulative fee pool balance (in stroops) as of this ledger's close, sourced from history_ledgers. This is a running total of all transaction fees ever collected by the network, not the fees for this individual ledger. | INTEGER |  | No |  |
 | airflow_start_ts | Timestamp when the Airflow DAG run started. Used for pipeline metadata and debugging. | STRING |  | No |  |
 
 </div>


### PR DESCRIPTION
Updated the fee_pool column descriptions in three Hubble data dictionary pages (history-ledgers, ledger-fee-stats-agg, daily-fee-stats-agg) to clarify that fee_pool is a cumulative running total, not a          
  per-ledger or per-day amount. This aligns the public docs with the model fix in stellar-dbt-public.