### PR TITLE
Replace sunset Stellarbeat references with Obsrvr Radar

### DIFF
--- a/docs/tools/developer-tools/network-status.mdx
+++ b/docs/tools/developer-tools/network-status.mdx
@@ -11,7 +11,7 @@ sidebar_position: 90
 
 Displays the current status of the Testnet and Mainnet. Monitor fee stats, recent operations, lumen supply, and more.
 
-### [Stellarbeat](https://stellarbeat.io/)
+### [Obsrvr Radar](https://radar.withobsrvr.com/)
 
 View Stellar network nodes and visualize consensus.
 

--- a/docs/validators/admin-guide/configuring.mdx
+++ b/docs/validators/admin-guide/configuring.mdx
@@ -134,7 +134,7 @@ When you add a validating node to your quorum set, it's generally because you tr
 
 In order to create a self-verified link between a node and the organization that runs it, a validator declares a home domain on-chain using a [`set_options` operation](../../learn/fundamentals/transactions/list-of-operations.mdx#set-options), and publishes organizational information in a `stellar.toml` file hosted on that domain. To find out how that works, take a look at [SEP-20].
 
-As a result of that link, you can look up a node by its Stellar public key and check the `stellar.toml` file to find out who runs it. It's possible to do that manually, but you can also just consult the list of nodes on [Stellarbeat.io](https://stellarbeat.io/nodes). If you decide to trust an organization, you can use that list to collect the information necessary to add their nodes to your configuration.
+As a result of that link, you can look up a node by its Stellar public key and check the `stellar.toml` file to find out who runs it. It's possible to do that manually, but you can also just consult the list of nodes on [Obsrvr Radar](https://radar.withobsrvr.com/). If you decide to trust an organization, you can use that list to collect the information necessary to add their nodes to your configuration.
 
 When you look at that list, you will discover that the most reliable organizations actually run more than one validator, and adding all of an organization's nodes to your quorum set creates the redundancy necessary to sustain arbitrary node failure. When an organization with a trio of nodes takes one down for maintenance, for instance, the remaining two nodes vote on the organization's behalf, and the organization's network presence persists.
 

--- a/docs/validators/admin-guide/monitoring.mdx
+++ b/docs/validators/admin-guide/monitoring.mdx
@@ -9,7 +9,7 @@ You can access this information using commands and inspecting Stellar Core's out
 
 :::info
 
-[**Stellarbeat**](https://www.stellarbeat.io), a community-run monitoring dashboard, can also be useful for viewing network health as a whole. You should keep a very close eye on your own node(s) using some of the tools suggested on this page, but monitoring performance of all the network's nodes can also be useful to understand how they all interact with each other.
+[**Obsrvr Radar**](https://radar.withobsrvr.com/), a community-run monitoring dashboard, can also be useful for viewing network health as a whole. You should keep a very close eye on your own node(s) using some of the tools suggested on this page, but monitoring performance of all the network's nodes can also be useful to understand how they all interact with each other.
 
 :::
 

--- a/docs/validators/admin-guide/prerequisites.mdx
+++ b/docs/validators/admin-guide/prerequisites.mdx
@@ -33,7 +33,7 @@ A Stellar Core node needs to allow all IPs to connect to its `PEER_PORT` over TC
 
 ### Outbound
 
-A Stellar Core node needs to connect to other nodes on the internet via their `PEER_PORT` over TCP. You can find information about other nodes' `PEER_PORT`s on a network explorer like [Stellarbeat](https://stellarbeat.io/), but most use the default port for this as well, which is (again) **11625**.
+A Stellar Core node needs to connect to other nodes on the internet via their `PEER_PORT` over TCP. You can find information about other nodes' `PEER_PORT`s on a network explorer like [Obsrvr Radar](https://radar.withobsrvr.com/), but most use the default port for this as well, which is (again) **11625**.
 
 ## Internal System Access
 

--- a/docs/validators/tier-1-orgs.mdx
+++ b/docs/validators/tier-1-orgs.mdx
@@ -73,7 +73,7 @@ Letting other validators know when you plan to change your quorum set allows the
 
 We recommend using Prometheus to scrape and store your stellar-core metrics, and Grafana to render that data for human consumption. You can find step-by-step instructions for setting up monitoring and alerts in [Monitoring and Diagnostics](./admin-guide/monitoring.mdx), along with links to Grafana dashboards we’ve created to make things easier.
 
-You can also use [Stellarbeat](https://stellarbeat.io) to view validators’ quorum configurations, get information about their availability and uptime, and the quorum command to diagnose problems with the quorum set of the local node.
+You can also use [Obsrvr Radar](https://radar.withobsrvr.com/) to view validators’ quorum configurations, get information about their availability and uptime, and the quorum command to diagnose problems with the quorum set of the local node.
 
 You should do regular check-ins on your quorum set. If nodes have bad uptime or prove otherwise unreliable, you may need to remove them from your quorum set so that you don’t get stuck and so that the network doesn’t halt. You may also want to add new organizations that come online and prove reliable. If you plan to do either of those things, remember to communicate and coordinate with other validators.
 


### PR DESCRIPTION
## Summary

Stellarbeat (https://stellarbeat.io) has been sunset. Obsrvr Radar (https://radar.withobsrvr.com/) is its successor for validator monitoring and quorum visualization. This PR replaces the 5 Stellarbeat references that remain in the docs.

Files updated:
- docs/tools/developer-tools/network-status.mdx
- docs/validators/admin-guide/configuring.mdx
- docs/validators/admin-guide/monitoring.mdx
- docs/validators/admin-guide/prerequisites.mdx
- docs/validators/tier-1-orgs.mdx

## Test plan
- [ ] Each updated link resolves to https://radar.withobsrvr.com/
- [ ] Rendered Docusaurus output looks correct