### PR TITLE
🐜 Patch react-loadable SSR URL resolution

### DIFF
--- a/patches/react-loadable-ssr-addon-v5-slorber+1.0.1.patch
+++ b/patches/react-loadable-ssr-addon-v5-slorber+1.0.1.patch
@@ -1,0 +1,93 @@
+diff --git a/node_modules/react-loadable-ssr-addon-v5-slorber/lib/ReactLoadableSSRAddon.js b/node_modules/react-loadable-ssr-addon-v5-slorber/lib/ReactLoadableSSRAddon.js
+index 80b1d3e..3a42c51 100644
+--- a/node_modules/react-loadable-ssr-addon-v5-slorber/lib/ReactLoadableSSRAddon.js
++++ b/node_modules/react-loadable-ssr-addon-v5-slorber/lib/ReactLoadableSSRAddon.js
+@@ -13,8 +13,6 @@ var _fs = _interopRequireDefault(require("fs"));
+ 
+ var _path = _interopRequireDefault(require("path"));
+ 
+-var _url = _interopRequireDefault(require("url"));
+-
+ var _utils = require("./utils");
+ 
+ var PLUGIN_NAME = 'ReactLoadableSSRAddon';
+@@ -30,6 +28,24 @@ var defaultOptions = {
+ };
+ exports.defaultOptions = defaultOptions;
+ 
++var resolvePublicPath = function resolvePublicPath(publicPath, file) {
++  var base = publicPath || '';
++
++  if (!base) {
++    return file;
++  }
++
++  try {
++    return new URL(file, base).toString();
++  } catch (_unused) {
++    var origin = 'https://webpack.local';
++    var normalizedBase = base.startsWith('/') ? base : "/" + base;
++    var resolved = new URL(file, "" + origin + normalizedBase);
++    var path = "" + resolved.pathname + resolved.search + resolved.hash;
++    return base.startsWith('/') ? path : path.replace(/^\//, '');
++  }
++};
++
+ var ReactLoadableSSRAddon = function () {
+   function ReactLoadableSSRAddon(options) {
+     if (options === void 0) {
+@@ -222,7 +238,7 @@ var ReactLoadableSSRAddon = function () {
+           assets[id][ext].push({
+             file: file,
+             hash: hash,
+-            publicPath: _url["default"].resolve(_this2.options.publicPath || '', file),
++            publicPath: resolvePublicPath(_this2.options.publicPath || '', file),
+             integrity: currentAsset[_this2.options.integrityPropertyName]
+           });
+         }
+diff --git a/node_modules/react-loadable-ssr-addon-v5-slorber/source/ReactLoadableSSRAddon.js b/node_modules/react-loadable-ssr-addon-v5-slorber/source/ReactLoadableSSRAddon.js
+index a416720..c1ecdbe 100644
+--- a/node_modules/react-loadable-ssr-addon-v5-slorber/source/ReactLoadableSSRAddon.js
++++ b/node_modules/react-loadable-ssr-addon-v5-slorber/source/ReactLoadableSSRAddon.js
+@@ -6,7 +6,6 @@
+ 
+ import fs from 'fs';
+ import path from 'path';
+-import url from 'url';
+ import { getFileExtension, computeIntegrity, hasEntry } from './utils';
+ 
+ // Webpack plugin name
+@@ -24,6 +23,24 @@ const defaultOptions = {
+   integrityPropertyName: 'integrity',
+ };
+ 
++const resolvePublicPath = (publicPath, file) => {
++  const base = publicPath || '';
++
++  if (!base) {
++    return file;
++  }
++
++  try {
++    return new URL(file, base).toString();
++  } catch (_) {
++    const origin = 'https://webpack.local';
++    const normalizedBase = base.startsWith('/') ? base : `/${base}`;
++    const resolved = new URL(file, `${origin}${normalizedBase}`);
++    const path = `${resolved.pathname}${resolved.search}${resolved.hash}`;
++    return base.startsWith('/') ? path : path.replace(/^\//, '');
++  }
++};
++
+ /**
+  * React Loadable SSR Add-on for Webpack
+  * @class ReactLoadableSSRAddon
+@@ -304,7 +321,7 @@ class ReactLoadableSSRAddon {
+           assets[id][ext].push({
+             file,
+             hash,
+-            publicPath: url.resolve(this.options.publicPath || '', file),
++            publicPath: resolvePublicPath(this.options.publicPath || '', file),
+             integrity: currentAsset[this.options.integrityPropertyName],
+           });
+         }


### PR DESCRIPTION
This little error popped up during my latest `yarn build`. Looks like the legacy Node variant didn't carry over to the v24 upgrade, so we will move on with this direct implementation. This gives us more space to implement needed linking logic; resolver warning fixed:

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/4c005f2e-13c1-4394-831f-45b622a60ee4" />

## Changes

Replaces the package use of Node’s legacy `url.resolve` with a WHATWG `URL`-based resolver. The patch updates both the compiled library output and the source file included in the package.

This prevents Docusaurus builds on Node 24 from emitting the `DEP0169` `url.parse` deprecation warning while preserving the expected public path behavior for relative paths, absolute paths, and absolute URLs.

Now that this is taken care of, I'd like to work on direct API page links for only the dev site. We can implement a post-build migrator along the lines of this PR, which inlines otherwise external links for import package managers.