### PR TITLE
Update building-with-ai page: remove Agent Skills sentence, add x402/MPP

### DIFF
--- a/docs/tools/developer-tools/building-with-ai.mdx
+++ b/docs/tools/developer-tools/building-with-ai.mdx
@@ -11,7 +11,7 @@ Stellar provides resources to help AI assistants and Large Language Models (LLMs
 
 ## Stellar Development Skill
 
-The [Stellar Development Skill](https://github.com/stellar/stellar-dev-skill) is a comprehensive AI skill that gives coding assistants deep knowledge of the Stellar ecosystem. It follows the open [Agent Skills](https://github.com/anthropics/agent-skills) standard, making it compatible with multiple AI coding tools.
+The [Stellar Development Skill](https://github.com/stellar/stellar-dev-skill) is a comprehensive AI skill that gives coding assistants deep knowledge of the Stellar ecosystem.
 
 The skill provides expertise in:
 
@@ -22,6 +22,7 @@ The skill provides expertise in:
 - Wallet integration (Freighter, Stellar Wallets Kit)
 - Smart accounts with passkeys
 - Testing strategies and security patterns
+- Agentic payment concepts such as x402 and MPP
 
 ### Supported platforms
 
@@ -32,7 +33,6 @@ The skill can be installed on any AI coding tool that supports the [Agent Skills
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/skills/` |
 | [OpenCode](https://opencode.ai) | `~/.config/opencode/skills/` |
 | [OpenAI Codex](https://openai.com/index/openai-codex/) | `~/.codex/skills/` |
-| [Pi](https://github.com/badlogic/pi-mono) | `~/.pi/agent/skills/` |
 
 ### Installation
 

--- a/docs/tools/developer-tools/building-with-ai.mdx
+++ b/docs/tools/developer-tools/building-with-ai.mdx
@@ -22,7 +22,7 @@ The skill provides expertise in:
 - Wallet integration (Freighter, Stellar Wallets Kit)
 - Smart accounts with passkeys
 - Testing strategies and security patterns
-- Agentic payment concepts such as x402 and MPP
+- Agentic payment concepts such as x402 and Machine Payments Protocol (MPP)
 
 ### Supported platforms
 


### PR DESCRIPTION
- Removed "It follows the open Agent Skills standard, making it compatible with multiple AI coding tools." sentence from the Stellar Development Skill description
- Added agentic payment concepts (x402 and MPP) to the skill's expertise list
- Removed Pi from the supported platforms table