### PR TITLE
📝 Normalize `App Guide` Heading Capitalization

### DIFF
--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -19,9 +19,9 @@ Although BasicPay is a full-fledged application on Stellar's Testnet, it has bee
 
 :::
 
-## Project setup
+## Project Setup
 
-### Project requirements
+### Project Requirements
 
 To build a basic Stellar application, you'll need:
 
@@ -52,14 +52,14 @@ This tutorial is probably best viewed as "_nearly_ comprehensive." We aren't goi
 
 :::
 
-### Dev helpers
+### Dev Helpers
 
 - [Stellar Lab]: an experimental playground to interact with the Stellar network
 - Friendbot: a bot that funds accounts with 10,000 fake XLM on Stellar's Testnet; you can fund your account by going to `https://friendbot.stellar.org/?addr=G...`
 - [Testnet toml file]: an example `stellar.toml` file that demonstrates what information an anchor might publish
 - [BasicPay dev helpers]: if you're _using_ the BasicPay application, we've created a few helpful tools to help you explore its functionality
 
-## Getting started
+## Getting Started
 
 Here are the steps we've taken to start building BasicPay. Feel free to be inspired and customize these directions as you see fit. The entire [BasicPay codebase] is freely open and available on GitHub for reference.
 
@@ -69,7 +69,7 @@ This part of the tutorial will need a large helping of "your mileage may vary." 
 
 :::
 
-### Install frameworks
+### Install Frameworks
 
 The first thing we'll need to do is create a SvelteKit app, using `npm`, we are using v18.x of nodejs.
 

--- a/docs/build/apps/ingest-sdk/overview.mdx
+++ b/docs/build/apps/ingest-sdk/overview.mdx
@@ -13,9 +13,9 @@ This tutorial walks through how an application can leverage [CDP architecture](h
 - `github.com/stellar/go-stellar-sdk/network` provides convenient pre-configured settings for Testnet and Mainnet networks
 - `github.com/stellar/go-stellar-sdk/xdr` a complete Golang binding to the Stellar network data model
 
-## Ingestion project setup
+## Ingestion Project Setup
 
-### Project requirements
+### Project Requirements
 
 To use this example CDP pipeline for live Stellar network transaction data, you'll need:
 

--- a/docs/build/apps/wallet/sep38.mdx
+++ b/docs/build/apps/wallet/sep38.mdx
@@ -12,7 +12,7 @@ import Header from "./component/header.mdx";
 
 The [SEP-38] standard defines a way for anchors to provide quotes for the exchange of an off-chain asset and a different on-chain asset, and vice versa. Quotes may be [indicative](https://www.investopedia.com/terms/i/indicativequote.asp) or [firm](https://www.investopedia.com/terms/f/firmquote.asp) ones. When either is used is explained in the sections below.
 
-## Creating Sep-38 Object
+## Creating SEP-38 Object
 
 Let's start with creating a sep38 object, which we'll use for all SEP-38 interactions. Authentication is optional for these requests, and depends on the anchor implementation. For our example we will include it.
 


### PR DESCRIPTION
Most of the docs pages use proper title case for section headings. And most section headings are small enough that it makes sense to do so. I've corrected some instances where the inconsistencies really stood out, without needing a ton of style reworking into flow.