### PR TITLE
🛠️ Create `.gitattributes`  with line-ending policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION

Add a root `.gitattributes` file to normalize text files to LF line endings:

```gitattributes
* text=auto eol=lf
````

## Why

This helps keep the repository consistent across different development environments.

On Windows machines, Git may check out or save files with CRLF line endings depending on local settings. However, the Ubuntu runtime used by GitHub Actions, as well as production-oriented build environments, generally expect LF line endings. Without an explicit repository-level rule, contributors can end up with noisy diffs or subtle formatting differences caused only by line ending changes.

This change makes Git normalize text files consistently so local development, CI, and production builds are working from the same line-ending assumptions.

## Change

* Added `.gitattributes`
* Set text files to use LF endings across the repository

## Impact

This should reduce cross-platform line-ending churn and make diffs cleaner when contributors work across Windows, macOS, Linux, GitHub Actions, and production build environments.

