### PR TITLE
fix(overview): update deprecated commands and wrong packages

### DIFF
--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -266,7 +266,7 @@ Next up, we'll look at how we register a user and create their account on the St
 [daisyui]: https://daisyui.com
 [tailwind css]: https://tailwindcss.com
 [`@stellar/stellar-sdk`]: https://www.npmjs.com/package/@stellar/stellar-sdk
-[`@stellar/typescript-wallet-sdk-km`]: https://github.com/stellar/typescript-wallet-sdk
+[`@stellar/typescript-wallet-sdk-km`]: https://www.npmjs.com/package/@stellar/typescript-wallet-sdk-km
 [cloudflare pages]: https://pages.cloudflare.com/
 [stellar lab]: https://lab.stellar.org
 [testnet toml file]: https://testanchor.stellar.org/.well-known/stellar.toml

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -265,7 +265,7 @@ Next up, we'll look at how we register a user and create their account on the St
 [sveltekit]: https://kit.svelte.dev
 [daisyui]: https://daisyui.com
 [tailwind css]: https://tailwindcss.com
-[`@stellar/stellar-sdk`]: https://github.com/stellar/js-stellar-sdk
+[`@stellar/stellar-sdk`]: https://www.npmjs.com/package/@stellar/stellar-sdk
 [`@stellar/typescript-wallet-sdk-km`]: https://github.com/stellar/typescript-wallet-sdk
 [cloudflare pages]: https://pages.cloudflare.com/
 [stellar lab]: https://lab.stellar.org

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -195,6 +195,8 @@ To work with the Stellar network, datastructures, and locally stored keypairs, w
 ```bash npm2yarn
 # Stellar SDKs
 npm install --save-dev @stellar/stellar-sdk @stellar/typescript-wallet-sdk-km
+# Wallet integration packages (required for vite.config.js SSR bundling)
+npm install --save-dev @creit.tech/stellar-wallets-kit @stellar/freighter-api @lobstrco/signer-extension-api
 # We will need some polyfills to make things available client-side
 npm install --save-dev @esbuild-plugins/node-globals-polyfill @esbuild-plugins/node-modules-polyfill \
     path @rollup/plugin-inject buffer svelte-local-storage-store uuid

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -28,7 +28,7 @@ To build a basic Stellar application, you'll need:
 - Application framework: we're using [SvelteKit] opting for JavaScript with JSDoc typing. SvelteKit is quite flexible and could be used for a lot, but we are mainly using it for its routing capabilities to minimize this being a "SvelteKit tutorial".
 - Frontend framework: we're using [DaisyUI] to simplify the use of [Tailwind CSS].
 - A way to interact with the Stellar network: we're using the [`js-stellar-sdk`], but you could use traditional fetch requests. The [`js-stellar-sdk`] is also used for building transactions to submit to the Stellar network.
-- A way to interact with the user's keypair: we're using the [`js-stellar-wallets` SDK], but you can opt to use an existing wallet.
+- A way to interact with the user's keypair: we're using [`@stellar/typescript-wallet-sdk-km`], but you can opt to use an existing wallet.
 
 :::note
 
@@ -74,7 +74,7 @@ This part of the tutorial will need a large helping of "your mileage may vary." 
 The first thing we'll need to do is create a SvelteKit app, using `npm`, we are using v18.x of nodejs.
 
 ```bash
-npm create svelte@latest my-basic-payment-app
+npx sv create my-basic-payment-app
 ```
 
 This will walk you through the SvelteKit creation process, asking you about the various options. We've chosen the following options:
@@ -87,7 +87,7 @@ After this process, the scaffolding for your application will live inside the `m
 
 ```bash npm2yarn
 cd my-basic-payment-app
-npm install --save-dev svelte-preprocess tailwindcss autoprefixer postcss @sveltejs/adapter-static \
+npm install --save-dev svelte-preprocess tailwindcss@^3 autoprefixer postcss @sveltejs/adapter-static \
     @tailwindcss/typography \
     daisyui svelte-feather-icons
 ```
@@ -194,7 +194,7 @@ To work with the Stellar network, datastructures, and locally stored keypairs, w
 
 ```bash npm2yarn
 # Stellar SDKs
-npm install --save-dev stellar-sdk @stellar/wallet-sdk
+npm install --save-dev @stellar/stellar-sdk @stellar/typescript-wallet-sdk-km
 # We will need some polyfills to make things available client-side
 npm install --save-dev @esbuild-plugins/node-globals-polyfill @esbuild-plugins/node-modules-polyfill \
     path @rollup/plugin-inject buffer svelte-local-storage-store uuid
@@ -248,7 +248,11 @@ export default defineConfig({
     },
   },
   ssr: {
-    noExternal: ["@stellar/wallet-sdk", "@albedo-link/intent"],
+    noExternal: [
+      "@creit.tech/stellar-wallets-kit",
+      "@stellar/freighter-api",
+      "@lobstrco/signer-extension-api",
+    ],
   },
 });
 ```
@@ -262,7 +266,7 @@ Next up, we'll look at how we register a user and create their account on the St
 [daisyui]: https://daisyui.com
 [tailwind css]: https://tailwindcss.com
 [`js-stellar-sdk`]: https://github.com/stellar/js-stellar-sdk
-[`js-stellar-wallets` sdk]: https://github.com/stellar/js-stellar-wallets
+[`@stellar/typescript-wallet-sdk-km`]: https://github.com/stellar/typescript-wallet-sdk
 [cloudflare pages]: https://pages.cloudflare.com/
 [stellar lab]: https://lab.stellar.org
 [testnet toml file]: https://testanchor.stellar.org/.well-known/stellar.toml

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -5,7 +5,7 @@ sidebar_position: 10
 
 :::note
 
-This tutorial walks through how to build an application with the [`js-stellar-sdk`], to build with the Wallet SDK, please follow the [Build a Wallet tutorial](../wallet/overview.mdx). To build with smart contracts, navigate to the [Smart Contracts section](../../../build/smart-contracts/getting-started/setup.mdx).
+This tutorial walks through how to build an application with the [`@stellar/stellar-sdk`], to build with the Wallet SDK, please follow the [Build a Wallet tutorial](../wallet/overview.mdx). To build with smart contracts, navigate to the [Smart Contracts section](../../../build/smart-contracts/getting-started/setup.mdx).
 
 :::
 
@@ -27,7 +27,7 @@ To build a basic Stellar application, you'll need:
 
 - Application framework: we're using [SvelteKit] opting for JavaScript with JSDoc typing. SvelteKit is quite flexible and could be used for a lot, but we are mainly using it for its routing capabilities to minimize this being a "SvelteKit tutorial".
 - Frontend framework: we're using [DaisyUI] to simplify the use of [Tailwind CSS].
-- A way to interact with the Stellar network: we're using the [`js-stellar-sdk`], but you could use traditional fetch requests. The [`js-stellar-sdk`] is also used for building transactions to submit to the Stellar network.
+- A way to interact with the Stellar network: we're using the [`@stellar/stellar-sdk`], but you could use traditional fetch requests. The [`@stellar/stellar-sdk`] is also used for building transactions to submit to the Stellar network.
 - A way to interact with the user's keypair: we're using [`@stellar/typescript-wallet-sdk-km`], but you can opt to use an existing wallet.
 
 :::note
@@ -200,7 +200,7 @@ npm install --save-dev @esbuild-plugins/node-globals-polyfill @esbuild-plugins/n
     path @rollup/plugin-inject buffer svelte-local-storage-store uuid
 ```
 
-We will use a `window.js` file to inject Buffer into our client-side code, since that's required by some parts of the `stellar-sdk`.
+We will use a `window.js` file to inject Buffer into our client-side code, since that's required by some parts of the `@stellar/stellar-sdk`.
 
 ```js title="/src/lib/window.js"
 import { browser } from "$app/environment";
@@ -265,7 +265,7 @@ Next up, we'll look at how we register a user and create their account on the St
 [sveltekit]: https://kit.svelte.dev
 [daisyui]: https://daisyui.com
 [tailwind css]: https://tailwindcss.com
-[`js-stellar-sdk`]: https://github.com/stellar/js-stellar-sdk
+[`@stellar/stellar-sdk`]: https://github.com/stellar/js-stellar-sdk
 [`@stellar/typescript-wallet-sdk-km`]: https://github.com/stellar/typescript-wallet-sdk
 [cloudflare pages]: https://pages.cloudflare.com/
 [stellar lab]: https://lab.stellar.org

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -5,7 +5,7 @@ sidebar_position: 10
 
 :::note
 
-This tutorial walks through how to build an application with the [`@stellar/stellar-sdk`], to build with the Wallet SDK, please follow the [Build a Wallet tutorial](../wallet/overview.mdx). To build with smart contracts, navigate to the [Smart Contracts section](../../../build/smart-contracts/getting-started/setup.mdx).
+This tutorial walks through how to build an application with the [`@stellar/stellar-sdk`]. To build with the Wallet SDK, please follow the [Build a Wallet tutorial](../wallet/overview.mdx). To build with smart contracts, navigate to the [Smart Contracts section](../../../build/smart-contracts/getting-started/setup.mdx).
 
 :::
 

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -87,7 +87,7 @@ After this process, the scaffolding for your application will live inside the `m
 
 ```bash npm2yarn
 cd my-basic-payment-app
-npm install --save-dev svelte-preprocess tailwindcss@^3 autoprefixer postcss @sveltejs/adapter-static \
+npm install --save-dev svelte-preprocess tailwindcss@^3.4.13 autoprefixer postcss @sveltejs/adapter-static \
     @tailwindcss/typography \
     daisyui svelte-feather-icons
 ```
@@ -194,9 +194,9 @@ To work with the Stellar network, datastructures, and locally stored keypairs, w
 
 ```bash npm2yarn
 # Stellar SDKs
-npm install --save-dev @stellar/stellar-sdk @stellar/typescript-wallet-sdk-km
+npm install @stellar/stellar-sdk @stellar/typescript-wallet-sdk-km
 # Wallet integration packages (required for vite.config.js SSR bundling)
-npm install --save-dev @creit.tech/stellar-wallets-kit @stellar/freighter-api @lobstrco/signer-extension-api
+npm install @creit.tech/stellar-wallets-kit @stellar/freighter-api @lobstrco/signer-extension-api
 # We will need some polyfills to make things available client-side
 npm install --save-dev @esbuild-plugins/node-globals-polyfill @esbuild-plugins/node-modules-polyfill \
     path @rollup/plugin-inject buffer svelte-local-storage-store uuid


### PR DESCRIPTION
The Overview page of the BasicPay example application tutorial contains several broken setup instructions that cause developers to fail immediately. These stem from two root causes: the BasicPay repo was overhauled in October 2024 (commit \`a25cc81\`) and the docs were never updated to match, and upstream tools (Svelte CLI, Tailwind CSS) shipped breaking major versions with no version pinning in the tutorial.

### Changes

**\`npx sv create\` (was \`npm create svelte@latest\`)**
\`create-svelte\` is deprecated on npm and outputs a deprecation message instead of scaffolding. The replacement CLI is \`sv\`.

**\`tailwindcss@^3\` pin**
The tutorial installs \`tailwindcss\` without a version pin. Tailwind v4 (now the default) removed the \`init\` command entirely, breaking \`npx tailwindcss init -p\`. The BasicPay repo itself uses \`^3.4.13\`; the pin makes this explicit.

**\`@stellar/stellar-sdk\` (was \`stellar-sdk\`)**
\`stellar-sdk\` carries an npm deprecation warning pointing to \`@stellar/stellar-sdk\`. All prose references and links updated to use the npm package name.

**\`@stellar/typescript-wallet-sdk-km\` (was \`@stellar/wallet-sdk\`)**
\`@stellar/wallet-sdk\` is the wrong package — different API surface, last updated January 2024. The BasicPay repo uses \`@stellar/typescript-wallet-sdk-km\` (currently v2.0.0).

**\`vite.config.js\` \`noExternal\` entries**
Updated from \`["@stellar/wallet-sdk", "@albedo-link/intent"]\` to the packages the BasicPay repo actually ships after the October 2024 update: \`@creit.tech/stellar-wallets-kit\`, \`@stellar/freighter-api\`, \`@lobstrco/signer-extension-api\`. Albedo integration was dropped in that same update in favor of \`@creit.tech/stellar-wallets-kit\`.

**Dead \`js-stellar-wallets\` reference**
\`js-stellar-wallets\` does not exist on npm and links to an archived GitHub repo. Updated all references to \`@stellar/typescript-wallet-sdk-km\` pointing to npm.

### File changed
\`docs/build/apps/example-application-tutorial/overview.mdx\`

### Follow-up
The other tutorial pages (Account Creation, Querying Data, SEP-1, SEP-10) still reference the old packages and will be fixed in follow-up PRs.