### PR TITLE
🔭 Return Hubble `history-vs-state` page to Markdown

### DIFF
--- a/docs/data/analytics/hubble/analyst-guide/history-vs-state-tables.mdx
+++ b/docs/data/analytics/hubble/analyst-guide/history-vs-state-tables.mdx
@@ -29,14 +29,14 @@ As seen in the table, each row shows the `balance` of `DUMMYACCOUNT` at a sepeci
 
 ### List of state tables
 
-- [Accounts](../data-catalog/data-dictionary/accounts.mdx)
-- [Claimable Balances](../data-catalog/data-dictionary/claimable-balances.mdx)
-- [Contract Code](../data-catalog/data-dictionary/contract-code.mdx)
-- [Contract Data](../data-catalog/data-dictionary/contract-data.mdx)
-- [Liquidity Pools](../data-catalog/data-dictionary/liquidity-pools.mdx)
-- [Offers](../data-catalog/data-dictionary/offers.mdx)
-- [Trustlines](../data-catalog/data-dictionary/trustlines.mdx)
-- [TTL](../data-catalog/data-dictionary/ttl.mdx)
+- [Accounts](../data-catalog/data-dictionary/bronze/accounts.mdx)
+- [Claimable Balances](../data-catalog/data-dictionary/bronze/claimable-balances.mdx)
+- [Contract Code](../data-catalog/data-dictionary/bronze/contract-code.mdx)
+- [Contract Data](../data-catalog/data-dictionary/bronze/contract-data.mdx)
+- [Liquidity Pools](../data-catalog/data-dictionary/bronze/liquidity-pools.mdx)
+- [Offers](../data-catalog/data-dictionary/bronze/offers.mdx)
+- [Trustlines](../data-catalog/data-dictionary/bronze/trustlines.mdx)
+- [TTL](../data-catalog/data-dictionary/bronze/ttl.mdx)
 
 ## What are history tables?
 
@@ -59,11 +59,11 @@ As seen in the table, each row shows the distinct operation with its unique `id`
 
 ### List of history tables
 
-- [History Assets](../data-catalog/data-dictionary/history-assets.mdx)
-- [History Contract Events](../data-catalog/data-dictionary/history-contract-events.mdx)
-- [History Effects](../data-catalog/data-dictionary/history-effects.mdx)
-- [History Ledgers](../data-catalog/data-dictionary/history-ledgers.mdx)
-- [History Operations](../data-catalog/data-dictionary/history-operations.mdx)
-- [History Trades](../data-catalog/data-dictionary/history-trades.mdx)
-- [History Transactions](../data-catalog/data-dictionary/history-transactions.mdx)
-- [Enriched History Operations](../data-catalog/data-dictionary/enriched-history-operations.mdx)
+- [History Assets](../data-catalog/data-dictionary/bronze/history-assets.mdx)
+- [History Contract Events](../data-catalog/data-dictionary/bronze/history-contract-events.mdx)
+- [History Effects](../data-catalog/data-dictionary/bronze/history-effects.mdx)
+- [History Ledgers](../data-catalog/data-dictionary/bronze/history-ledgers.mdx)
+- [History Operations](../data-catalog/data-dictionary/bronze/history-operations.mdx)
+- [History Trades](../data-catalog/data-dictionary/bronze/history-trades.mdx)
+- [History Transactions](../data-catalog/data-dictionary/bronze/history-transactions.mdx)
+- [Enriched History Operations](../data-catalog/data-dictionary/silver/enriched-history-operations.mdx)

--- a/docs/data/analytics/hubble/analyst-guide/history-vs-state-tables.mdx
+++ b/docs/data/analytics/hubble/analyst-guide/history-vs-state-tables.mdx
@@ -27,8 +27,6 @@ Let's say we only want the ledger entries for the balance of `DUMMYACCOUNT`. The
 
 As seen in the table, each row shows the `balance` of `DUMMYACCOUNT` at a sepecific `ledger_sequence`.
 
-```
-
 ### List of state tables
 
 - [Accounts](../data-catalog/data-dictionary/accounts.mdx)
@@ -69,4 +67,3 @@ As seen in the table, each row shows the distinct operation with its unique `id`
 - [History Trades](../data-catalog/data-dictionary/history-trades.mdx)
 - [History Transactions](../data-catalog/data-dictionary/history-transactions.mdx)
 - [Enriched History Operations](../data-catalog/data-dictionary/enriched-history-operations.mdx)
-```

--- a/docs/data/apis/horizon/api-reference/structure/streaming.mdx
+++ b/docs/data/apis/horizon/api-reference/structure/streaming.mdx
@@ -1,59 +1,27 @@
 ---
-id: streaming
 title: Streaming
-description: Use Horizon streaming mode to receive new ledger data in near real time. Streaming requests use the same endpoint parameters as normal requests and can begin from the earliest known record or from a supplied cursor.
-sidebar_label: Streaming
 sidebar_position: 30
 ---
 
-Horizon supports streaming for endpoints that expose newly ingested ledger data over time.
+import { MethodTable } from "@site/src/components/MethodTable";
 
-Instead of repeatedly polling an endpoint for new results, you can keep a connection open and receive updates as new ledgers close and matching records become available. This is useful when you want to react to ledger activity without repeatedly issuing requests that return no new data.
+Horizon provides a streaming mechanism for receiving events in near real time. Instead of repeatedly sending requests to Horizon for batch updates, a connection is established between a client and Horizon with updates to an endpoint response streaming as new ledgers close and updates occur.
 
-## How Streaming Works
+This reduces requests that return no data and allows near instantaneous updates client-side.
 
-Streaming mode uses the same endpoint and query parameters as the standard request for that resource.
+All attributes for the endpoints that allow streaming are the same as regular responses. A caller can initiate streaming by setting ‘Accept: text/event-stream’ in the HTTP header when making the request.
 
-To open a stream, send the request with the `Accept: text/event-stream` header.
+<MethodTable title="Endpoints with Streaming">
 
-For example:
+|                                                       |
+| ----------------------------------------------------- |
+| [Ledgers](../resources/ledgers/README.mdx)            |
+| [Transactions](../resources/transactions/README.mdx)  |
+| [Operations](../resources/operations/README.mdx)      |
+| [Payments](../resources/payments/README.mdx)          |
+| [Effects](../resources/effects/README.mdx)            |
+| [Accounts](../resources/accounts/README.mdx)          |
+| [Trades](../resources/trades/README.mdx)              |
+| [Order Books](../aggregations/order-books/README.mdx) |
 
-```bash
-curl -N \
-  -H "Accept: text/event-stream" \
-  "<horizon-url>/operations?cursor=now"
-```
-
-## Cursor Behavior
-
-Cursor behavior is the main difference between a standard request and a streaming request.
-
-- If no `cursor` is provided, Horizon starts at the earliest known matching record and streams forward from there.
-- If a `cursor` is provided, Horizon starts from that cursor.
-- If `cursor=now` is provided, Horizon starts from your request time and streams only newly created matching records.
-
-Use `cursor=now` when you want to watch for new activity only. Use a specific cursor when you want to resume from a known point.
-
-## When To Use Streaming
-
-Streaming is a good fit when you want to:
-
-- watch for new transactions, operations, payments, or effects
-- follow new ledger closures
-- track changing order book data
-- keep an application UI updated as new matching records arrive
-
-## Supported Endpoints
-
-Many Horizon resource endpoints support streaming. Check the individual endpoint reference to confirm whether a specific endpoint can be called in streaming mode.
-
-Common examples include endpoints for:
-
-- [Ledgers](../resources/ledgers/README.mdx)
-- [Transactions](../resources/transactions/README.mdx)
-- [Operations](../resources/operations/README.mdx)
-- [Payments](../resources/payments/README.mdx)
-- [Effects](../resources/effects/README.mdx)
-- [Accounts](../resources/accounts/README.mdx)
-- [Trades](../resources/trades/README.mdx)
-- [Order Books](../aggregations/order-books/README.mdx)
+</MethodTable>

--- a/docs/data/apis/horizon/api-reference/structure/streaming.mdx
+++ b/docs/data/apis/horizon/api-reference/structure/streaming.mdx
@@ -1,27 +1,59 @@
 ---
+id: streaming
 title: Streaming
+description: Use Horizon streaming mode to receive new ledger data in near real time. Streaming requests use the same endpoint parameters as normal requests and can begin from the earliest known record or from a supplied cursor.
+sidebar_label: Streaming
 sidebar_position: 30
 ---
 
-import { MethodTable } from "@site/src/components/MethodTable";
+Horizon supports streaming for endpoints that expose newly ingested ledger data over time.
 
-Horizon provides a streaming mechanism for receiving events in near real time. Instead of repeatedly sending requests to Horizon for batch updates, a connection is established between a client and Horizon with updates to an endpoint response streaming as new ledgers close and updates occur.
+Instead of repeatedly polling an endpoint for new results, you can keep a connection open and receive updates as new ledgers close and matching records become available. This is useful when you want to react to ledger activity without repeatedly issuing requests that return no new data.
 
-This reduces requests that return no data and allows near instantaneous updates client-side.
+## How Streaming Works
 
-All attributes for the endpoints that allow streaming are the same as regular responses. A caller can initiate streaming by setting ‘Accept: text/event-stream’ in the HTTP header when making the request.
+Streaming mode uses the same endpoint and query parameters as the standard request for that resource.
 
-<MethodTable title="Endpoints with Streaming">
+To open a stream, send the request with the `Accept: text/event-stream` header.
 
-|                                                       |
-| ----------------------------------------------------- |
-| [Ledgers](../resources/ledgers/README.mdx)            |
-| [Transactions](../resources/transactions/README.mdx)  |
-| [Operations](../resources/operations/README.mdx)      |
-| [Payments](../resources/payments/README.mdx)          |
-| [Effects](../resources/effects/README.mdx)            |
-| [Accounts](../resources/accounts/README.mdx)          |
-| [Trades](../resources/trades/README.mdx)              |
-| [Order Books](../aggregations/order-books/README.mdx) |
+For example:
 
-</MethodTable>
+```bash
+curl -N \
+  -H "Accept: text/event-stream" \
+  "<horizon-url>/operations?cursor=now"
+```
+
+## Cursor Behavior
+
+Cursor behavior is the main difference between a standard request and a streaming request.
+
+- If no `cursor` is provided, Horizon starts at the earliest known matching record and streams forward from there.
+- If a `cursor` is provided, Horizon starts from that cursor.
+- If `cursor=now` is provided, Horizon starts from your request time and streams only newly created matching records.
+
+Use `cursor=now` when you want to watch for new activity only. Use a specific cursor when you want to resume from a known point.
+
+## When To Use Streaming
+
+Streaming is a good fit when you want to:
+
+- watch for new transactions, operations, payments, or effects
+- follow new ledger closures
+- track changing order book data
+- keep an application UI updated as new matching records arrive
+
+## Supported Endpoints
+
+Many Horizon resource endpoints support streaming. Check the individual endpoint reference to confirm whether a specific endpoint can be called in streaming mode.
+
+Common examples include endpoints for:
+
+- [Ledgers](../resources/ledgers/README.mdx)
+- [Transactions](../resources/transactions/README.mdx)
+- [Operations](../resources/operations/README.mdx)
+- [Payments](../resources/payments/README.mdx)
+- [Effects](../resources/effects/README.mdx)
+- [Accounts](../resources/accounts/README.mdx)
+- [Trades](../resources/trades/README.mdx)
+- [Order Books](../aggregations/order-books/README.mdx)

--- a/i18n/es/docusaurus-plugin-content-docs/current/data/analytics/hubble/analyst-guide/history-vs-state-tables.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/data/analytics/hubble/analyst-guide/history-vs-state-tables.mdx
@@ -27,8 +27,6 @@ Digamos que solo queremos las entradas de ledger para el balance de `DUMMYACCOUN
 
 Como se ve en la tabla, cada fila muestra el `balance` de `DUMMYACCOUNT` en un `ledger_sequence` específico.
 
-```
-
 ### List of state tables
 
 - [Accounts](../data-catalog/data-dictionary/accounts.mdx)
@@ -69,4 +67,3 @@ As seen in the table, each row shows the distinct operation with its unique `id`
 - [History Trades](../data-catalog/data-dictionary/history-trades.mdx)
 - [History Transactions](../data-catalog/data-dictionary/history-transactions.mdx)
 - [Enriched History Operations](../data-catalog/data-dictionary/enriched-history-operations.mdx)
-```


### PR DESCRIPTION
https://github.com/stellar/stellar-docs/commit/2b092bf85c2fa38d3cce4d861628de244e0c89a2#diff-ccd72c03c28f81372b7d8d7c162d4ba8835150166d210234d7c126c368c67a9b removed a reference to how Hubble returned a different result than Horizon. However, in doing so, it accidentally added ` ``` ` to the end of the file, rendering half the page as a blockquote.

Also fixes the reference links, which grew outdated.