### PR TITLE
fix: replace deprecated --id flag in stellar contract deploy (cross-contract-call example)

### DIFF
--- a/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
+++ b/docs/build/smart-contracts/example-contracts/cross-contract-call.mdx
@@ -296,7 +296,7 @@ stellar contract deploy `
 </TabItem>
 </Tabs>
 
-Invoke Contract B's `add_with` function, passing in values for `x` and `y` (e.g. as `5` and `7`), and then pass in the contract ID of Contract A.
+Invoke Contract B's `add_with` function, passing in values for `x` and `y` (e.g. as `5` and `7`), and then pass in the contract ID or alias of Contract A.
 
 <Tabs groupId="platform" defaultValue={getPlatform()}>
 <TabItem value="unix" label="macOS/Linux">


### PR DESCRIPTION
The `cross-contract-call` example was using the deprecated `--id` flag with `stellar contract deploy`, which was removed in CLI v20.0.0-rc.4.1 (October 2023). Running those commands on any current CLI version produces:

error: unexpected argument '--id' found

This PR:
- Replaces `--id a/b` with `--alias cross_contract_a_example` / `--alias cross_contract_b_example` in both deploy commands (bash + PowerShell tabs)
- Updates the downstream `invoke` command to reference the new alias names in both `--id` and `--contract` arguments  - Adds `--source-account alice --network testnet` flags for consistency with other example docs

Closes #2339
Related: #2220