### PR TITLE
fix: replace LedgerHeader -> LedgerHeaderHistoryEntry

### DIFF
--- a/openrpc/src/stellar-rpc/schemas/Ledgers.json
+++ b/openrpc/src/stellar-rpc/schemas/Ledgers.json
@@ -18,7 +18,7 @@
       },
       "headerXdr": {
         "type": "string",
-        "description": "The [LedgerHeader](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L74) structure for this ledger (base64-encoded string)."
+        "description": "The [LedgerHeaderHistoryEntry](https://github.com/stellar/stellar-xdr/blob/v26.0/Stellar-ledger.x#L277) structure for this ledger (base64-encoded string)."
       },
       "metadataXdr": {
         "type": "string",

--- a/static/stellar-rpc.openrpc.json
+++ b/static/stellar-rpc.openrpc.json
@@ -945,7 +945,7 @@
                   },
                   "headerXdr": {
                     "type": "string",
-                    "description": "The [LedgerHeader](https://github.com/stellar/stellar-xdr/blob/v22.0/Stellar-ledger.x#L74) structure for this ledger (base64-encoded string)."
+                    "description": "The [LedgerHeaderHistoryEntry](https://github.com/stellar/stellar-xdr/blob/v26.0/Stellar-ledger.x#L277) structure for this ledger (base64-encoded string)."
                   },
                   "metadataXdr": {
                     "type": "string",


### PR DESCRIPTION
## What

- Replaces `LedgerHeader` to `LedgerHeaderHistoryEntry` on the getLedgers api reference page
- Replaces link  to src code for `LedgerHeaderHistoryEntry`

Fixes #2365
