### PR TITLE
Fix typo: `SURVIVOR_KEYS` -> `SURVEYOR_KEYS`

### DIFF
--- a/docs/validators/admin-guide/monitoring.mdx
+++ b/docs/validators/admin-guide/monitoring.mdx
@@ -169,7 +169,7 @@ The output will look something like:
 
 There is a survey mechanism in the overlay that allows a validator to request connection information from other nodes on the network. The survey can be triggered from a validator, and will flood through the network like any other message, but will request information from other nodes about which nodes it is connected to and a brief summary of their per-connection traffic volumes.
 
-By default, a node will relay or respond to a survey message if the message originated from a node in the receiving node's transitive quorum. This behavior can be overridden by setting the `SURVEYOR_KEYS` field in the config file to a more restrictive set of nodes to relay or respond to. Set `SURVIVOR_KEYS` to `["$self"]` to opt-out of responding to survey requests entirely.
+By default, a node will relay or respond to a survey message if the message originated from a node in the receiving node's transitive quorum. This behavior can be overridden by setting the `SURVEYOR_KEYS` field in the config file to a more restrictive set of nodes to relay or respond to. Set `SURVEYOR_KEYS` to `["$self"]` to opt-out of responding to survey requests entirely.
 
 The survey works in two phases: the collecting phase, and the reporting phase. During the collecting phase, nodes record information about themselves and their peers, such as the number of messages sent to a given peer. During the reporting phase, the surveyor requests the results of the collecting phase from nodes on the network.
 


### PR DESCRIPTION
I noticed a small typo in the core admin guide monitoring docs.