### PR TITLE
fix(account-creation): update wallet SDK package, imports

### DIFF
--- a/docs/build/apps/example-application-tutorial/account-creation.mdx
+++ b/docs/build/apps/example-application-tutorial/account-creation.mdx
@@ -17,7 +17,7 @@ Since we are building a [non-custodial application], the encrypted secret key wi
 
 ![public and private keys](/assets/basic-pay/public-and-private-keys.png)
 
-Next, we'll trigger the user to submit a pincode to encrypt their secret key before it gets saved to their browser's `localStorage` (this is handled by the [`js-stellar-wallets` SDK]). The user will need to remember their pincode for future logins and to submit transactions.
+Next, we'll trigger the user to submit a pincode to encrypt their secret key before it gets saved to their browser's `localStorage` (this is handled by the [`@stellar/typescript-wallet-sdk-km`]). The user will need to remember their pincode for future logins and to submit transactions.
 
 With BasicPay, when the user clicks the “Signup” button, they will be asked to confirm their pincode. When they do, the `create_account` operation is triggered, and the user's account is automatically funded with XLM for the minimum balance (starting with 10,000 XLM).
 
@@ -27,7 +27,7 @@ When you're ready to move the application to Pubnet, accounts will need to be fu
 
 ## Code implementation
 
-We will create a Svelte `store` to interact with our user's randomly generated keypair. The store will take advantage of some of the `js-stellar-wallets` SDK to encrypt/decrypt the keypair, as well as sign transactions.
+We will create a Svelte `store` to interact with our user's randomly generated keypair. The store will take advantage of [`@stellar/typescript-wallet-sdk-km`] to encrypt/decrypt the keypair, as well as sign transactions.
 
 ### Creating the `walletStore` store
 
@@ -39,8 +39,8 @@ Our `walletStore` will make a few things possible throughout our application.
 
 ```js title="/src/lib/stores/walletStore.js"
 import { persisted } from "svelte-local-storage-store";
-import { KeyManager, KeyManagerPlugins, KeyType } from "@stellar/wallet-sdk";
-import { TransactionBuilder } from "stellar-sdk";
+import { KeyManager, LocalStorageKeyStore, ScryptEncrypter, KeyType } from "@stellar/typescript-wallet-sdk-km";
+import { TransactionBuilder } from "@stellar/stellar-sdk";
 import { error } from "@sveltejs/kit";
 import { get } from "svelte/store";
 
@@ -74,7 +74,7 @@ function createWalletStore() {
             privateKey: secretKey,
           },
           password: pincode,
-          encrypterName: KeyManagerPlugins.ScryptEncrypter.name,
+          encrypterName: ScryptEncrypter.name,
         });
 
         // Set the `walletStore` fields for the `keyId` and `publicKey`
@@ -95,7 +95,7 @@ function createWalletStore() {
     },
 
     // Compares a submitted pincode to make sure it is valid for the stored, encrypted keypair.
-    confirmCorrectPincode: async ({
+    confirmPincode: async ({
       pincode,
       firstPincode = "",
       signup = false,
@@ -147,7 +147,7 @@ export const walletStore = createWalletStore();
 // Configure a `KeyManager` for use with stored keypairs.
 const setupKeyManager = () => {
   // We make a new `KeyStore`
-  const localKeyStore = new KeyManagerPlugins.LocalStorageKeyStore();
+  const localKeyStore = new LocalStorageKeyStore();
 
   // Configure it to use `localStorage` and specify a(n optional) prefix
   localKeyStore.configure({
@@ -161,7 +161,7 @@ const setupKeyManager = () => {
   });
 
   // Configure the `KeyManager` to use the `scrypt` encrypter
-  keyManager.registerEncrypter(KeyManagerPlugins.ScryptEncrypter);
+  keyManager.registerEncrypter(ScryptEncrypter);
 
   // Return the `KeyManager` for use in other functions
   return keyManager;
@@ -190,6 +190,6 @@ Our `walletStore` is used in a ton of places in our application, especially in t
 
 [accounts section]: ../../../learn/fundamentals/stellar-data-structures/accounts.mdx
 [non-custodial application]: ../application-design-considerations.mdx#non-custodial-service
-[`js-stellar-wallets` sdk]: https://github.com/stellar/js-stellar-wallets
+[`@stellar/typescript-wallet-sdk-km`]: https://www.npmjs.com/package/@stellar/typescript-wallet-sdk-km
 [sponsored reserves]: ../../guides/transactions/sponsored-reserves.mdx
 [contacts list]: ./contacts-list

--- a/docs/build/apps/example-application-tutorial/account-creation.mdx
+++ b/docs/build/apps/example-application-tutorial/account-creation.mdx
@@ -39,7 +39,12 @@ Our `walletStore` will make a few things possible throughout our application.
 
 ```js title="/src/lib/stores/walletStore.js"
 import { persisted } from "svelte-local-storage-store";
-import { KeyManager, LocalStorageKeyStore, ScryptEncrypter, KeyType } from "@stellar/typescript-wallet-sdk-km";
+import {
+  KeyManager,
+  LocalStorageKeyStore,
+  ScryptEncrypter,
+  KeyType,
+} from "@stellar/typescript-wallet-sdk-km";
 import { TransactionBuilder } from "@stellar/stellar-sdk";
 import { error } from "@sveltejs/kit";
 import { get } from "svelte/store";
@@ -95,11 +100,7 @@ function createWalletStore() {
     },
 
     // Compares a submitted pincode to make sure it is valid for the stored, encrypted keypair.
-    confirmPincode: async ({
-      pincode,
-      firstPincode = "",
-      signup = false,
-    }) => {
+    confirmPincode: async ({ pincode, firstPincode = "", signup = false }) => {
       // If we are not signing up, make sure the submitted pincode successfully
       // decrypts and loads the stored keypair.
       if (!signup) {


### PR DESCRIPTION
Three issues on the Account Creation page introduced when the BasicPay repo was updated in October 2024 (commit `a25cc81`) but the docs were never updated to match.

## Changes

### Wrong wallet SDK package and API

The tutorial imported from `@stellar/wallet-sdk` using the old `KeyManagerPlugins.*` namespace. The repo uses `@stellar/typescript-wallet-sdk-km`, where `LocalStorageKeyStore` and `ScryptEncrypter` are top-level named exports. Updated the import and all three usages:

- `KeyManagerPlugins.LocalStorageKeyStore`
- `KeyManagerPlugins.ScryptEncrypter.name`
- `KeyManagerPlugins.ScryptEncrypter` in `registerEncrypter`

### Deprecated `stellar-sdk` import

`import { TransactionBuilder } from "stellar-sdk"` updated to `@stellar/stellar-sdk`.


### `confirmCorrectPincode` renamed to `confirmPincode`

The method was renamed in the repo in the same October 2024 update. The old name would throw a runtime error.

Also replaced two prose references and the dead link to the archived `js-stellar-wallets` repo with `@stellar/typescript-wallet-sdk-km` pointing to npm.

## Relevant File

`docs/build/apps/example-application-tutorial/account-creation.mdx`