### PR TITLE
fix(tutorial): update deprecated and renamed SDK APIs across querying-data, SEP-1, and SEP-10

### DIFF
--- a/docs/build/apps/example-application-tutorial/anchor-integration/sep1.mdx
+++ b/docs/build/apps/example-application-tutorial/anchor-integration/sep1.mdx
@@ -10,17 +10,17 @@ For anchors, we’re interested in the `CURRENCIES` they issue, the `TRANSFER_SE
 BasicPay is interoperating with the testing anchor located at `testanchor.stellar.org` and you can view its toml file [here](https://testanchor.stellar.org/.well-known/stellar.toml).
 
 ```js title=/src/lib/stellar/sep1.js
-import { StellarTomlResolver } from "stellar-sdk";
+import { StellarToml } from "@stellar/stellar-sdk";
 
 // Fetches and returns the stellar.toml file hosted by a provided domain.
 export async function fetchStellarToml(domain) {
-  let stellarToml = await StellarTomlResolver.resolve(domain);
+  let stellarToml = await StellarToml.Resolver.resolve(domain);
   return stellarToml;
 }
 ```
 
 **Source:** https://github.com/stellar/basic-payment-app/blob/main/src/lib/stellar/sep1.js
 
-Strictly speaking, the `StellarTomlResolver` function from the JavaScript SDK is the only function we _need_ to retrieve and use the information provided by the anchor (heck, we could even just write our own `fetch`-based function, and bypass the SDK altogether). However, we've created quite a few "helper" functions to make the rest of our queries a bit more verbose and clear as to what we're looking for from the anchor server. Make sure to check out the `sep1.js` source file linked above!
+Strictly speaking, the `StellarToml.Resolver` function from the JavaScript SDK is the only function we _need_ to retrieve and use the information provided by the anchor (heck, we could even just write our own `fetch`-based function, and bypass the SDK altogether). However, we've created quite a few "helper" functions to make the rest of our queries a bit more verbose and clear as to what we're looking for from the anchor server. Make sure to check out the `sep1.js` source file linked above!
 
 Using the `stellar.toml` information for an asset with a `home_domain`, we can display to the user some options (depending on the available infrastructure). We'll start with SEP-10 authentication.

--- a/docs/build/apps/example-application-tutorial/anchor-integration/sep1.mdx
+++ b/docs/build/apps/example-application-tutorial/anchor-integration/sep1.mdx
@@ -21,6 +21,6 @@ export async function fetchStellarToml(domain) {
 
 **Source:** https://github.com/stellar/basic-payment-app/blob/main/src/lib/stellar/sep1.js
 
-Strictly speaking, the `StellarToml.Resolver` function from the JavaScript SDK is the only function we _need_ to retrieve and use the information provided by the anchor (heck, we could even just write our own `fetch`-based function, and bypass the SDK altogether). However, we've created quite a few "helper" functions to make the rest of our queries a bit more verbose and clear as to what we're looking for from the anchor server. Make sure to check out the `sep1.js` source file linked above!
+Strictly speaking, `StellarToml.Resolver.resolve()` from the JavaScript SDK is the only call we _need_ to retrieve and use the information provided by the anchor (heck, we could even just write our own `fetch`-based function, and bypass the SDK altogether). However, we've created quite a few "helper" functions to make the rest of our queries a bit more verbose and clear as to what we're looking for from the anchor server. Make sure to check out the `sep1.js` source file linked above!
 
 Using the `stellar.toml` information for an asset with a `home_domain`, we can display to the user some options (depending on the available infrastructure). We'll start with SEP-10 authentication.

--- a/docs/build/apps/example-application-tutorial/anchor-integration/sep10.mdx
+++ b/docs/build/apps/example-application-tutorial/anchor-integration/sep10.mdx
@@ -114,7 +114,7 @@ Now, when the user clicks the "authenticate" button, it triggers the `auth` func
 As part of the `auth` function, BasicPay makes a `GET` request with an `account` param (the public key of the user) to the anchor, which sends back a Stellar transaction signed by the server's signing key (called a challenge transaction) with an invalid sequence number so it couldn't actually do anything if it were accidentally submitted to the network.
 
 ```js title=/src/lib/stellar/sep10.js
-import { Utils } from "stellar-sdk";
+import { WebAuth } from "@stellar/stellar-sdk";
 import { fetchStellarToml } from "$lib/stellar/sep1";
 
 // Requests, validates, and returns a SEP-10 challenge transaction from an anchor server.
@@ -125,7 +125,7 @@ export async function getChallengeTransaction({ publicKey, homeDomain }) {
   // In order for the SEP-10 flow to work, we must have at least a server
   // signing key, and a web auth endpoint (which can be the transfer server as
   // a fallback)
-  if (!WEB_AUTH_ENDPOINT || !TRANSFER_SERVER || !SIGNING_KEY) {
+  if (!(WEB_AUTH_ENDPOINT || TRANSFER_SERVER) || !SIGNING_KEY) {
     throw error(500, {
       message:
         "could not get challenge transaction (server missing toml entry or entries)",
@@ -169,7 +169,7 @@ function validateChallengeTransaction({
   try {
     // Use the `readChallengeTx` function from Stellar SDK to read and
     // verify most of the challenge transaction information
-    let results = Utils.readChallengeTx(
+    let results = WebAuth.readChallengeTx(
       transactionXDR,
       serverSigningKey,
       network,

--- a/docs/build/apps/example-application-tutorial/querying-data.mdx
+++ b/docs/build/apps/example-application-tutorial/querying-data.mdx
@@ -18,15 +18,15 @@ In other places in this tutorial, we have omitted the JSDoc descriptions and typ
 ```js title="/src/lib/stellar/horizonQueries.js"
 import { error } from "@sveltejs/kit";
 import {
-  Server,
+  Horizon,
   TransactionBuilder,
   Networks,
   StrKey,
   Asset,
-} from "stellar-sdk";
+} from "@stellar/stellar-sdk";
 
 const horizonUrl = "https://horizon-testnet.stellar.org";
-const server = new Server(horizonUrl);
+const server = new Horizon.Server(horizonUrl);
 
 /**
  * @module $lib/stellar/horizonQueries
@@ -37,14 +37,14 @@ const server = new Server(horizonUrl);
  */
 
 // We'll import some type definitions that already exists within the
-// `stellar-sdk` package, so our functions will know what to expect.
-/** @typedef {import('stellar-sdk').ServerApi.AccountRecord} AccountRecord */
-/** @typedef {import('stellar-sdk').Horizon.ErrorResponseData} ErrorResponseData */
-/** @typedef {import('stellar-sdk').ServerApi.PaymentOperationRecord} PaymentOperationRecord */
-/** @typedef {import('stellar-sdk').Horizon.BalanceLine} BalanceLine */
-/** @typedef {import('stellar-sdk').Horizon.BalanceLineAsset} BalanceLineAsset */
-/** @typedef {import('stellar-sdk').Transaction} Transaction */
-/** @typedef {import('stellar-sdk').ServerApi.PaymentPathRecord} PaymentPathRecord */
+// `@stellar/stellar-sdk` package, so our functions will know what to expect.
+/** @typedef {import('@stellar/stellar-sdk').ServerApi.AccountRecord} AccountRecord */
+/** @typedef {import('@stellar/stellar-sdk').Horizon.ErrorResponseData} ErrorResponseData */
+/** @typedef {import('@stellar/stellar-sdk').ServerApi.PaymentOperationRecord} PaymentOperationRecord */
+/** @typedef {import('@stellar/stellar-sdk').Horizon.BalanceLine} BalanceLine */
+/** @typedef {import('@stellar/stellar-sdk').Horizon.BalanceLineAsset} BalanceLineAsset */
+/** @typedef {import('@stellar/stellar-sdk').Transaction} Transaction */
+/** @typedef {import('@stellar/stellar-sdk').ServerApi.PaymentPathRecord} PaymentPathRecord */
 ```
 
 **Source:** https://github.com/stellar/basic-payment-app/blob/main/src/lib/stellar/horizonQueries.js

--- a/docs/build/apps/example-application-tutorial/querying-data.mdx
+++ b/docs/build/apps/example-application-tutorial/querying-data.mdx
@@ -36,7 +36,7 @@ const server = new Horizon.Server(horizonUrl);
  * _everything_ contained within our `*.svelte` files.
  */
 
-// We'll import some type definitions that already exists within the
+// We'll import some type definitions that already exist within the
 // `@stellar/stellar-sdk` package, so our functions will know what to expect.
 /** @typedef {import('@stellar/stellar-sdk').ServerApi.AccountRecord} AccountRecord */
 /** @typedef {import('@stellar/stellar-sdk').Horizon.ErrorResponseData} ErrorResponseData */


### PR DESCRIPTION
# BasicPay: stellar-sdk@11.0.0 Breaking Changes Fix Summary

Four issues across three tutorial pages introduced when `stellar-sdk@11.0.0` removed and renamed several APIs in December 2023. The tutorial was not updated to match, causing runtime failures for anyone following it.

## Changes

### Querying Data: `Server` is not a top-level export

`import { Server } from "stellar-sdk"` returns `undefined` on v11+. Updated to use `Horizon.Server` (Basicpay uses Horizon) from `@stellar/stellar-sdk`. Also updated the `@typedef` JSDoc comments which referenced the old `stellar-sdk` package name.

### SEP-1 — `StellarTomlResolver` renamed to `StellarToml.Resolver`

`StellarTomlResolver` was removed in v11. Updated import and call site to use `StellarToml.Resolver.resolve()` from `@stellar/stellar-sdk`. Updated prose reference accordingly.

### SEP-10 — `Utils` renamed to `WebAuth`

`Utils.readChallengeTx` was removed in v11. Updated import and call site to use `WebAuth.readChallengeTx` from `@stellar/stellar-sdk`.

### SEP-10 — Logic error in TOML validation

```js
// before: requires ALL three fields — rejects valid anchors that have
// WEB_AUTH_ENDPOINT but no TRANSFER_SERVER (or vice versa)
if (!WEB_AUTH_ENDPOINT || !TRANSFER_SERVER || !SIGNING_KEY)

// after: requires at least one of WEB_AUTH_ENDPOINT/TRANSFER_SERVER, AND SIGNING_KEY
if (!(WEB_AUTH_ENDPOINT || TRANSFER_SERVER) || !SIGNING_KEY)
```

## Files Changed

- `docs/build/apps/example-application-tutorial/querying-data.mdx`
- `docs/build/apps/example-application-tutorial/anchor-integration/sep1.mdx`
- `docs/build/apps/example-application-tutorial/anchor-integration/sep10.mdx`

Related: #2346