### PR TITLE
Update the description for 'create account'

### DIFF
--- a/docs/learn/fundamentals/transactions/list-of-operations.mdx
+++ b/docs/learn/fundamentals/transactions/list-of-operations.mdx
@@ -30,7 +30,7 @@ Creates and funds a new account with the specified starting balance
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| Destination | account ID | Account address to be created and funded by this operation |
+| Destination | account ID | The account address to be created and funded by this operation. |
 | Starting Balance | integer | Amount of XLM to send to the newly created account. This XLM comes from the source account. |
 
 **Possible errors**:

--- a/docs/learn/fundamentals/transactions/list-of-operations.mdx
+++ b/docs/learn/fundamentals/transactions/list-of-operations.mdx
@@ -30,7 +30,7 @@ Creates and funds a new account with the specified starting balance
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| Destination | account ID | New account address that is created and funded. |
+| Destination | account ID | Account address to be created and funded by this operation |
 | Starting Balance | integer | Amount of XLM to send to the newly created account. This XLM comes from the source account. |
 
 **Possible errors**:


### PR DESCRIPTION
I found the original text `"New account address that is created and funded"` ambiguous. It sounded like 'an address that is already created and funded.' 

Updated the description to `"The account address to be created and funded by this operation"`