### PR TITLE
🧭 Simplified SDEX navbar explanation

### DIFF
--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -263,7 +263,7 @@ const learn: NavbarItem = {
     },
     {
       to: '/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
-      label: 'SDEX',
+      label: 'Stellar Decentralized Exchange',
       activeBasePath: 'docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
     },
     {

--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -263,7 +263,7 @@ const learn: NavbarItem = {
     },
     {
       to: '/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
-      label: 'Stellar Decentralized Exchange',
+      label: 'Stellar Decentralized Exchange (SDEX)',
       activeBasePath: 'docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
     },
     {

--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -229,6 +229,11 @@ const learn: NavbarItem = {
       className: 'has-nested-items',
     },
     {
+      to: '/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
+      label: 'Stellar Decentralized Exchange (SDEX)',
+      activeBasePath: 'docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
+    },
+    {
       to: '/docs/learn/fundamentals/transactions',
       label: 'Operations & Transactions',
       activeBasePath: 'docs/learn/fundamentals/transactions',
@@ -260,11 +265,6 @@ const learn: NavbarItem = {
       to: '/docs/learn/fundamentals/anchors',
       label: 'Ramps (anchors)',
       activeBasePath: 'docs/learn/fundamentals/anchors',
-    },
-    {
-      to: '/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
-      label: 'Stellar Decentralized Exchange (SDEX)',
-      activeBasePath: 'docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools',
     },
     {
       type: 'html',

--- a/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
+++ b/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Liquidity Pools on the Stellar DEX: Provide Liquidity and Enable Asset Swaps"
-sidebar_label: "SDEX"
-description: "Learn how liquidity pools enable trading on the Stellar DEX. Understand how they work, provide liquidity, and enable decentralized asset swaps on the network."
-sidebar_position: 100
+title: "Liquidity Pools on the Stellar Decentralized Exchange: Provide Liquidity and Enable Asset Swaps"
+sidebar_label: "Stellar Decentralized Exchange"
+description: "Learn how liquidity pools enable trading on the Stellar Decentralized Exchange. Understand how they work, provide liquidity, and enable decentralized asset swaps on the network."
+sidebar_position: 42
 ---
 
-# Liquidity on Stellar: SDEX & Liquidity Pools
+# Liquidity on Stellar: Stellar Decentralized Exchange & Liquidity Pools
 
 :::note
 

--- a/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
+++ b/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
@@ -2,7 +2,7 @@
 title: "Liquidity Pools on the Stellar Decentralized Exchange: Provide Liquidity and Enable Asset Swaps"
 sidebar_label: "Stellar Decentralized Exchange"
 description: "Learn how liquidity pools enable trading on the Stellar Decentralized Exchange. Understand how they work, provide liquidity, and enable decentralized asset swaps on the network."
-sidebar_position: 42
+sidebar_position: 55
 ---
 
 # Liquidity on Stellar: Stellar Decentralized Exchange & Liquidity Pools


### PR DESCRIPTION
For readers first coming across Stellar, they may not know what the SDEX is. Other acronym concepts such as SCPU are spelled out in the menubar before having a parenthesis notation:

<img width="264" height="389" alt="image" src="https://github.com/user-attachments/assets/587580e9-dbf2-496d-b932-2ef0077fbf88" />

However, the SDEX doesn't currently receive the same treatment. It's an important concept which encompasses a lot of the network.

Along this line of thinking, this PR also spells out DEX in the page title since the acronym may be unfamiliar and is subsequently explained and defined in the actual doc page.

Lastly, this maintains the sidebar practice of spelling it out without the acronym:

<img width="296" height="363" alt="image" src="https://github.com/user-attachments/assets/be873fb0-b9a3-4db6-80e0-853cec88d0d5" />