### PR TITLE
fix(overview): update deprecated commands and wrong packages

### DIFF
--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -266,7 +266,7 @@ Next up, we'll look at how we register a user and create their account on the St
 [daisyui]: https://daisyui.com
 [tailwind css]: https://tailwindcss.com
 [`@stellar/stellar-sdk`]: https://www.npmjs.com/package/@stellar/stellar-sdk
-[`@stellar/typescript-wallet-sdk-km`]: https://github.com/stellar/typescript-wallet-sdk
+[`@stellar/typescript-wallet-sdk-km`]: https://www.npmjs.com/package/@stellar/typescript-wallet-sdk-km
 [cloudflare pages]: https://pages.cloudflare.com/
 [stellar lab]: https://lab.stellar.org
 [testnet toml file]: https://testanchor.stellar.org/.well-known/stellar.toml


### PR DESCRIPTION
- Replace `npm create svelte@latest` with `npx sv create` (create-svelte is deprecated)
- Pin tailwindcss to v3 to prevent breakage with v4 (init -p was removed in v4)
- Replace deprecated `stellar-sdk` with `@stellar/stellar-sdk`
- Replace `@stellar/wallet-sdk` with `@stellar/typescript-wallet-sdk-km` (wrong package, different API)
- Update vite.config.js noExternal to reflect packages from basicpay a25cc81 (Oct 2024)
- Replace dead `js-stellar-wallets` reference (archived repo, not on npm) with `@stellar/typescript-wallet-sdk-km`