### PR TITLE
Add CAP-77 note for Soroban settings upgrades.

### DIFF
--- a/docs/validators/admin-guide/soroban-settings.mdx
+++ b/docs/validators/admin-guide/soroban-settings.mdx
@@ -15,6 +15,32 @@ If you are being asked to vote for an upgrade, please move on to the [Examine a 
 
 :::
 
+### Frozen ledger keys
+
+[CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md) has been introduced in protocol 26 to allow validators to make certain ledger keys "frozen", meaning that they will not be accessible for read or write. This is a mechanism that can be used to quarantine corrupted data in case of data corruption bugs, or remove the access to stolen funds in case of security incidents.
+
+Freezing/unfreezing the keys follows the standard upgrade procedure described below. The only caveat is that the upgrade JSON must contain hex-encoded `LedgerKey` XDR in the sets of keys to freeze and/or unfreeze, for example:
+
+```json
+{
+  "updated_entry": [
+    {
+      "frozen_ledger_keys_delta": {
+        "keys_to_freeze": [
+          "000000000000000000000000000000000000000000000000000000000000000000000000"
+        ],
+        "keys_to_unfreeze": [
+          "000000000000000000000000000000000000000000000000000000000000000000000001"
+        ]
+      }
+    }
+  ]
+}
+```
+
+Since most of the systems encode XDR in base64, you can use a helper script in the [stellar-core repository](https://github.com/stellar/stellar-core/blob/master/scripts/frozen_keys_base64_to_hex.py).
+
+
 ## Helper Script
 
 A script to help you create the transactions below is available [in the stellar-core GitHub repo](https://github.com/stellar/stellar-core/blob/master/scripts/settings-helper.sh), with usage details [also available](https://github.com/stellar/stellar-core/blob/master/scripts/README.md). We've saved the information below for now, because it's important to be aware of how the underlying process to generate the transactions works in case the script has some issues.

--- a/docs/validators/admin-guide/soroban-settings.mdx
+++ b/docs/validators/admin-guide/soroban-settings.mdx
@@ -38,7 +38,7 @@ Freezing/unfreezing the keys follows the standard upgrade procedure described be
 }
 ```
 
-Since most of the systems encode XDR in base64, you can use a helper script in the [stellar-core repository](https://github.com/stellar/stellar-core/blob/master/scripts/frozen_keys_base64_to_hex.py).
+Since most tools encode XDR as base64, you can use a helper script in the [stellar-core repository](https://github.com/stellar/stellar-core/blob/master/scripts/frozen_keys_base64_to_hex.py).
 
 ## Helper Script
 

--- a/docs/validators/admin-guide/soroban-settings.mdx
+++ b/docs/validators/admin-guide/soroban-settings.mdx
@@ -40,7 +40,6 @@ Freezing/unfreezing the keys follows the standard upgrade procedure described be
 
 Since most of the systems encode XDR in base64, you can use a helper script in the [stellar-core repository](https://github.com/stellar/stellar-core/blob/master/scripts/frozen_keys_base64_to_hex.py).
 
-
 ## Helper Script
 
 A script to help you create the transactions below is available [in the stellar-core GitHub repo](https://github.com/stellar/stellar-core/blob/master/scripts/settings-helper.sh), with usage details [also available](https://github.com/stellar/stellar-core/blob/master/scripts/README.md). We've saved the information below for now, because it's important to be aware of how the underlying process to generate the transactions works in case the script has some issues.

--- a/docs/validators/admin-guide/soroban-settings.mdx
+++ b/docs/validators/admin-guide/soroban-settings.mdx
@@ -17,7 +17,7 @@ If you are being asked to vote for an upgrade, please move on to the [Examine a 
 
 ### Frozen ledger keys
 
-[CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md) has been introduced in protocol 26 to allow validators to make certain ledger keys "frozen", meaning that they will not be accessible for read or write. This is a mechanism that can be used to quarantine corrupted data in case of data corruption bugs, or remove the access to stolen funds in case of security incidents.
+[CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md) has been introduced in protocol 26 to allow validators to make certain ledger keys "frozen", meaning that they will not be accessible for reading or writing. This is a mechanism that can be used to quarantine corrupted data in case of data corruption bugs, or remove access to stolen funds in case of security incidents.
 
 Freezing/unfreezing the keys follows the standard upgrade procedure described below. The only caveat is that the upgrade JSON must contain hex-encoded `LedgerKey` XDR in the sets of keys to freeze and/or unfreeze, for example:
 


### PR DESCRIPTION
CAP-77 setting upgrade process is mostly the same as for any other setting, the only caveat is hex-encoding, for which we provide a helper script.