### PR TITLE
docs: add Wallet Backend GraphQL API reference

### DIFF
--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -371,6 +371,11 @@ const data: NavbarItem = {
       activeBasePath: 'docs/data/apis/migrate-from-horizon-to-rpc'
     },
     {
+      to: '/docs/data/apis/wallet-backend',
+      label: 'Wallet Backend',
+      activeBasePath: 'docs/data/apis/wallet-backend'
+    },
+    {
       type: 'html',
       value: '<hr><a href="/docs/data/indexers" class="subtitle"><small>Indexers</small>',
       className:'subtitle'

--- a/docs/data/apis/README.mdx
+++ b/docs/data/apis/README.mdx
@@ -3,15 +3,17 @@ title: APIs Overview
 sidebar_position: 0
 ---
 
-Learn about the services that provide access to real-time Stellar network data
+Learn about the services that provide access to Stellar network data
 
-| Features                | RPC | Horizon |
-| ----------------------- | --- | ------- |
-| Real-time Data          | ✅  | ✅      |
-| Historical Data         | ❌  | ❌\*    |
-| Smart Contracts         | ✅  | ❌      |
-| Transaction Simulation  | ✅  | ❌      |
-| Curated and Parsed Data | ❌  | ✅      |
+| Features                | RPC | Horizon | Wallet Backend |
+| ----------------------- | --- | ------- | -------------- |
+| Real-time Data          | ✅  | ✅      | ✅             |
+| Historical Data         | ❌  | ❌\*    | ✅             |
+| Smart Contracts         | ✅  | ❌      | ✅             |
+| Transaction Simulation  | ✅  | ❌      | ❌             |
+| Curated and Parsed Data | ❌  | ✅      | ✅             |
+| GraphQL API             | ❌  | ❌      | ✅             |
+| Fee Sponsorship         | ❌  | ❌      | ✅             |
 
 \*_Please note that Horizon can provide full historical data but is not the recommended tool for full historical data access. Please use [Hubble](../analytics/hubble/README.mdx) or [Galexie](../indexers/build-your-own/galexie/README.mdx) instead._
 
@@ -34,3 +36,7 @@ Horizon is considered deprecated in favor of Stellar RPC. While it will continue
 :::
 
 Horizon is an API for accessing and interacting with Stellar network data.
+
+## [Wallet Backend](./wallet-backend/README.mdx)
+
+The Wallet Backend is a Go service that provides a GraphQL API for querying Stellar network data and building transactions. It powers wallet applications by providing indexed transaction history, multi-token account balances, and transaction building with fee sponsorship via channel accounts.

--- a/docs/data/apis/wallet-backend/README.mdx
+++ b/docs/data/apis/wallet-backend/README.mdx
@@ -1,0 +1,33 @@
+---
+title: "Query Stellar Data & Build Transactions with the Wallet Backend GraphQL API"
+sidebar_label: Wallet Backend
+sidebar_position: 30
+description: "Learn how the Wallet Backend provides a GraphQL API for querying transactions, balances, and building fee-sponsored transactions on the Stellar network."
+---
+
+import DocCardList from "@theme/DocCardList";
+
+# Wallet Backend
+
+The Wallet Backend is a Go service that provides a [GraphQL API](/docs/data/apis/wallet-backend/api-reference) for querying Stellar network data and building transactions. It powers wallet applications like [Freighter](/docs/build/guides/freighter) by providing indexed transaction history, account balances, and transaction building with fee sponsorship.
+
+## Key Features
+
+- **GraphQL API** for querying transactions, operations, accounts, and state changes
+- **Multi-token balance queries** supporting XLM, classic assets, SAC, and SEP-41 tokens
+- **Transaction building** with automatic sequence number management via channel accounts
+- **Fee sponsorship** via fee bump transactions signed by a distribution account
+- **Real-time ingestion** of Stellar ledger data from RPC
+- **JWT authentication** with Ed25519 signatures derived from Stellar keypairs
+
+## In These Docs
+
+- [Queries](./api-reference/queries/README.mdx): GraphQL queries for transactions, operations, accounts, state changes, and balances.
+- [Mutations](./api-reference/mutations/README.mdx): GraphQL mutations for building and submitting transactions with fee sponsorship.
+- [Structure](./api-reference/structure/README.mdx): authentication, data types, pagination, and error handling.
+
+## External Resources
+
+- [GitHub Repository](https://github.com/stellar/wallet-backend): source code, setup instructions, and contribution guide.
+
+<DocCardList />

--- a/docs/data/apis/wallet-backend/api-reference/README.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/README.mdx
@@ -1,0 +1,11 @@
+---
+title: API Reference
+sidebar_position: 20
+sidebar_key: wallet-backend-api-reference
+---
+
+import DocCardList from "@theme/DocCardList";
+
+View all Wallet Backend GraphQL API information.
+
+<DocCardList />

--- a/docs/data/apis/wallet-backend/api-reference/_category_.json
+++ b/docs/data/apis/wallet-backend/api-reference/_category_.json
@@ -1,0 +1,3 @@
+{
+  "collapsed": true
+}

--- a/docs/data/apis/wallet-backend/api-reference/mutations/README.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/mutations/README.mdx
@@ -1,0 +1,13 @@
+---
+title: Mutations
+sidebar_position: 20
+---
+
+import DocCardList from "@theme/DocCardList";
+
+The Wallet Backend provides 2 GraphQL mutations for building and submitting transactions.
+
+- [`buildTransaction`](./buildTransaction.mdx) - Build and sign a transaction using channel accounts
+- [`createFeeBumpTransaction`](./createFeeBumpTransaction.mdx) - Wrap a signed transaction in a fee bump for fee sponsorship
+
+<DocCardList />

--- a/docs/data/apis/wallet-backend/api-reference/mutations/_category_.json
+++ b/docs/data/apis/wallet-backend/api-reference/mutations/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Mutations",
+  "position": 20,
+  "collapsed": true
+}

--- a/docs/data/apis/wallet-backend/api-reference/mutations/buildTransaction.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/mutations/buildTransaction.mdx
@@ -1,0 +1,80 @@
+---
+hide_title: true
+description: Build and sign a transaction using channel accounts
+---
+
+# buildTransaction
+
+Build and sign a transaction using channel accounts. The mutation takes a transaction XDR, assigns a channel account as the source (handling sequence numbers), and returns the signed transaction ready for submission.
+
+```graphql
+buildTransaction(input: BuildTransactionInput!): BuildTransactionPayload!
+```
+
+## Input Fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `transactionXdr` | `String!` | Yes | The base64-encoded transaction envelope XDR |
+| `simulationResult` | `SimulationResultInput` | No | Soroban simulation result for smart contract transactions |
+
+### SimulationResultInput
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `transactionData` | `String` | No | Soroban transaction data from simulation |
+| `events` | `[String!]` | No | Simulated events |
+| `minResourceFee` | `String` | No | Minimum resource fee from simulation |
+| `results` | `[String!]` | No | Simulation results |
+| `latestLedger` | `Int` | No | Latest ledger at time of simulation |
+| `error` | `String` | No | Simulation error message |
+
+## Example (Basic)
+
+```graphql
+mutation {
+  buildTransaction(input: { transactionXdr: "AAAAAgAAAAB..." }) {
+    success
+    transactionXdr
+  }
+}
+```
+
+## Example (With Soroban Simulation)
+
+```graphql
+mutation {
+  buildTransaction(
+    input: {
+      transactionXdr: "AAAAAgAAAAB..."
+      simulationResult: {
+        minResourceFee: "100000"
+        transactionData: "AAAAAAAAAAk..."
+      }
+    }
+  ) {
+    success
+    transactionXdr
+  }
+}
+```
+
+## Output Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `success` | `Boolean!` | Whether the transaction was built successfully |
+| `transactionXdr` | `String!` | The signed transaction envelope XDR (base64-encoded) |
+
+## Error Codes
+
+| Code | Description |
+| --- | --- |
+| `INVALID_TRANSACTION_XDR` | The provided XDR could not be decoded as a valid transaction envelope |
+| `INVALID_OPERATION_STRUCTURE` | The transaction operations have an invalid structure |
+| `INVALID_SOROBAN_TRANSACTION` | The Soroban simulation result is invalid or incompatible with the transaction |
+| `CHANNEL_ACCOUNT_UNAVAILABLE` | No channel accounts are currently available to sign the transaction |
+| `FORBIDDEN_SIGNER` | The transaction source account is not allowed to sign through this service |
+| `TRANSACTION_BUILD_FAILED` | The transaction could not be built due to an internal error |
+
+:::note[Channel Accounts] The Wallet Backend uses channel accounts to handle sequence numbers on behalf of clients. This means the client does not need to manage sequence numbers or worry about conflicts from concurrent submissions. :::

--- a/docs/data/apis/wallet-backend/api-reference/mutations/createFeeBumpTransaction.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/mutations/createFeeBumpTransaction.mdx
@@ -1,0 +1,52 @@
+---
+hide_title: true
+description: Wrap a signed transaction in a fee bump for fee sponsorship
+---
+
+# createFeeBumpTransaction
+
+Wrap a signed transaction in a fee bump transaction for fee sponsorship. The Wallet Backend pays the transaction fee on behalf of the user.
+
+```graphql
+createFeeBumpTransaction(input: CreateFeeBumpTransactionInput!): CreateFeeBumpTransactionPayload!
+```
+
+## Input Fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `transactionXDR` | `String!` | Yes | The base64-encoded, **already-signed** transaction envelope XDR |
+
+:::caution The input transaction must already be signed before wrapping it in a fee bump. The fee bump transaction preserves the inner signatures and adds the fee sponsor's signature. If the transaction is not pre-signed, the mutation will return a `NO_SIGNATURES_PROVIDED` error. :::
+
+## Example
+
+```graphql
+mutation {
+  createFeeBumpTransaction(input: { transactionXDR: "AAAAAgAAAAB..." }) {
+    success
+    transaction
+    networkPassphrase
+  }
+}
+```
+
+## Output Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `success` | `Boolean!` | Whether the fee bump transaction was created successfully |
+| `transaction` | `String!` | The fee bump transaction envelope XDR (base64-encoded) |
+| `networkPassphrase` | `String!` | The network passphrase used for the transaction |
+
+## Error Codes
+
+| Code | Description |
+| --- | --- |
+| `INVALID_TRANSACTION_XDR` | The provided XDR could not be decoded as a valid transaction envelope |
+| `FEE_BUMP_TX_NOT_ALLOWED` | Fee bump transactions are not allowed for this type of transaction |
+| `INVALID_TRANSACTION` | The inner transaction is invalid |
+| `FEE_EXCEEDS_MAXIMUM` | The calculated fee exceeds the configured maximum. The error details include `maximumBaseFee` with the allowed limit. |
+| `NO_SIGNATURES_PROVIDED` | The inner transaction has no signatures. It must be signed before creating a fee bump. |
+| `ACCOUNT_NOT_ELIGIBLE_FOR_BEING_SPONSORED` | The transaction source account is not eligible for fee sponsorship |
+| `FEE_BUMP_CREATION_FAILED` | The fee bump transaction could not be created due to an internal error |

--- a/docs/data/apis/wallet-backend/api-reference/queries/README.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/README.mdx
@@ -1,0 +1,19 @@
+---
+title: Queries
+sidebar_position: 10
+---
+
+import DocCardList from "@theme/DocCardList";
+
+The Wallet Backend provides 8 GraphQL queries for reading transactions, operations, accounts, state changes, and balances.
+
+- [`transactionByHash`](./transactionByHash.mdx) - Retrieve a specific transaction by its hash
+- [`transactions`](./transactions.mdx) - List transactions with cursor-based pagination
+- [`accountByAddress`](./accountByAddress.mdx) - Get account details with nested transaction, operation, and state change queries
+- [`operations`](./operations.mdx) - List all operations with pagination
+- [`operationById`](./operationById.mdx) - Retrieve a specific operation by its ID
+- [`stateChanges`](./stateChanges.mdx) - List all state changes with polymorphic types
+- [`balancesByAccountAddress`](./balancesByAccountAddress.mdx) - Get all balances for a single account
+- [`balancesByAccountAddresses`](./balancesByAccountAddresses.mdx) - Get balances for multiple accounts in a single request
+
+<DocCardList />

--- a/docs/data/apis/wallet-backend/api-reference/queries/_category_.json
+++ b/docs/data/apis/wallet-backend/api-reference/queries/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Queries",
+  "position": 10,
+  "collapsed": true
+}

--- a/docs/data/apis/wallet-backend/api-reference/queries/accountByAddress.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/accountByAddress.mdx
@@ -1,0 +1,97 @@
+---
+hide_title: true
+description: Get account details with nested transaction, operation, and state change queries
+---
+
+# accountByAddress
+
+Get account details with nested transaction, operation, and state change queries. This is the most powerful query for per-account data, allowing you to fetch transactions, operations, and state changes in a single request.
+
+```graphql
+accountByAddress(address: String!): Account
+```
+
+## Parameters
+
+| Parameter | Type      | Required | Description                             |
+| --------- | --------- | -------- | --------------------------------------- |
+| `address` | `String!` | Yes      | The Stellar account address (G-address) |
+
+## Example
+
+```graphql
+query {
+  accountByAddress(address: "GABC...XYZ") {
+    address
+    transactions(first: 5) {
+      edges {
+        node {
+          hash
+          resultCode
+          ledgerCreatedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+    operations(first: 5) {
+      edges {
+        node {
+          id
+          operationType
+          successful
+        }
+      }
+    }
+    stateChanges(
+      filter: {
+        transactionHash: "abc123..."
+        category: "BALANCE"
+        reason: "CREDIT"
+      }
+      first: 10
+      since: "2025-01-01T00:00:00Z"
+      until: "2025-12-31T23:59:59Z"
+    ) {
+      edges {
+        node {
+          ... on StandardBalanceChange {
+            tokenId
+            amount
+            type
+            reason
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## State Change Filters
+
+The nested `stateChanges` connection supports the following parameters:
+
+**Direct parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `since` | `Time` | Filter for changes on or after this timestamp |
+| `until` | `Time` | Filter for changes on or before this timestamp |
+| `first` | `Int` | Number of items to return from the beginning (forward pagination) |
+| `after` | `String` | Cursor to start after (forward pagination) |
+| `last` | `Int` | Number of items to return from the end (backward pagination) |
+| `before` | `String` | Cursor to start before (backward pagination) |
+
+**Filter input fields** (passed inside `filter: {}`):
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `transactionHash` | `String` | Filter by the hash of the transaction that caused the change |
+| `operationId` | `Int64` | Filter by the ID of the operation that caused the change |
+| `category` | `String` | Filter by the category of state change |
+| `reason` | `String` | Filter by the reason for the state change |
+
+:::note This is the most powerful query for per-account data. Use the nested connections and filters to avoid multiple round-trips to the API. :::

--- a/docs/data/apis/wallet-backend/api-reference/queries/balancesByAccountAddress.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/balancesByAccountAddress.mdx
@@ -1,0 +1,78 @@
+---
+hide_title: true
+description: Get all balances for a single account
+---
+
+# balancesByAccountAddress
+
+Get all balances for a single account. Returns balances across all token types using polymorphic inline fragments.
+
+```graphql
+balancesByAccountAddress(address: String!): [Balance!]!
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `address` | `String!` | Yes | The account address. Supports both G-addresses (classic Stellar) and C-addresses (Soroban contracts). |
+
+## Example
+
+```graphql
+query {
+  balancesByAccountAddress(address: "GABC...XYZ") {
+    ... on NativeBalance {
+      balance
+      tokenId
+      tokenType
+      minimumBalance
+    }
+    ... on TrustlineBalance {
+      balance
+      tokenId
+      tokenType
+      code
+      issuer
+      isAuthorized
+    }
+    ... on SACBalance {
+      balance
+      tokenId
+      tokenType
+      code
+      issuer
+      decimals
+    }
+    ... on SEP41Balance {
+      balance
+      tokenId
+      tokenType
+      name
+      symbol
+      decimals
+    }
+  }
+}
+```
+
+## Balance Types
+
+The response returns a list of `Balance` interface members. Use inline fragments to access type-specific fields:
+
+| Type | Description |
+| --- | --- |
+| `NativeBalance` | XLM balance |
+| `TrustlineBalance` | Classic trustline asset balance |
+| `SACBalance` | Stellar Asset Contract balance (classic asset wrapped in a contract) |
+| `SEP41Balance` | SEP-41 token balance (custom Soroban token) |
+
+See the [Data Types](../structure/types.mdx#balance-types) reference for the full field list on each type.
+
+## Error Codes
+
+| Code | Description |
+| --- | --- |
+| `INVALID_ADDRESS` | The provided address is not a valid Stellar G-address or C-address |
+| `RPC_UNAVAILABLE` | The RPC service is temporarily unavailable |
+| `INTERNAL_ERROR` | An unexpected error occurred |

--- a/docs/data/apis/wallet-backend/api-reference/queries/balancesByAccountAddresses.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/balancesByAccountAddresses.mdx
@@ -1,0 +1,80 @@
+---
+hide_title: true
+description: Get balances for multiple accounts in a single request
+---
+
+# balancesByAccountAddresses
+
+Get balances for multiple accounts in a single request. Each account's result is returned independently, with per-account error handling.
+
+```graphql
+balancesByAccountAddresses(addresses: [String!]!): [AccountBalances!]!
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `addresses` | `[String!]!` | Yes | List of account addresses. Supports both G-addresses and C-addresses. Maximum 20 addresses per request (configurable). |
+
+## Example
+
+```graphql
+query {
+  balancesByAccountAddresses(
+    addresses: ["GABC...XYZ", "GDEF...UVW", "CXYZ...123"]
+  ) {
+    address
+    error
+    balances {
+      ... on NativeBalance {
+        balance
+        tokenId
+        tokenType
+        minimumBalance
+      }
+      ... on TrustlineBalance {
+        balance
+        tokenId
+        tokenType
+        code
+        issuer
+        isAuthorized
+      }
+      ... on SACBalance {
+        balance
+        tokenId
+        tokenType
+        code
+        issuer
+        decimals
+      }
+      ... on SEP41Balance {
+        balance
+        tokenId
+        tokenType
+        name
+        symbol
+        decimals
+      }
+    }
+  }
+}
+```
+
+## Response
+
+Returns an `AccountBalances` object for each address. Each result includes:
+
+| Field      | Type          | Description                                 |
+| ---------- | ------------- | ------------------------------------------- |
+| `address`  | `String!`     | The requested account address               |
+| `balances` | `[Balance!]!` | List of balances for this account           |
+| `error`    | `String`      | Per-account error message (null on success) |
+
+## Notes
+
+- **Maximum addresses**: Up to 20 addresses per request (server-configurable).
+- **Deduplication**: Duplicate addresses in the input are deduplicated automatically.
+- **Parallel processing**: RPC calls for each account are processed in parallel for performance.
+- **Per-account errors**: If one account fails (e.g., invalid address, RPC timeout), other accounts in the same request still return successfully. Check the `error` field on each result.

--- a/docs/data/apis/wallet-backend/api-reference/queries/operationById.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/operationById.mdx
@@ -1,0 +1,61 @@
+---
+hide_title: true
+description: Retrieve a specific operation by its ID
+---
+
+# operationById
+
+Retrieve a specific operation by its ID.
+
+```graphql
+operationById(id: Int64!): Operation
+```
+
+## Parameters
+
+| Parameter | Type     | Required | Description      |
+| --------- | -------- | -------- | ---------------- |
+| `id`      | `Int64!` | Yes      | The operation ID |
+
+## Example
+
+```graphql
+query {
+  operationById(id: "12345678") {
+    id
+    operationType
+    successful
+    transaction {
+      hash
+      feeCharged
+      resultCode
+      ledgerCreatedAt
+    }
+    stateChanges(first: 10) {
+      edges {
+        node {
+          ... on StandardBalanceChange {
+            tokenId
+            amount
+            type
+            reason
+          }
+          ... on AccountChange {
+            type
+            reason
+          }
+          ... on SignerChange {
+            signerAddress
+            type
+            reason
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Response
+
+Returns an [`Operation`](../structure/types.mdx) object with full details, including the parent transaction and any resulting state changes.

--- a/docs/data/apis/wallet-backend/api-reference/queries/operations.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/operations.mdx
@@ -1,0 +1,61 @@
+---
+hide_title: true
+description: List all operations with pagination
+---
+
+# operations
+
+List all operations with cursor-based pagination.
+
+```graphql
+operations(
+  first: Int
+  after: String
+  last: Int
+  before: String
+): OperationConnection
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `first` | `Int` | No | Number of items to return from the beginning (forward pagination) |
+| `after` | `String` | No | Cursor to start after (forward pagination) |
+| `last` | `Int` | No | Number of items to return from the end (backward pagination) |
+| `before` | `String` | No | Cursor to start before (backward pagination) |
+
+## Example
+
+```graphql
+query {
+  operations(first: 10) {
+    edges {
+      cursor
+      node {
+        id
+        operationType
+        successful
+        transaction {
+          hash
+          ledgerCreatedAt
+        }
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
+}
+```
+
+## Pagination
+
+This query uses [Relay-style cursor pagination](../structure/pagination.mdx). The default page size is **10**.
+
+## Operation Types
+
+The `operationType` field returns one of 27 [`OperationType`](../structure/types.mdx#enums) values representing all Stellar operation types.

--- a/docs/data/apis/wallet-backend/api-reference/queries/stateChanges.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/stateChanges.mdx
@@ -1,0 +1,94 @@
+---
+hide_title: true
+description: List all state changes with polymorphic types
+---
+
+# stateChanges
+
+List all state changes with cursor-based pagination. State changes use a polymorphic interface pattern, so you must use inline fragments (`... on TypeName`) to access type-specific fields.
+
+```graphql
+stateChanges(
+  first: Int
+  after: String
+  last: Int
+  before: String
+): StateChangeConnection
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `first` | `Int` | No | Number of items to return from the beginning (forward pagination) |
+| `after` | `String` | No | Cursor to start after (forward pagination) |
+| `last` | `Int` | No | Number of items to return from the end (backward pagination) |
+| `before` | `String` | No | Cursor to start before (backward pagination) |
+
+## Example
+
+```graphql
+query {
+  stateChanges(first: 10) {
+    edges {
+      cursor
+      node {
+        ... on StandardBalanceChange {
+          tokenId
+          amount
+          type
+          reason
+          account {
+            address
+          }
+          operation {
+            id
+          }
+          transaction {
+            hash
+          }
+        }
+        ... on AccountChange {
+          type
+          reason
+          account {
+            address
+          }
+          operation {
+            id
+          }
+          transaction {
+            hash
+          }
+        }
+        ... on SignerChange {
+          signerAddress
+          type
+          reason
+          account {
+            address
+          }
+          operation {
+            id
+          }
+          transaction {
+            hash
+          }
+        }
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
+}
+```
+
+## Polymorphic Types
+
+The `BaseStateChange` interface has 9 implementations. You must use inline fragments (`... on TypeName`) to access fields specific to each type. See the [Data Types](../structure/types.mdx#state-change-types) reference for the full list of implementations and their fields.
+
+:::caution Querying state changes without inline fragments will only return the base interface fields. Always include `... on TypeName` fragments for the state change types you need. :::

--- a/docs/data/apis/wallet-backend/api-reference/queries/transactionByHash.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/transactionByHash.mdx
@@ -1,0 +1,52 @@
+---
+hide_title: true
+description: Retrieve a specific transaction by its hash
+---
+
+# transactionByHash
+
+Retrieve a specific transaction by its hash.
+
+```graphql
+transactionByHash(hash: String!): Transaction
+```
+
+## Parameters
+
+| Parameter | Type      | Required | Description                     |
+| --------- | --------- | -------- | ------------------------------- |
+| `hash`    | `String!` | Yes      | The transaction hash to look up |
+
+## Example
+
+```graphql
+query {
+  transactionByHash(hash: "abc123def456...") {
+    hash
+    feeCharged
+    resultCode
+    ledgerNumber
+    isFeeBump
+    ledgerCreatedAt
+    ingestedAt
+    operations(first: 5) {
+      edges {
+        node {
+          id
+          operationType
+          successful
+        }
+      }
+    }
+    accounts {
+      address
+    }
+  }
+}
+```
+
+## Response
+
+Returns a [`Transaction`](../structure/types.mdx) object containing full transaction details including nested operations and accounts.
+
+:::note[ingestedAt vs ledgerCreatedAt] The `ingestedAt` timestamp reflects when the Wallet Backend ingested the transaction, while `ledgerCreatedAt` reflects when the ledger containing the transaction was closed on the Stellar network. These may differ depending on ingestion lag. :::

--- a/docs/data/apis/wallet-backend/api-reference/queries/transactions.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/queries/transactions.mdx
@@ -1,0 +1,58 @@
+---
+hide_title: true
+description: List transactions with cursor-based pagination
+---
+
+# transactions
+
+List transactions with cursor-based pagination.
+
+```graphql
+transactions(
+  first: Int
+  after: String
+  last: Int
+  before: String
+): TransactionConnection
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `first` | `Int` | No | Number of items to return from the beginning (forward pagination) |
+| `after` | `String` | No | Cursor to start after (forward pagination) |
+| `last` | `Int` | No | Number of items to return from the end (backward pagination) |
+| `before` | `String` | No | Cursor to start before (backward pagination) |
+
+## Example
+
+```graphql
+query {
+  transactions(first: 5) {
+    edges {
+      cursor
+      node {
+        hash
+        feeCharged
+        resultCode
+        ledgerNumber
+        isFeeBump
+        ledgerCreatedAt
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
+}
+```
+
+## Pagination
+
+This query uses [Relay-style cursor pagination](../structure/pagination.mdx). You must use either forward pagination (`first` + `after`) or backward pagination (`last` + `before`), but not both in the same request.
+
+The default page size is **10** when neither `first` nor `last` is specified.

--- a/docs/data/apis/wallet-backend/api-reference/structure/README.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/structure/README.mdx
@@ -1,0 +1,10 @@
+---
+title: Structure
+sidebar_position: 30
+---
+
+import DocCardList from "@theme/DocCardList";
+
+Learn about the Wallet Backend API structure, authentication, data types, and error handling.
+
+<DocCardList />

--- a/docs/data/apis/wallet-backend/api-reference/structure/_category_.json
+++ b/docs/data/apis/wallet-backend/api-reference/structure/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Structure",
+  "position": 30,
+  "collapsed": true
+}

--- a/docs/data/apis/wallet-backend/api-reference/structure/authentication.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/structure/authentication.mdx
@@ -1,0 +1,48 @@
+---
+title: Authentication
+sidebar_position: 10
+---
+
+# Authentication
+
+The Wallet Backend API uses JWT authentication with Ed25519 signatures. Clients must sign a JWT token with their Ed25519 private key and include it in the `Authorization` header of each request.
+
+## Authorization Header
+
+```
+Authorization: Bearer <JWT_TOKEN>
+```
+
+## JWT Claims
+
+| Claim | Type | Description |
+| --- | --- | --- |
+| `exp` | `number` | Expiration time (Unix timestamp). Must be within 15 seconds of the current time. |
+| `iat` | `number` | Issued-at time (Unix timestamp) |
+| `sub` | `string` | The Stellar public key (G-address) of the client |
+| `methodAndPath` | `string` | The HTTP method and path of the request (e.g., `POST /graphql`) |
+| `bodyHash` | `string` | SHA-256 hash of the request body (hex-encoded) |
+
+## Configuration
+
+The server must be configured with the public keys that are allowed to authenticate. This is set via the `CLIENT_AUTH_PUBLIC_KEYS` configuration, which accepts a comma-separated list of Ed25519 public keys.
+
+## Token Lifetime
+
+:::caution The maximum token lifetime is **15 seconds**. Tokens with an `exp` claim more than 15 seconds in the future will be rejected. Generate a fresh token for each request. :::
+
+## Body Hash
+
+:::info The `bodyHash` claim is required for all requests, including those with empty bodies. For an empty body, compute the SHA-256 hash of an empty string. :::
+
+## Example Token Payload
+
+```json
+{
+  "exp": 1700000015,
+  "iat": 1700000000,
+  "sub": "GABC...XYZ",
+  "methodAndPath": "POST /graphql",
+  "bodyHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}
+```

--- a/docs/data/apis/wallet-backend/api-reference/structure/errors.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/structure/errors.mdx
@@ -27,8 +27,9 @@ The Wallet Backend API returns errors using the standard GraphQL error format wi
 }
 ```
 
-## Error Codes
+## Common Error Codes
 
+The following table lists common error codes returned by the Wallet Backend GraphQL API. Some queries and mutations may document additional operation-specific error codes in their respective reference pages.
 | Code | Description | Retryable |
 | --- | --- | --- |
 | `INVALID_ADDRESS` | The provided account address is not a valid Stellar address | No |

--- a/docs/data/apis/wallet-backend/api-reference/structure/errors.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/structure/errors.mdx
@@ -1,0 +1,69 @@
+---
+title: Error Handling
+sidebar_position: 40
+---
+
+# Error Handling
+
+The Wallet Backend API returns errors using the standard GraphQL error format with additional structured details in the `extensions` field.
+
+## Error Format
+
+```json
+{
+  "errors": [
+    {
+      "message": "The provided address is not valid",
+      "path": ["balancesByAccountAddress"],
+      "extensions": {
+        "code": "INVALID_ADDRESS",
+        "details": {
+          "address": "INVALID..."
+        }
+      }
+    }
+  ],
+  "data": null
+}
+```
+
+## Error Codes
+
+| Code | Description | Retryable |
+| --- | --- | --- |
+| `INVALID_ADDRESS` | The provided account address is not a valid Stellar address | No |
+| `INVALID_TRANSACTION_XDR` | The provided XDR could not be decoded as a valid transaction | No |
+| `RPC_UNAVAILABLE` | The RPC service is temporarily unavailable | Yes |
+| `CHANNEL_ACCOUNT_UNAVAILABLE` | No channel accounts are available to sign the transaction | Yes |
+| `AUTHENTICATION_FAILED` | The JWT token is invalid, expired, or has an incorrect signature | No |
+| `UNAUTHORIZED` | The authenticated client is not authorized for this operation | No |
+| `FEE_EXCEEDS_MAXIMUM` | The calculated fee exceeds the configured maximum base fee | No |
+| `INTERNAL_ERROR` | An unexpected internal error occurred | Yes |
+
+## Error Details
+
+Some error codes include additional context in `extensions.details`:
+
+- **`FEE_EXCEEDS_MAXIMUM`**: includes `maximumBaseFee` (the configured limit)
+- **`INVALID_ADDRESS`**: includes `address` (the invalid input)
+- **`CHANNEL_ACCOUNT_UNAVAILABLE`**: may include retry guidance
+
+## Per-Field Errors
+
+The [`balancesByAccountAddresses`](../queries/balancesByAccountAddresses.mdx) query uses per-field error handling rather than top-level GraphQL errors. Each account in the response has its own `error` field, which is a `String` containing the error message if the balance fetch failed for that account:
+
+```graphql
+query {
+  balancesByAccountAddresses(addresses: ["GABC...XYZ", "INVALID"]) {
+    address
+    error
+    balances {
+      ... on NativeBalance {
+        balance
+      }
+    }
+  }
+}
+```
+
+In this pattern, a failing address does not prevent other addresses from returning results. Always check the `error` field on each `AccountBalances` result before reading `balances`.

--- a/docs/data/apis/wallet-backend/api-reference/structure/pagination.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/structure/pagination.mdx
@@ -1,0 +1,69 @@
+---
+title: Pagination
+sidebar_position: 30
+---
+
+# Pagination
+
+The Wallet Backend API uses Relay-style cursor-based pagination for all list queries. This approach provides stable pagination even when data is being ingested concurrently.
+
+## Forward Pagination
+
+Use `first` and `after` to paginate forward through results.
+
+```graphql
+query {
+  transactions(first: 10, after: "cursor_abc123") {
+    edges {
+      cursor
+      node {
+        hash
+        resultCode
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+  }
+}
+```
+
+## Backward Pagination
+
+Use `last` and `before` to paginate backward through results.
+
+```graphql
+query {
+  transactions(last: 10, before: "cursor_xyz789") {
+    edges {
+      cursor
+      node {
+        hash
+        resultCode
+      }
+    }
+    pageInfo {
+      startCursor
+      hasPreviousPage
+    }
+  }
+}
+```
+
+## Rules
+
+- Use **either** forward pagination (`first` + `after`) **or** backward pagination (`last` + `before`), but never both in the same request.
+- The default page size is **10** when neither `first` nor `last` is specified.
+- Cursors are **opaque strings** -- do not attempt to parse or construct them. Always use cursor values returned by the API.
+
+## PageInfo Fields
+
+Every paginated connection includes a `pageInfo` object:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `startCursor` | `String` | Cursor of the first edge in the current page |
+| `endCursor` | `String` | Cursor of the last edge in the current page |
+| `hasNextPage` | `Boolean!` | Whether more results exist after the last edge |
+| `hasPreviousPage` | `Boolean!` | Whether more results exist before the first edge |

--- a/docs/data/apis/wallet-backend/api-reference/structure/types.mdx
+++ b/docs/data/apis/wallet-backend/api-reference/structure/types.mdx
@@ -1,0 +1,530 @@
+---
+title: Data Types
+sidebar_position: 20
+---
+
+# Data Types
+
+This page documents all types, interfaces, enums, scalars, inputs, and connection types used by the Wallet Backend GraphQL API.
+
+## Core Types
+
+### Transaction
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `hash` | `String!` | Transaction hash |
+| `feeCharged` | `Int64!` | Fee charged for the transaction in stroops |
+| `resultCode` | `String!` | Transaction result code |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `isFeeBump` | `Boolean!` | Whether the transaction is a fee bump transaction |
+| `ingestedAt` | `Time!` | When the transaction was ingested by the Wallet Backend |
+| `operations` | `OperationConnection` | Paginated operations within this transaction |
+| `accounts` | `[Account!]!` | Accounts involved in this transaction |
+| `stateChanges` | `StateChangeConnection` | Paginated state changes resulting from this transaction |
+
+The `operations` field accepts pagination arguments: `first`, `after`, `last`, `before`.
+
+The `stateChanges` field accepts pagination arguments: `first`, `after`, `last`, `before`.
+
+### Account
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `address` | `String!` | Account public key address |
+| `transactions` | `TransactionConnection` | Paginated transactions involving this account |
+| `operations` | `OperationConnection` | Paginated operations involving this account |
+| `stateChanges` | `StateChangeConnection` | Paginated state changes for this account |
+
+The `transactions` field accepts arguments: `since` (`Time`), `until` (`Time`), `first` (`Int`), `after` (`String`), `last` (`Int`), `before` (`String`).
+
+The `operations` field accepts arguments: `since` (`Time`), `until` (`Time`), `first` (`Int`), `after` (`String`), `last` (`Int`), `before` (`String`).
+
+The `stateChanges` field accepts arguments: `filter` (`AccountStateChangeFilterInput`), `since` (`Time`), `until` (`Time`), `first` (`Int`), `after` (`String`), `last` (`Int`), `before` (`String`).
+
+### Operation
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `Int64!` | Operation ID |
+| `operationType` | `OperationType!` | The type of operation |
+| `operationXdr` | `String!` | XDR-encoded operation |
+| `resultCode` | `String!` | Operation result code |
+| `successful` | `Boolean!` | Whether the operation was successful |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ingestedAt` | `Time!` | When the operation was ingested by the Wallet Backend |
+| `transaction` | `Transaction!` | Parent transaction |
+| `accounts` | `[Account!]!` | Accounts involved in this operation |
+| `stateChanges` | `StateChangeConnection` | Paginated state changes resulting from this operation |
+
+The `stateChanges` field accepts pagination arguments: `first`, `after`, `last`, `before`.
+
+## Balance Types
+
+Balances use a GraphQL interface pattern. All implementations share the fields defined in the `Balance` interface, with additional fields on each concrete type. Use inline fragments to access type-specific fields.
+
+### Balance (Interface)
+
+| Field       | Type         | Description                                 |
+| ----------- | ------------ | ------------------------------------------- |
+| `balance`   | `String!`    | Balance amount                              |
+| `tokenId`   | `String!`    | Unique token identifier                     |
+| `tokenType` | `TokenType!` | Type of token (NATIVE, CLASSIC, SAC, SEP41) |
+
+### NativeBalance
+
+Implements `Balance`. Represents the native XLM balance.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `balance` | `String!` | XLM balance amount |
+| `tokenId` | `String!` | Unique token identifier |
+| `tokenType` | `TokenType!` | Type of token |
+| `minimumBalance` | `String!` | Minimum required balance (base reserve) |
+| `buyingLiabilities` | `String!` | Buying liabilities |
+| `sellingLiabilities` | `String!` | Selling liabilities |
+| `lastModifiedLedger` | `UInt32!` | Ledger number when last modified |
+
+### TrustlineBalance
+
+Implements `Balance`. Represents a classic trustline balance.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `balance` | `String!` | Balance amount |
+| `tokenId` | `String!` | Unique token identifier |
+| `tokenType` | `TokenType!` | Type of token |
+| `code` | `String!` | Asset code (e.g., `USDC`) |
+| `issuer` | `String!` | Asset issuer address |
+| `type` | `String!` | Trustline asset type |
+| `limit` | `String!` | Trustline limit |
+| `buyingLiabilities` | `String!` | Buying liabilities |
+| `sellingLiabilities` | `String!` | Selling liabilities |
+| `lastModifiedLedger` | `UInt32!` | Ledger number when last modified |
+| `isAuthorized` | `Boolean!` | Whether the trustline is authorized |
+| `isAuthorizedToMaintainLiabilities` | `Boolean!` | Whether the trustline is authorized to maintain liabilities |
+
+### SACBalance
+
+Implements `Balance`. Stellar Asset Contract balance -- a classic asset wrapped in a Soroban contract.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `balance` | `String!` | Balance amount |
+| `tokenId` | `String!` | Unique token identifier |
+| `tokenType` | `TokenType!` | Type of token |
+| `code` | `String!` | Asset code |
+| `issuer` | `String!` | Asset issuer address |
+| `decimals` | `Int!` | Token decimal precision |
+| `isAuthorized` | `Boolean!` | Whether the balance is authorized |
+| `isClawbackEnabled` | `Boolean!` | Whether clawback is enabled for this asset |
+
+### SEP41Balance
+
+Implements `Balance`. Custom Soroban token conforming to the SEP-41 token interface.
+
+| Field       | Type         | Description             |
+| ----------- | ------------ | ----------------------- |
+| `balance`   | `String!`    | Balance amount          |
+| `tokenId`   | `String!`    | Unique token identifier |
+| `tokenType` | `TokenType!` | Type of token           |
+| `name`      | `String!`    | Token name              |
+| `symbol`    | `String!`    | Token symbol            |
+| `decimals`  | `Int!`       | Token decimal precision |
+
+### AccountBalances
+
+| Field      | Type          | Description                               |
+| ---------- | ------------- | ----------------------------------------- |
+| `address`  | `String!`     | Account public key address                |
+| `balances` | `[Balance!]!` | List of balances for the account          |
+| `error`    | `String`      | Error message if balance retrieval failed |
+
+## State Change Types
+
+State changes use a GraphQL interface pattern. All implementations share the base fields defined in the `BaseStateChange` interface, with additional fields on each concrete type.
+
+### BaseStateChange (Interface)
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change (nullable) |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+
+### StandardBalanceChange
+
+Implements `BaseStateChange`. Represents a standard balance credit or debit.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `tokenId` | `String!` | Unique token identifier |
+| `amount` | `String!` | Amount of the balance change |
+
+### AccountChange
+
+Implements `BaseStateChange`. Represents an account creation or merge.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `funderAddress` | `String` | Address of the funder (nullable) |
+
+### SignerChange
+
+Implements `BaseStateChange`. Represents a signer addition, removal, or update.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `signerAddress` | `String` | Address of the signer (nullable) |
+| `signerWeights` | `String` | Weight of the signer (nullable) |
+
+### SignerThresholdsChange
+
+Implements `BaseStateChange`. Represents a change to account signature thresholds.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `thresholds` | `String!` | Threshold values |
+
+### MetadataChange
+
+Implements `BaseStateChange`. Represents a change to account data entries.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `keyValue` | `String!` | Key-value data |
+
+### FlagsChange
+
+Implements `BaseStateChange`. Represents a change to account flags.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `flags` | `[String!]!` | List of flags that changed |
+
+### TrustlineChange
+
+Implements `BaseStateChange`. Represents a trustline creation, update, or removal.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `tokenId` | `String` | Unique token identifier (nullable) |
+| `limit` | `String` | Trustline limit (nullable) |
+| `liquidityPoolId` | `String` | Liquidity pool ID (nullable) |
+
+### ReservesChange
+
+Implements `BaseStateChange`. Represents a change to account reserves or sponsorships.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `sponsoredAddress` | `String` | Address of the sponsored account (nullable) |
+| `sponsorAddress` | `String` | Address of the sponsor (nullable) |
+| `liquidityPoolId` | `String` | Liquidity pool ID (nullable) |
+| `claimableBalanceId` | `String` | Claimable balance ID (nullable) |
+| `sponsoredTrustline` | `String` | Sponsored trustline (nullable) |
+| `sponsoredData` | `String` | Sponsored data entry (nullable) |
+
+### BalanceAuthorizationChange
+
+Implements `BaseStateChange`. Represents a change to balance authorization flags.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | `StateChangeCategory!` | Category of state change |
+| `reason` | `StateChangeReason!` | Reason for the state change |
+| `ingestedAt` | `Time!` | When the state change was ingested |
+| `ledgerCreatedAt` | `Time!` | When the ledger was closed on the network |
+| `ledgerNumber` | `UInt32!` | Ledger sequence number |
+| `account` | `Account!` | Account affected by this change |
+| `operation` | `Operation` | Operation that caused this change |
+| `transaction` | `Transaction!` | Transaction that caused this change |
+| `tokenId` | `String` | Unique token identifier (nullable) |
+| `liquidityPoolId` | `String` | Liquidity pool ID (nullable) |
+| `flags` | `[String!]!` | List of authorization flags |
+
+## Enums
+
+### OperationType
+
+The 27 Stellar operation types:
+
+| Value | Description |
+| --- | --- |
+| `CREATE_ACCOUNT` | Create a new account |
+| `PAYMENT` | Send a payment |
+| `PATH_PAYMENT_STRICT_RECEIVE` | Path payment with strict receive amount |
+| `PATH_PAYMENT_STRICT_SEND` | Path payment with strict send amount |
+| `MANAGE_SELL_OFFER` | Create, update, or delete a sell offer |
+| `CREATE_PASSIVE_SELL_OFFER` | Create a passive sell offer |
+| `MANAGE_BUY_OFFER` | Create, update, or delete a buy offer |
+| `SET_OPTIONS` | Set account options (signers, thresholds, flags, etc.) |
+| `CHANGE_TRUST` | Create, update, or delete a trustline |
+| `ALLOW_TRUST` | Allow or revoke trust for an asset |
+| `ACCOUNT_MERGE` | Merge an account into another |
+| `INFLATION` | Run inflation |
+| `MANAGE_DATA` | Set, modify, or delete a data entry |
+| `BUMP_SEQUENCE` | Bump account sequence number |
+| `CREATE_CLAIMABLE_BALANCE` | Create a claimable balance |
+| `CLAIM_CLAIMABLE_BALANCE` | Claim a claimable balance |
+| `BEGIN_SPONSORING_FUTURE_RESERVES` | Begin sponsoring future reserves |
+| `END_SPONSORING_FUTURE_RESERVES` | End sponsoring future reserves |
+| `REVOKE_SPONSORSHIP` | Revoke a sponsorship |
+| `CLAWBACK` | Claw back an asset |
+| `CLAWBACK_CLAIMABLE_BALANCE` | Claw back a claimable balance |
+| `SET_TRUST_LINE_FLAGS` | Set trustline flags |
+| `LIQUIDITY_POOL_DEPOSIT` | Deposit into a liquidity pool |
+| `LIQUIDITY_POOL_WITHDRAW` | Withdraw from a liquidity pool |
+| `INVOKE_HOST_FUNCTION` | Invoke a Soroban smart contract function |
+| `EXTEND_FOOTPRINT_TTL` | Extend the TTL of a Soroban footprint |
+| `RESTORE_FOOTPRINT` | Restore a Soroban footprint |
+
+### StateChangeCategory
+
+The 9 state change categories:
+
+| Value                   | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `BALANCE`               | Balance change (credit, debit, mint, burn) |
+| `ACCOUNT`               | Account creation or merge                  |
+| `SIGNER`                | Signer addition, removal, or update        |
+| `SIGNATURE_THRESHOLD`   | Signature threshold change                 |
+| `METADATA`              | Data entry change                          |
+| `FLAGS`                 | Account flags change                       |
+| `TRUSTLINE`             | Trustline creation, update, or removal     |
+| `RESERVES`              | Reserve or sponsorship change              |
+| `BALANCE_AUTHORIZATION` | Balance authorization change               |
+
+### StateChangeReason
+
+The 18 state change reasons:
+
+| Value         | Description         |
+| ------------- | ------------------- |
+| `CREATE`      | Created             |
+| `MERGE`       | Merged              |
+| `DEBIT`       | Debited             |
+| `CREDIT`      | Credited            |
+| `MINT`        | Minted              |
+| `BURN`        | Burned              |
+| `ADD`         | Added               |
+| `REMOVE`      | Removed             |
+| `UPDATE`      | Updated             |
+| `LOW`         | Low threshold       |
+| `MEDIUM`      | Medium threshold    |
+| `HIGH`        | High threshold      |
+| `HOME_DOMAIN` | Home domain change  |
+| `SET`         | Flag set            |
+| `CLEAR`       | Flag cleared        |
+| `DATA_ENTRY`  | Data entry change   |
+| `SPONSOR`     | Sponsorship added   |
+| `UNSPONSOR`   | Sponsorship removed |
+
+### TokenType
+
+The 4 token types:
+
+| Value     | Description                       |
+| --------- | --------------------------------- |
+| `NATIVE`  | Native XLM token                  |
+| `CLASSIC` | Classic Stellar asset (trustline) |
+| `SAC`     | Stellar Asset Contract            |
+| `SEP41`   | SEP-41 custom Soroban token       |
+
+## Custom Scalars
+
+| Scalar | Description |
+| --- | --- |
+| `Time` | ISO 8601 datetime string (e.g., `2025-01-15T12:00:00Z`) |
+| `UInt32` | Unsigned 32-bit integer |
+| `Int64` | 64-bit integer represented as a string to avoid JavaScript precision loss |
+
+## Input Types
+
+### AccountStateChangeFilterInput
+
+Used to filter state changes when querying an account's `stateChanges` field.
+
+| Field             | Type     | Description                     |
+| ----------------- | -------- | ------------------------------- |
+| `transactionHash` | `String` | Filter by transaction hash      |
+| `operationId`     | `Int64`  | Filter by operation ID          |
+| `category`        | `String` | Filter by state change category |
+| `reason`          | `String` | Filter by state change reason   |
+
+### BuildTransactionInput
+
+Input for building a transaction.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `transactionXdr` | `String!` | XDR-encoded transaction envelope |
+| `simulationResult` | `SimulationResultInput` | Optional simulation result for Soroban transactions |
+
+### SimulationResultInput
+
+Simulation result input for Soroban transactions.
+
+| Field             | Type        | Description                         |
+| ----------------- | ----------- | ----------------------------------- |
+| `transactionData` | `String`    | Serialized transaction data         |
+| `events`          | `[String!]` | List of serialized events           |
+| `minResourceFee`  | `String`    | Minimum resource fee                |
+| `results`         | `[String!]` | List of serialized results          |
+| `latestLedger`    | `Int`       | Latest ledger at time of simulation |
+| `error`           | `String`    | Error message from simulation       |
+
+### CreateFeeBumpTransactionInput
+
+Input for creating a fee bump transaction.
+
+| Field            | Type      | Description                                   |
+| ---------------- | --------- | --------------------------------------------- |
+| `transactionXDR` | `String!` | XDR-encoded transaction to wrap in a fee bump |
+
+## Mutation Payload Types
+
+### BuildTransactionPayload
+
+Response payload for the `buildTransaction` mutation.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `success` | `Boolean!` | Whether the transaction was built successfully |
+| `transactionXdr` | `String!` | XDR-encoded built transaction |
+
+### CreateFeeBumpTransactionPayload
+
+Response payload for the `createFeeBumpTransaction` mutation.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `success` | `Boolean!` | Whether the fee bump transaction was created successfully |
+| `transaction` | `String!` | XDR-encoded fee bump transaction |
+| `networkPassphrase` | `String!` | Network passphrase for the transaction |
+
+## Connection Types (Pagination)
+
+The API uses the Relay-style cursor-based pagination pattern. Each connection type follows the same structure:
+
+### PageInfo
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `startCursor` | `String` | Cursor of the first edge in the page |
+| `endCursor` | `String` | Cursor of the last edge in the page |
+| `hasNextPage` | `Boolean!` | Whether there are more items after the last edge |
+| `hasPreviousPage` | `Boolean!` | Whether there are more items before the first edge |
+
+### TransactionConnection
+
+| Field      | Type                 | Description               |
+| ---------- | -------------------- | ------------------------- |
+| `edges`    | `[TransactionEdge!]` | List of transaction edges |
+| `pageInfo` | `PageInfo!`          | Pagination info           |
+
+**TransactionEdge:**
+
+| Field    | Type          | Description          |
+| -------- | ------------- | -------------------- |
+| `cursor` | `String!`     | Cursor for this edge |
+| `node`   | `Transaction` | The transaction      |
+
+### OperationConnection
+
+| Field      | Type               | Description             |
+| ---------- | ------------------ | ----------------------- |
+| `edges`    | `[OperationEdge!]` | List of operation edges |
+| `pageInfo` | `PageInfo!`        | Pagination info         |
+
+**OperationEdge:**
+
+| Field    | Type        | Description          |
+| -------- | ----------- | -------------------- |
+| `cursor` | `String!`   | Cursor for this edge |
+| `node`   | `Operation` | The operation        |
+
+### StateChangeConnection
+
+| Field      | Type                 | Description                |
+| ---------- | -------------------- | -------------------------- |
+| `edges`    | `[StateChangeEdge!]` | List of state change edges |
+| `pageInfo` | `PageInfo!`          | Pagination info            |
+
+**StateChangeEdge:**
+
+| Field    | Type              | Description          |
+| -------- | ----------------- | -------------------- |
+| `cursor` | `String!`         | Cursor for this edge |
+| `node`   | `BaseStateChange` | The state change     |


### PR DESCRIPTION
## Summary

Adds complete GraphQL API reference documentation for the [Wallet Backend](https://github.com/stellar/wallet-backend) service, plus site navigation integration. All field names, types, enums, and examples

## Files added/changed

| Path | Description |
|------|-------------|
| `config/theme/navbar.ts` | Add Wallet Backend to Data dropdown |
| `docs/data/apis/README.mdx` | Add to feature comparison table and overview |
| `docs/data/apis/wallet-backend/README.mdx` | Overview, key features, navigation |
| `docs/data/apis/wallet-backend/api-reference/queries/*.mdx` | 8 query pages (transactions, operations, accounts, balances, state changes) |
| `docs/data/apis/wallet-backend/api-reference/mutations/*.mdx` | 2 mutation pages (buildTransaction, createFeeBumpTransaction) |
| `docs/data/apis/wallet-backend/api-reference/structure/*.mdx` | Types, authentication, pagination, error handling |

## Context

- Source: https://github.com/stellar/wallet-backend
- Schema verified against: `internal/serve/graphql/schema/*.graphqls` (12 schema files)

<img width="197" height="582" alt="Screenshot 2026-04-08 at 11 20 16" src="https://github.com/user-attachments/assets/911392c3-1251-4909-a58b-2fc59497b5d0" />
<img width="1809" height="878" alt="Screenshot 2026-04-08 at 11 21 41" src="https://github.com/user-attachments/assets/74e57685-f329-4157-931c-9f81ed032832" />
<img width="2514" height="1227" alt="Screenshot 2026-04-08 at 11 22 06" src="https://github.com/user-attachments/assets/40127a60-9de4-4f01-a0d0-f32f452cbb02" />
