### PR TITLE
Update soroban contract fees documentation to explain that this does …

### DIFF
--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/hourly-soroban-fee-agg-contract.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/hourly-soroban-fee-agg-contract.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hourly Soroban Fee Agg Contract
 sidebar_position: 83
-description: "Hourly Soroban fee aggregation by contract. Strictly per-contract — excludes ops whose footprint has no resolvable contract address (upload_wasm, and code-only extend_footprint_ttl / restore_footprint), so totals here do not represent total network-wide Soroban fees."
+description: "Hourly Soroban fee aggregation by contract. Strictly per-contract — operations whose footprint resolves to no contract address are excluded (`upload_wasm`, plus `extend_footprint_ttl` and `restore_footprint` operations whose footprint contains only `ContractCode` entries with no `ContractData`). Totals here therefore do not represent total network-wide Soroban fees."
 ---
 
 <div className="scoped-data-dictionary-table">
@@ -20,7 +20,7 @@ description: "Hourly Soroban fee aggregation by contract. Strictly per-contract 
 | Name | Description | Data Type | Domain Values | Required? | Notes |
 | --- | --- | --- | --- | --- | --- |
 | hour_agg | Hour-truncated UTC timestamp of the aggregation window. Derived from `timestamp_trunc(closed_at, hour)`. | TIMESTAMP |  | Yes |  |
-| contract_id | The Soroban smart contract address (strkey `C...`) targeted by the transaction — either invoked directly (`invoke_host_function` / `invoke_contract`), deployed (`create_contract` / `create_contract_v2`), or touched via the transaction's Soroban footprint (`extend_footprint_ttl` / `restore_footprint` on `ContractData` entries). Never NULL or empty: rows without a resolvable contract_id are filtered out upstream. | STRING |  | Yes |  |
+| contract_id | The Soroban smart contract address (strkey `C...`) attributed to the transaction. Derived from the operation's `details.type`: `invoke_contract` (the invoked contract), `create_contract` / `create_contract_v2` (the deployed contract), or `extend_footprint_ttl` / `restore_footprint` (the contract whose `ContractData` entry was in the footprint). Never NULL or empty — rows without a resolvable contract_id are filtered out upstream. | STRING |  | Yes |  |
 | txn_count | Total number of Soroban transactions invoking this contract in the hour. | INTEGER |  | Yes |  |
 | failed_txn_count | Number of failed Soroban transactions for this contract in the hour. Failed transactions are still charged inclusion_fee_charged and non_refundable_resource_fee_charged. | INTEGER |  | No |  |
 | unique_fee_source_accounts | Count of distinct fee-paying accounts for this contract in the hour. For fee-bump transactions this is the fee sponsor; for regular transactions this is the transaction originator. Useful for distinguishing between a single account driving a contract's fee volume vs. broad usage. | INTEGER |  | Yes |  |

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/hourly-soroban-fee-agg-contract.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/gold/hourly-soroban-fee-agg-contract.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hourly Soroban Fee Agg Contract
 sidebar_position: 83
-description: ""
+description: "Hourly Soroban fee aggregation by contract. Strictly per-contract — excludes ops whose footprint has no resolvable contract address (upload_wasm, and code-only extend_footprint_ttl / restore_footprint), so totals here do not represent total network-wide Soroban fees."
 ---
 
 <div className="scoped-data-dictionary-table">
@@ -20,7 +20,7 @@ description: ""
 | Name | Description | Data Type | Domain Values | Required? | Notes |
 | --- | --- | --- | --- | --- | --- |
 | hour_agg | Hour-truncated UTC timestamp of the aggregation window. Derived from `timestamp_trunc(closed_at, hour)`. | TIMESTAMP |  | Yes |  |
-| contract_id | The Soroban smart contract address invoked by the transaction. | STRING |  | Yes |  |
+| contract_id | The Soroban smart contract address (strkey `C...`) targeted by the transaction — either invoked directly (`invoke_host_function` / `invoke_contract`), deployed (`create_contract` / `create_contract_v2`), or touched via the transaction's Soroban footprint (`extend_footprint_ttl` / `restore_footprint` on `ContractData` entries). Never NULL or empty: rows without a resolvable contract_id are filtered out upstream. | STRING |  | Yes |  |
 | txn_count | Total number of Soroban transactions invoking this contract in the hour. | INTEGER |  | Yes |  |
 | failed_txn_count | Number of failed Soroban transactions for this contract in the hour. Failed transactions are still charged inclusion_fee_charged and non_refundable_resource_fee_charged. | INTEGER |  | No |  |
 | unique_fee_source_accounts | Count of distinct fee-paying accounts for this contract in the hour. For fee-bump transactions this is the fee sponsor; for regular transactions this is the transaction originator. Useful for distinguishing between a single account driving a contract's fee volume vs. broad usage. | INTEGER |  | Yes |  |


### PR DESCRIPTION
### What

- Adds a frontmatter `description` to `gold/hourly-soroban-fee-agg-contract.mdx` clarifying the model is strictly per-contract and **does not** represent total network-wide Soroban fees.
- Expands the `contract_id` column description to spell out how it's populated: directly invoked contracts (`invoke_host_function` / `invoke_contract`), deployments (`create_contract` / `create_contract_v2`), and contracts touched via the Soroban footprint (`extend_footprint_ttl` / `restore_footprint` on `ContractData` entries). Notes that rows without a resolvable `contract_id` are filtered out upstream.

### Why

The data dictionary page didn't make the model's scope clear. Operations whose footprint has no resolvable contract address — `upload_wasm`, and code-only `extend_footprint_ttl` / `restore_footprint` — are excluded, so summing this table does not yield total network Soroban fees. Analysts using it for network-level fee analysis would get misleading numbers without that caveat.