### PR TITLE
🐶 Add Husky pre-commit context-based explanations

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,16 +1,33 @@
+#!/bin/bash
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+if ! nvm use 22 >/dev/null 2>&1; then
+  echo "⚠️  Node v22 not installed. Skipping formatting check."
+  exit 0
+fi
+
 G='\033[0;32m'
 P='\033[0;35m'
 CLEAN='\033[0;0m'
 
-staged_mdx_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.mdx')
+if command -v yarn >/dev/null 2>&1; then
+  CHECK_OUTPUT=$(yarn run check:mdx 2>&1)
+  STATUS=$?
 
-[ -z "$staged_mdx_files" ] && exit 0
+  if echo "$CHECK_OUTPUT" | grep -q 'The engine "node" is incompatible with this module'; then
+    echo -e "${G}Warning:${CLEAN} Node version mismatch. Skipping formatting check."
+    exit 0
+  fi
 
-check_failed=0
+  if [ "$STATUS" -ne 0 ]; then
+    echo "$CHECK_OUTPUT"
+    echo -e "${G}Hint:${CLEAN} Run ${P}yarn run format:mdx${CLEAN} to fix formatting."
+    exit 1
+  fi
 
-printf '%s\n' "$staged_mdx_files" | xargs -n 50 yarn prettier --config .prettierrc.js -c || check_failed=1
-
-[ "$check_failed" -eq 0 ] && exit 0
-
-printf '%b\n' "${G}Hint:${CLEAN} execute ${P}yarn prettier --config .prettierrc.js --write <staged-mdx-files>${CLEAN} to format the staged Markdown files"
-exit 1
+else
+  echo -e "${G}Hint:${CLEAN} Yarn not installed. Skipping formatting check."
+  exit 0
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,33 +1,30 @@
 #!/bin/bash
+REQ_NODE_MAJOR=$(sed -E 's/^v?([0-9]+).*/\1/' .nvmrc)
 
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.split(".")[0]')" -lt "$REQ_NODE_MAJOR" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-if ! nvm use 24 >/dev/null 2>&1; then
-  echo "⚠️  Node v24 not installed. Skipping formatting check."
-  exit 0
-fi
-
-G='\033[0;32m'
-P='\033[0;35m'
-CLEAN='\033[0;0m'
-
-if command -v yarn >/dev/null 2>&1; then
-  CHECK_OUTPUT=$(yarn run check:mdx 2>&1)
-  STATUS=$?
-
-  if echo "$CHECK_OUTPUT" | grep -q 'The engine "node" is incompatible with this module'; then
-    echo -e "${G}Warning:${CLEAN} Node version mismatch. Skipping formatting check."
+  if command -v nvm >/dev/null 2>&1; then
+    if ! nvm use "$REQ_NODE_MAJOR" >/dev/null 2>&1; then
+      echo "❔ Node v$REQ_NODE_MAJOR is not installed in nvm. Skipping formatting check."
+      exit 0
+    fi
+  elif command -v node >/dev/null 2>&1; then
+    echo "⚠ Node v$REQ_NODE_MAJOR or higher is required, but $(node -v) is on PATH and nvm is not available. Skipping formatting check."
+    exit 0
+  else
+    echo "✖ Node is not installed and nvm is not available. Skipping formatting check."
     exit 0
   fi
+fi
 
-  if [ "$STATUS" -ne 0 ]; then
-    echo "$CHECK_OUTPUT"
-    echo -e "${G}Hint:${CLEAN} Run ${P}yarn run format:mdx${CLEAN} to fix formatting."
+if command -v yarn >/dev/null 2>&1; then
+  if ! yarn run check:mdx; then
+    echo -e "ℹ  Run \`yarn run format:mdx\` to fix formatting."
     exit 1
   fi
-
 else
-  echo -e "${G}Hint:${CLEAN} Yarn not installed. Skipping formatting check."
+  echo -e "❕ Yarn not installed. Skipping formatting check."
   exit 0
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,8 @@
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-if ! nvm use 22 >/dev/null 2>&1; then
-  echo "⚠️  Node v22 not installed. Skipping formatting check."
+if ! nvm use 24 >/dev/null 2>&1; then
+  echo "⚠️  Node v24 not installed. Skipping formatting check."
   exit 0
 fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,23 @@
 #!/bin/bash
 
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+REQ_NODE_MAJOR=$(sed -E 's/^v?([0-9]+).*/\1/' .nvmrc)
 
-if ! nvm use 24 >/dev/null 2>&1; then
-  echo "⚠️  Node v24 not installed. Skipping formatting check."
-  exit 0
+if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.split(".")[0]')" -lt "$REQ_NODE_MAJOR" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+  if command -v nvm >/dev/null 2>&1; then
+    if ! nvm use "$REQ_NODE_MAJOR" >/dev/null 2>&1; then
+      echo "Node v$REQ_NODE_MAJOR is not installed in nvm. Skipping formatting check."
+      exit 0
+    fi
+  elif command -v node >/dev/null 2>&1; then
+    echo "Node v$REQ_NODE_MAJOR or higher is required, but $(node -v) is on PATH and nvm is not available. Skipping formatting check."
+    exit 0
+  else
+    echo "Node is not installed and nvm is not available. Skipping formatting check."
+    exit 0
+  fi
 fi
 
 G='\033[0;32m'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 REQ_NODE_MAJOR=$(sed -E 's/^v?([0-9]+).*/\1/' .nvmrc)
 
 if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.split(".")[0]')" -lt "$REQ_NODE_MAJOR" ]; then
@@ -19,12 +20,24 @@ if ! command -v node >/dev/null 2>&1 || [ "$(node -p 'process.versions.node.spli
   fi
 fi
 
-if command -v yarn >/dev/null 2>&1; then
-  if ! yarn run check:mdx; then
-    echo -e "ℹ  Run \`yarn run format:mdx\` to fix formatting."
-    exit 1
+if ! command -v yarn >/dev/null 2>&1; then
+  if command -v corepack >/dev/null 2>&1; then
+    if corepack enable >/dev/null 2>&1 && corepack prepare yarn@stable --activate >/dev/null 2>&1; then
+      echo "✓ Yarn is available through Corepack."
+    fi
   fi
-else
-  echo -e "❕ Yarn not installed. Skipping formatting check."
-  exit 0
+  if ! command -v yarn >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+    if npm install -g yarn >/dev/null 2>&1; then
+      echo "✓ Yarn installed with npm."
+    fi
+  fi
+  if ! command -v yarn >/dev/null 2>&1; then
+    echo "❕ Yarn not found. Skipping formatting check."
+    exit 0
+  fi
+fi
+
+if ! yarn run check:mdx; then
+  echo -e "ℹ  Run \`yarn run format:mdx\` to fix formatting."
+  exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,15 @@ G='\033[0;32m'
 P='\033[0;35m'
 CLEAN='\033[0;0m'
 
-yarn run check:mdx || (echo -e "${G}Hint:${CLEAN} execute ${P}yarn run format:mdx${CLEAN} to format files" && exit 1)
+staged_mdx_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.mdx')
+
+[ -z "$staged_mdx_files" ] && exit 0
+
+check_failed=0
+
+printf '%s\n' "$staged_mdx_files" | xargs -n 50 yarn prettier --config .prettierrc.js -c || check_failed=1
+
+[ "$check_failed" -eq 0 ] && exit 0
+
+printf '%b\n' "${G}Hint:${CLEAN} execute ${P}yarn prettier --config .prettierrc.js --write <staged-mdx-files>${CLEAN} to format the staged Markdown files"
+exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 REQ_NODE_MAJOR=$(sed -E 's/^v?([0-9]+).*/\1/' .nvmrc)
 

--- a/docs/data/apis/horizon/api-reference/structure/streaming.mdx
+++ b/docs/data/apis/horizon/api-reference/structure/streaming.mdx
@@ -1,59 +1,27 @@
 ---
-id: streaming
 title: Streaming
-description: Use Horizon streaming mode to receive new ledger data in near real time. Streaming requests use the same endpoint parameters as normal requests and can begin from the earliest known record or from a supplied cursor.
-sidebar_label: Streaming
 sidebar_position: 30
 ---
 
-Horizon supports streaming for endpoints that expose newly ingested ledger data over time.
+import { MethodTable } from "@site/src/components/MethodTable";
 
-Instead of repeatedly polling an endpoint for new results, you can keep a connection open and receive updates as new ledgers close and matching records become available. This is useful when you want to react to ledger activity without repeatedly issuing requests that return no new data.
+Horizon provides a streaming mechanism for receiving events in near real time. Instead of repeatedly sending requests to Horizon for batch updates, a connection is established between a client and Horizon with updates to an endpoint response streaming as new ledgers close and updates occur.
 
-## How Streaming Works
+This reduces requests that return no data and allows near instantaneous updates client-side.
 
-Streaming mode uses the same endpoint and query parameters as the standard request for that resource.
+All attributes for the endpoints that allow streaming are the same as regular responses. A caller can initiate streaming by setting ‘Accept: text/event-stream’ in the HTTP header when making the request.
 
-To open a stream, send the request with the `Accept: text/event-stream` header.
+<MethodTable title="Endpoints with Streaming">
 
-For example:
+|                                                       |
+| ----------------------------------------------------- |
+| [Ledgers](../resources/ledgers/README.mdx)            |
+| [Transactions](../resources/transactions/README.mdx)  |
+| [Operations](../resources/operations/README.mdx)      |
+| [Payments](../resources/payments/README.mdx)          |
+| [Effects](../resources/effects/README.mdx)            |
+| [Accounts](../resources/accounts/README.mdx)          |
+| [Trades](../resources/trades/README.mdx)              |
+| [Order Books](../aggregations/order-books/README.mdx) |
 
-```bash
-curl -N \
-  -H "Accept: text/event-stream" \
-  "<horizon-url>/operations?cursor=now"
-```
-
-## Cursor Behavior
-
-Cursor behavior is the main difference between a standard request and a streaming request.
-
-- If no `cursor` is provided, Horizon starts at the earliest known matching record and streams forward from there.
-- If a `cursor` is provided, Horizon starts from that cursor.
-- If `cursor=now` is provided, Horizon starts from your request time and streams only newly created matching records.
-
-Use `cursor=now` when you want to watch for new activity only. Use a specific cursor when you want to resume from a known point.
-
-## When To Use Streaming
-
-Streaming is a good fit when you want to:
-
-- watch for new transactions, operations, payments, or effects
-- follow new ledger closures
-- track changing order book data
-- keep an application UI updated as new matching records arrive
-
-## Supported Endpoints
-
-Many Horizon resource endpoints support streaming. Check the individual endpoint reference to confirm whether a specific endpoint can be called in streaming mode.
-
-Common examples include endpoints for:
-
-- [Ledgers](../resources/ledgers/README.mdx)
-- [Transactions](../resources/transactions/README.mdx)
-- [Operations](../resources/operations/README.mdx)
-- [Payments](../resources/payments/README.mdx)
-- [Effects](../resources/effects/README.mdx)
-- [Accounts](../resources/accounts/README.mdx)
-- [Trades](../resources/trades/README.mdx)
-- [Order Books](../aggregations/order-books/README.mdx)
+</MethodTable>

--- a/docs/data/apis/horizon/api-reference/structure/streaming.mdx
+++ b/docs/data/apis/horizon/api-reference/structure/streaming.mdx
@@ -1,27 +1,59 @@
 ---
+id: streaming
 title: Streaming
+description: Use Horizon streaming mode to receive new ledger data in near real time. Streaming requests use the same endpoint parameters as normal requests and can begin from the earliest known record or from a supplied cursor.
+sidebar_label: Streaming
 sidebar_position: 30
 ---
 
-import { MethodTable } from "@site/src/components/MethodTable";
+Horizon supports streaming for endpoints that expose newly ingested ledger data over time.
 
-Horizon provides a streaming mechanism for receiving events in near real time. Instead of repeatedly sending requests to Horizon for batch updates, a connection is established between a client and Horizon with updates to an endpoint response streaming as new ledgers close and updates occur.
+Instead of repeatedly polling an endpoint for new results, you can keep a connection open and receive updates as new ledgers close and matching records become available. This is useful when you want to react to ledger activity without repeatedly issuing requests that return no new data.
 
-This reduces requests that return no data and allows near instantaneous updates client-side.
+## How Streaming Works
 
-All attributes for the endpoints that allow streaming are the same as regular responses. A caller can initiate streaming by setting ‘Accept: text/event-stream’ in the HTTP header when making the request.
+Streaming mode uses the same endpoint and query parameters as the standard request for that resource.
 
-<MethodTable title="Endpoints with Streaming">
+To open a stream, send the request with the `Accept: text/event-stream` header.
 
-|                                                       |
-| ----------------------------------------------------- |
-| [Ledgers](../resources/ledgers/README.mdx)            |
-| [Transactions](../resources/transactions/README.mdx)  |
-| [Operations](../resources/operations/README.mdx)      |
-| [Payments](../resources/payments/README.mdx)          |
-| [Effects](../resources/effects/README.mdx)            |
-| [Accounts](../resources/accounts/README.mdx)          |
-| [Trades](../resources/trades/README.mdx)              |
-| [Order Books](../aggregations/order-books/README.mdx) |
+For example:
 
-</MethodTable>
+```bash
+curl -N \
+  -H "Accept: text/event-stream" \
+  "<horizon-url>/operations?cursor=now"
+```
+
+## Cursor Behavior
+
+Cursor behavior is the main difference between a standard request and a streaming request.
+
+- If no `cursor` is provided, Horizon starts at the earliest known matching record and streams forward from there.
+- If a `cursor` is provided, Horizon starts from that cursor.
+- If `cursor=now` is provided, Horizon starts from your request time and streams only newly created matching records.
+
+Use `cursor=now` when you want to watch for new activity only. Use a specific cursor when you want to resume from a known point.
+
+## When To Use Streaming
+
+Streaming is a good fit when you want to:
+
+- watch for new transactions, operations, payments, or effects
+- follow new ledger closures
+- track changing order book data
+- keep an application UI updated as new matching records arrive
+
+## Supported Endpoints
+
+Many Horizon resource endpoints support streaming. Check the individual endpoint reference to confirm whether a specific endpoint can be called in streaming mode.
+
+Common examples include endpoints for:
+
+- [Ledgers](../resources/ledgers/README.mdx)
+- [Transactions](../resources/transactions/README.mdx)
+- [Operations](../resources/operations/README.mdx)
+- [Payments](../resources/payments/README.mdx)
+- [Effects](../resources/effects/README.mdx)
+- [Accounts](../resources/accounts/README.mdx)
+- [Trades](../resources/trades/README.mdx)
+- [Order Books](../aggregations/order-books/README.mdx)


### PR DESCRIPTION
Over the years writing #723 from a few different computers, I ran into a lot of fun situations with the Husky precommit. I started finicking around with it when I got stuck in an airport and couldn't commit locally because of some improper config on a laptop terminal. From there, it expanded to support for local environments that ran a wildly different OS from the cloud shell that compiles the site and runs the GitHub Actions checks.

This started piecing together when I could run the Actions call remotely from the VS Code extension. I was able to isolate what went wrong with local mismatches and write out a fix script path that kept development possible despite configuration technical hiccups. I found myself temporarily importing it in cross-build branches just to allow valid commits.

I really don't see how this repo doesn't have a more fleshed out process like this. Not everyone starts off with advanced computer or terminal familiarity, and that makes it hard to work on the docs locally. My proxy for that is the number of new contributions using anything other than a `patch-*` name from the native edit branch function on the GitHub website.

Hopefully we'll enable a lot more of that now that it's not 20 minutes of config to get the commit box working! As for safety, the PR will still need to pass the script in Actions, so I think we're totally fine. And it preserves the Prettier echo warnings that can pop up to make clear why their PR may have an ❌