### PR TITLE
Update privacy page nomenclature

### DIFF
--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -5,21 +5,21 @@ sidebar_position: 74
 
 # Privacy on Stellar
 
-Stellar is a public blockchain: every transaction is recorded on-chain and visible to anyone. This transparency enables permissionless validation, but many real-world use cases — payroll, institutional settlement, everyday payments — require transaction privacy.
+Stellar is a public blockchain: every transaction is recorded onchain and visible to anyone. This transparency enables permissionless validation, but many real-world use cases — payroll, institutional settlement, everyday payments — require transaction privacy.
 
 To support use cases like these, the Stellar community is building configurable, compliance-ready privacy tools. From low-level cryptographic host functions to managed private payment systems, these solutions help developers protect sensitive financial information while supporting regulatory compliance and enterprise requirements.
 
 ## Privacy Pools
 
-Privacy Pools are smart contract-based systems that let users pay each other or interact with other protocols while optionally keeping their balances, transaction amounts, and addresses private on the public blockchain. Deposits and withdrawals into the pool are visible on-chain, but transactions between parties within the pool do not need to be.
+Privacy Pools are smart contract-based systems that let users pay each other or interact with other protocols while optionally keeping their balances, transaction amounts, and addresses private on the public blockchain. Deposits and withdrawals into the pool are visible onchain, but transactions between parties within the pool do not need to be.
 
-Privacy Pools include built-in features that allow operators to implement compliance policies and processes. Association Set Providers (ASPs) can manage allow/deny lists that ensure known bad actors cannot interact within the pool, while legitimate users, merchants, and exchanges are free to transact safely without revealing unnecessary transaction history or personal information on-chain to prove integrity. Some systems also include view keys that allow authorized parties to investigate suspicious transactions or respond to law enforcement requests, without sacrificing the privacy of other legitimate pool participants.
+Privacy Pools include built-in features that allow operators to implement compliance policies and processes. Association Set Providers (ASPs) can manage allow/deny lists that ensure known bad actors cannot interact within the pool, while legitimate users, merchants, and exchanges are free to transact safely without revealing unnecessary transaction history or personal information onchain to prove integrity. Some systems also include view keys that allow authorized parties to investigate suspicious transactions or respond to law enforcement requests, without sacrificing the privacy of other legitimate pool participants.
 
 - **Whitepaper** (Buterin, Illum, Nadler, Schär, Soleimani): [privacypools.com/whitepaper.pdf](https://privacypools.com/whitepaper.pdf)
 
 ### Stellar Private Payments
 
-Nethermind's ZK team has built a proof-of-concept Privacy Pools implementation for Stellar using Circom circuits, Groth16 proofs, and Soroban smart contracts.
+Nethermind's ZK team has built a proof-of-concept Privacy Pools implementation for Stellar using Circom circuits, Groth16 proofs, and Stellar smart contracts.
 
 :::caution
 
@@ -30,7 +30,7 @@ Research prototype, not audited. Do not use in production with real assets.
 | Component                   | Description                                  |
 | --------------------------- | -------------------------------------------- |
 | Pool contract               | Manages deposits, transfers, and withdrawals |
-| Groth16 verifier            | On-chain ZK proof verification               |
+| Groth16 verifier            | Onchain ZK proof verification               |
 | ASP membership contract     | Merkle tree of approved addresses            |
 | ASP non-membership contract | Sparse Merkle tree for exclusion proofs      |
 
@@ -41,18 +41,18 @@ Proofs are generated client-side in the browser via WebAssembly — user secrets
 
 ## Confidential Tokens
 
-Confidential Tokens let users keep token balances and transaction amounts private while keeping the sender and receiver's addresses publicly visible on-chain. Confidential tokens are designed for contexts where the parties to a transaction are known, but the amounts should not be.
+Confidential Tokens let users keep token balances and transaction amounts private while keeping the sender and receiver's addresses publicly visible onchain. Confidential tokens are designed for contexts where the parties to a transaction are known, but the amounts should not be.
 
 This makes confidential tokens well-suited for payments where parties need confidentiality without sacrificing public auditability.
 
-The [Confidential Token Association](https://www.confidentialtoken.org/) — whose members include the Stellar Development Foundation, Nethermind, OpenZeppelin, and Zama — is developing an open standard for encryption-based on-chain confidentiality compatible with existing token interfaces. Implementation on Soroban is in progress.
+The [Confidential Token Association](https://www.confidentialtoken.org/) — whose members include the Stellar Development Foundation, Nethermind, OpenZeppelin, and Zama — is developing an open standard for encryption-based onchain confidentiality compatible with existing token interfaces. Implementation on Stellar is in progress.
 
 - **Website**: [confidentialtoken.org](https://www.confidentialtoken.org/)
 - **Overview/demo video**: [youtube.com/watch?v=6NnDqVQYOHM](https://www.youtube.com/watch?v=6NnDqVQYOHM)
 
-## On-Chain ZK Verifiers
+## Onchain ZK Verifiers
 
-An on-chain verifier is a Soroban contract that accepts a compact zero-knowledge proof and confirms its validity without re-running the original computation. These verifiers can be used to support zero-knowledge systems that protect privacy and ensure computational integrity. These verifiers build on the cryptographic host functions introduced in Stellar's Protocol 25/26 releases, making them efficient and affordable to run.
+An onchain verifier is a smart contract that accepts a compact zero-knowledge proof and confirms its validity without re-running the original computation. These verifiers can be used to support zero-knowledge systems that protect privacy and ensure computational integrity. These verifiers build on the cryptographic host functions introduced in Stellar's Protocol 25/26 releases, making them efficient and affordable to run.
 
 ### RISC Zero (Groth16) Verifier
 
@@ -67,16 +67,16 @@ A verifier for circuits built with Aztec's Noir language and Barretenberg backen
 
 - **Repo**:
   - [ultrahonk verifier](https://github.com/yugocabrio/rs-soroban-ultrahonk)
-  - [ultrahonk soroban contract](https://github.com/indextree/ultrahonk_soroban_contract)
+  - [ultrahonk Stellar smart contract](https://github.com/indextree/ultrahonk_soroban_contract)
 
 ## ZK Cryptographic Primitives
 
-Stellar's Protocol [22](https://stellar.org/blog/developers/announcing-protocol-22), [25 ("X-Ray")](https://stellar.org/blog/developers/announcing-stellar-x-ray-protocol-25) and [26 ("Yardstick")](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide) releases introduced native host functions into Soroban that underpin all ZK-based privacy on Stellar:
+Stellar's Protocol [22](https://stellar.org/blog/developers/announcing-protocol-22), [25 ("X-Ray")](https://stellar.org/blog/developers/announcing-stellar-x-ray-protocol-25) and [26 ("Yardstick")](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide) releases introduced native host functions into Stellar smart contracts that underpin all ZK-based privacy on Stellar:
 
 **BLS12-381** ([CAP-0059](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0059.md)) – pairing-friendly elliptic curve with 128-bit security and efficient signature aggregation, enabling zk-SNARKs.
 
 **BN254** ([CAP-0074](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0074.md)) — the pairing-friendly elliptic curve used by most ZK applications in production today. Adds `bn254_g1_add`, `bn254_g1_mul`, and `bn254_multi_pairing_check` host functions, mirroring Ethereum's EIP-196/197 precompiles. Existing BN254-based circuits and tooling can be ported to Stellar without modification.
 
-**Poseidon / Poseidon2** ([CAP-0075](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0075.md)) — hash functions designed for ZK circuits. Far more efficient inside proofs than SHA-256, used for commitments, Merkle trees, and nullifiers. Available as host functions, keeping hashing logic consistent between off-chain circuits and on-chain contracts.
+**Poseidon / Poseidon2** ([CAP-0075](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0075.md)) — hash functions designed for ZK circuits. Far more efficient inside proofs than SHA-256, used for commitments, Merkle trees, and nullifiers. Available as host functions, keeping hashing logic consistent between off-chain circuits and onchain contracts.
 
 Navigate to [this page](../apps/zk.mdx) For full details and code examples.

--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -30,7 +30,7 @@ Research prototype, not audited. Do not use in production with real assets.
 | Component                   | Description                                  |
 | --------------------------- | -------------------------------------------- |
 | Pool contract               | Manages deposits, transfers, and withdrawals |
-| Groth16 verifier            | Onchain ZK proof verification               |
+| Groth16 verifier            | Onchain ZK proof verification                |
 | ASP membership contract     | Merkle tree of approved addresses            |
 | ASP non-membership contract | Sparse Merkle tree for exclusion proofs      |
 


### PR DESCRIPTION
Replaced "Soroban" with Stellar smart contracts, and "on-chain" with "onchain", per Stellar comms guidelines.