### PR TITLE
Add Link response headers for agent discovery (RFC 8288)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,12 +18,20 @@ http {
         rewrite ^/(.*)/$ /$1 permanent;
         try_files $uri $uri.html $uri/index.html =404;
 
-        add_header Link "</stellar-rpc.openrpc.json>; rel=\"service-desc\"; type=\"application/json\"; title=\"Stellar RPC (OpenRPC)\"" always;
+        add_header Link "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\"" always;
+        add_header Link "</openapi/horizon.yml>; rel=\"service-desc\"; type=\"application/yaml\"; title=\"Horizon OpenAPI\"" always;
+        add_header Link "</openapi/anchor-platform.yaml>; rel=\"service-desc\"; type=\"application/yaml\"; title=\"Anchor Platform OpenAPI\"" always;
+        add_header Link "</openapi/stellar-disbursement-platform.yaml>; rel=\"service-desc\"; type=\"application/yaml\"; title=\"Stellar Disbursement Platform OpenAPI\"" always;
+        add_header Link "</stellar-rpc.openrpc.json>; rel=\"service-desc\"; type=\"application/json\"; title=\"Stellar RPC OpenRPC\"" always;
         add_header Link "</docs/data/apis/horizon/api-reference>; rel=\"service-doc\"; title=\"Horizon API reference\"" always;
         add_header Link "</docs/data/apis/rpc/api-reference>; rel=\"service-doc\"; title=\"Stellar RPC API reference\"" always;
         add_header Link "</docs/platforms/anchor-platform/api-reference>; rel=\"service-doc\"; title=\"Anchor Platform API reference\"" always;
         add_header Link "</docs/platforms/stellar-disbursement-platform/api-reference>; rel=\"service-doc\"; title=\"Stellar Disbursement Platform API reference\"" always;
         add_header Link "</llms.txt>; rel=\"describedby\"; type=\"text/plain\"; title=\"LLM-friendly site description\"" always;
+    }
+    location = /.well-known/api-catalog {
+        default_type application/linkset+json;
+        try_files $uri =404;
     }
     location /assets/ {
         try_files $uri $uri/ =404;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,6 +17,13 @@ http {
     location / {
         rewrite ^/(.*)/$ /$1 permanent;
         try_files $uri $uri.html $uri/index.html =404;
+
+        add_header Link "</stellar-rpc.openrpc.json>; rel=\"service-desc\"; type=\"application/json\"; title=\"Stellar RPC (OpenRPC)\"" always;
+        add_header Link "</docs/data/apis/horizon/api-reference>; rel=\"service-doc\"; title=\"Horizon API reference\"" always;
+        add_header Link "</docs/data/apis/rpc/api-reference>; rel=\"service-doc\"; title=\"Stellar RPC API reference\"" always;
+        add_header Link "</docs/platforms/anchor-platform/api-reference>; rel=\"service-doc\"; title=\"Anchor Platform API reference\"" always;
+        add_header Link "</docs/platforms/stellar-disbursement-platform/api-reference>; rel=\"service-doc\"; title=\"Stellar Disbursement Platform API reference\"" always;
+        add_header Link "</llms.txt>; rel=\"describedby\"; type=\"text/plain\"; title=\"LLM-friendly site description\"" always;
     }
     location /assets/ {
         try_files $uri $uri/ =404;

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,72 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://developers.stellar.org/docs/data/apis/horizon",
+      "service-desc": [
+        {
+          "href": "https://developers.stellar.org/openapi/horizon.yml",
+          "type": "application/yaml",
+          "title": "Horizon OpenAPI specification"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://developers.stellar.org/docs/data/apis/horizon/api-reference",
+          "type": "text/html",
+          "title": "Horizon API reference"
+        }
+      ]
+    },
+    {
+      "anchor": "https://developers.stellar.org/docs/data/apis/rpc",
+      "service-desc": [
+        {
+          "href": "https://developers.stellar.org/stellar-rpc.openrpc.json",
+          "type": "application/json",
+          "title": "Stellar RPC OpenRPC specification"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://developers.stellar.org/docs/data/apis/rpc/api-reference",
+          "type": "text/html",
+          "title": "Stellar RPC API reference"
+        }
+      ]
+    },
+    {
+      "anchor": "https://developers.stellar.org/docs/platforms/anchor-platform",
+      "service-desc": [
+        {
+          "href": "https://developers.stellar.org/openapi/anchor-platform.yaml",
+          "type": "application/yaml",
+          "title": "Anchor Platform OpenAPI specification"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://developers.stellar.org/docs/platforms/anchor-platform/api-reference",
+          "type": "text/html",
+          "title": "Anchor Platform API reference"
+        }
+      ]
+    },
+    {
+      "anchor": "https://developers.stellar.org/docs/platforms/stellar-disbursement-platform",
+      "service-desc": [
+        {
+          "href": "https://developers.stellar.org/openapi/stellar-disbursement-platform.yaml",
+          "type": "application/yaml",
+          "title": "Stellar Disbursement Platform OpenAPI specification"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://developers.stellar.org/docs/platforms/stellar-disbursement-platform/api-reference",
+          "type": "text/html",
+          "title": "Stellar Disbursement Platform API reference"
+        }
+      ]
+    }
+  ]
+}

--- a/static/openapi/anchor-platform.yaml
+++ b/static/openapi/anchor-platform.yaml
@@ -1,0 +1,664 @@
+openapi: 3.1.0
+info:
+  version: 3.0.0
+  title: Platform Server
+  description: |
+    The platform server is an internal component. It should be hosted in a private network and should not be accessible from the Internet. This server enables the business to fetch and update the state of transactions using its API.
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://platform-server.exampleanchor.com
+tags:
+  - name: Transactions
+    description: Transactions initiated by client applications via SEP APIs
+paths:
+  /transactions:
+    get:
+      tags:
+        - Transactions
+      x-seps:
+        - SEP-6
+        - SEP-24
+        - SEP-31
+      summary: Retrieve a List of Transactions
+      operationId: getTransactions
+      description: Allows to query list of transactions for desired SEP. This api supports pagination, and it's possible (and recommended) to make multiple requests to query transactions. The last page is reached when the number of elements returned by the endpoint is smaller than provided `page_size`.
+      parameters:
+        - in: query
+          name: sep
+          required: true
+          schema:
+            type: string
+            enum:
+              - '6'
+              - '24'
+              - '31'
+          description: Lookup transactions belonging to this SEP.
+        - in: query
+          name: order_by
+          schema:
+            type: string
+            enum:
+              - created_at
+              - transfer_received_at
+              - user_action_required_by
+            default: created_at
+          description: |-
+            Specifies field that transactions will be ordered by. Note, that secondary sort is transaction id in ascending value.
+            I.e. when timestamps for 2 or more transactions is identical, they will be sorted by id.
+        - in: query
+          name: order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            default: asc
+          description: |-
+            Specifies order. Note, that when the field is null, all transactions with null value will be last, regardless of soring order (NULLS LAST).
+            For example, transfer time may not be specified for some transactions, resulting into `transfer_received_at` being null. If so, transactions with non-null values will be sorted and returned first, followed by all transactions with null timestamps.
+        - in: query
+          name: statuses
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/StatusSEPAll'
+          description: Filters transactions for specified array of statuses. If not provided, filtering is disabled (default behavior)
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            default: 20
+          description: Size of a single search page. Must be positive.
+        - in: query
+          name: page_number
+          schema:
+            type: integer
+            default: 0
+          description: Page number to use for continuous search. Page count beings at 0.
+      responses:
+        '200':
+          description: Transaction found.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/TransactionListSEP6'
+                  - $ref: '#/components/schemas/TransactionListSEP24'
+                  - $ref: '#/components/schemas/TransactionListSEP31'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Transaction not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /transactions/{id}:
+    get:
+      tags:
+        - Transactions
+      x-seps:
+        - SEP-6
+        - SEP-24
+        - SEP-31
+      summary: Retrieve a Transaction
+      operationId: getTransaction
+      description: Provides the information necessary for the business to determine the state of the transaction identified by `id`, decide if any action must be taken to continue processing the transaction, and act on the decision.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Transaction found.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/TransactionSEP6'
+                  - $ref: '#/components/schemas/TransactionSEP24'
+                  - $ref: '#/components/schemas/TransactionSEP31'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Transaction not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    StatusSEPAll:
+      type: string
+      description: Possible status values for all transactions
+      enum:
+        - incomplete
+        - completed
+        - refunded
+        - expired
+        - error
+        - pending_stellar
+        - pending_external
+        - pending_user_transfer_start
+        - pending_user_transfer_complete
+        - pending_anchor
+        - pending_trust
+        - pending_user
+        - no_market
+        - too_small
+        - too_large
+        - pending_sender
+        - pending_receiver
+        - pending_transaction_info_update
+        - pending_customer_info_update
+    StatusSEP6:
+      type: string
+      description: Possible status value for SEP-6 transactions
+      enum:
+        - incomplete
+        - completed
+        - refunded
+        - expired
+        - error
+        - pending_stellar
+        - pending_external
+        - pending_customer_info_update
+        - pending_user_transfer_start
+        - pending_user_transfer_complete
+        - pending_anchor
+        - pending_trust
+        - pending_user
+        - no_market
+        - too_small
+        - too_large
+    Amount:
+      type: object
+      required:
+        - amount
+        - asset
+      properties:
+        amount:
+          type: string
+        asset:
+          type: string
+    FeeDescription:
+      type: object
+      required:
+        - name
+        - amount
+      properties:
+        name:
+          type: string
+        amount:
+          type: string
+        description:
+          type: string
+    FeeDetails:
+      type: object
+      required:
+        - total
+        - asset
+      properties:
+        total:
+          type: string
+        asset:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeeDescription'
+    Refunds:
+      type: object
+      properties:
+        amount_refunded:
+          $ref: '#/components/schemas/Amount'
+        amount_fee:
+          $ref: '#/components/schemas/Amount'
+        payments:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              id_type:
+                type: string
+                enum:
+                  - stellar
+                  - external
+              amount:
+                $ref: '#/components/schemas/Amount'
+              fee:
+                $ref: '#/components/schemas/Amount'
+              requested_at:
+                type: string
+                format: date-time
+              refunded_at:
+                type: string
+                format: date-time
+    StellarTransaction:
+      type: object
+      required:
+        - id
+        - created_at
+        - envelope
+        - payments
+      properties:
+        id:
+          type: string
+          description: The ID of the transaction in the Stellar network.
+        memo:
+          type: string
+          description: The memo of the transaction in the Stellar network.
+        memo_type:
+          type: string
+          description: The memo type of the transaction in the Stellar network. Should be present if memo is not null.
+          enum:
+            - text
+            - hash
+            - id
+        created_at:
+          type: string
+          format: date-time
+          description: The time the transaction was registered in the Stellar network.
+        envelope:
+          type: string
+          description: The transaction envelope, containing all the transaction information.
+        payments:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - payment_type
+              - source_account
+              - destination_account
+              - amount
+            properties:
+              id:
+                type: string
+                description: The ID of the payment in the Stellar Network.
+              payment_type:
+                type: string
+                description: The type of payment in the Stellar Network.
+                enum:
+                  - payment
+                  - path_payment
+                default: payment
+              source_account:
+                type: string
+                description: The account being debited in the Stellar Network.
+              destination_account:
+                type: string
+                description: The account being credited in the Stellar Network.
+              amount:
+                $ref: '#/components/schemas/Amount'
+    MemoType:
+      type: string
+      description: The memo type of the transaction in the Stellar network. Should be present if memo is not null.
+      enum:
+        - text id hash
+    StellarId:
+      type: object
+      description: |
+        StellarId's are objects that identify end-users and SEP-31 Sending Anchors, but not SEP-31 Receiving Anchors.
+
+        For a SEP-12 customer, the `id` field should be sufficient to fully identify the customer in the business' Backend.
+
+        For a SEP-31 Sending Anchor, the `account` and `memo` fields should be used.
+
+        For a SEP-6 or SEP-24 Anchor, the `account` and `memo` fields should be used.
+      properties:
+        id:
+          type: string
+          description: The `id` of the customer registered through SEP-12.
+        account:
+          type: string
+          description: Either the Stellar account or Muxed account address of the on-chain entity.
+        memo:
+          type: string
+          description: The memo value identifying a customer with a shared account, where the shared account is `account`.
+    TransactionSEP6:
+      type: object
+      required:
+        - id
+        - sep
+        - kind
+        - status
+        - started_at
+      properties:
+        id:
+          type: string
+        sep:
+          type: string
+          enum:
+            - '6'
+        kind:
+          type: string
+          enum:
+            - deposit
+            - deposit-exchange
+            - withdrawal
+            - withdrawal-exchange
+        status:
+          $ref: '#/components/schemas/StatusSEP6'
+        type:
+          type: string
+          description: The method the user used to deposit or withdraw offchain funds.
+        amount_expected:
+          $ref: '#/components/schemas/Amount'
+        amount_in:
+          $ref: '#/components/schemas/Amount'
+        amount_out:
+          $ref: '#/components/schemas/Amount'
+        fee_details:
+          $ref: '#/components/schemas/FeeDetails'
+        quote_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        transfer_received_at:
+          type: string
+          format: date-time
+        user_action_required_by:
+          type: string
+          format: date-time
+        message:
+          type: string
+        refunds:
+          $ref: '#/components/schemas/Refunds'
+        stellar_transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/StellarTransaction'
+        source_account:
+          type: string
+        destination_account:
+          type: string
+        external_transaction_id:
+          type: string
+        memo:
+          type: string
+        memo_type:
+          $ref: '#/components/schemas/MemoType'
+        refund_memo:
+          type: string
+          description: If provided, this memo should be used for refund transactions.
+        refund_memo_type:
+          $ref: '#/components/schemas/MemoType'
+        client_domain:
+          type: string
+        client_name:
+          type: string
+        customers:
+          type: object
+          description: |
+            The user that initiated the transaction is both the sender and receiver.
+          properties:
+            sender:
+              $ref: '#/components/schemas/StellarId'
+            receiver:
+              $ref: '#/components/schemas/StellarId'
+        creator:
+          $ref: '#/components/schemas/StellarId'
+    TransactionListSEP6:
+      type: object
+      properties:
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionSEP6'
+    StatusSEP24:
+      type: string
+      description: Possible status value for SEP-24 transactions
+      enum:
+        - incomplete
+        - completed
+        - refunded
+        - expired
+        - error
+        - pending_stellar
+        - pending_external
+        - pending_user_transfer_start
+        - pending_user_transfer_complete
+        - pending_anchor
+        - pending_trust
+        - pending_user
+        - no_market
+        - too_small
+        - too_large
+    TransactionSEP24:
+      type: object
+      required:
+        - id
+        - sep
+        - kind
+        - status
+        - amount_expected
+        - destination_account
+        - started_at
+      properties:
+        id:
+          type: string
+        sep:
+          type: string
+          enum:
+            - '24'
+        kind:
+          type: string
+          enum:
+            - deposit
+            - withdrawal
+        status:
+          $ref: '#/components/schemas/StatusSEP24'
+        type:
+          type: string
+          description: This field is always empty for SEP-24 transactions.
+        amount_expected:
+          $ref: '#/components/schemas/Amount'
+        amount_in:
+          $ref: '#/components/schemas/Amount'
+        amount_out:
+          $ref: '#/components/schemas/Amount'
+        fee_details:
+          $ref: '#/components/schemas/FeeDetails'
+        quote_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        transfer_received_at:
+          type: string
+          format: date-time
+        user_action_required_by:
+          type: string
+          format: date-time
+        message:
+          type: string
+        refunds:
+          $ref: '#/components/schemas/Refunds'
+        stellar_transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/StellarTransaction'
+        source_account:
+          type: string
+        destination_account:
+          type: string
+        external_transaction_id:
+          type: string
+        memo:
+          type: string
+        memo_type:
+          $ref: '#/components/schemas/MemoType'
+        refund_memo:
+          description: If provided, this memo should be used for refund transactions.
+          type: string
+        refund_memo_type:
+          $ref: '#/components/schemas/MemoType'
+        client_domain:
+          type: string
+        client_name:
+          type: string
+        customers:
+          type: object
+          description: |
+            The user that initiated the transaction is both the sender and receiver.
+          properties:
+            sender:
+              $ref: '#/components/schemas/StellarId'
+            receiver:
+              $ref: '#/components/schemas/StellarId'
+        creator:
+          $ref: '#/components/schemas/StellarId'
+    TransactionListSEP24:
+      type: object
+      properties:
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionSEP24'
+    StatusSEP31:
+      type: string
+      description: Possible status value for SEP-31 transactions
+      enum:
+        - incomplete
+        - completed
+        - refunded
+        - expired
+        - error
+        - pending_stellar
+        - pending_external
+        - pending_sender
+        - pending_receiver
+        - pending_transaction_info_update
+        - pending_customer_info_update
+    TransactionSEP31:
+      type: object
+      required:
+        - id
+        - sep
+        - kind
+        - status
+        - started_at
+      properties:
+        id:
+          type: string
+        sep:
+          type: string
+          enum:
+            - '31'
+        kind:
+          type: string
+          enum:
+            - receive
+        status:
+          $ref: '#/components/schemas/StatusSEP31'
+        type:
+          type: string
+          description: This field is always empty for SEP-31 transactions.
+        amount_expected:
+          $ref: '#/components/schemas/Amount'
+        amount_in:
+          $ref: '#/components/schemas/Amount'
+        amount_out:
+          $ref: '#/components/schemas/Amount'
+        fee_details:
+          $ref: '#/components/schemas/FeeDetails'
+        quote_id:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        transfer_received_at:
+          type: string
+          format: date-time
+        user_action_required_by:
+          type: string
+          format: date-time
+        message:
+          type: string
+        refunds:
+          $ref: '#/components/schemas/Refunds'
+        stellar_transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/StellarTransaction'
+        source_account:
+          type: string
+        destination_account:
+          type: string
+        external_transaction_id:
+          type: string
+        memo:
+          type: string
+        memo_type:
+          $ref: '#/components/schemas/MemoType'
+        refund_memo:
+          description: if provided, this memo should be used for refund transactions.
+          type: string
+        refund_memo_type:
+          $ref: '#/components/schemas/MemoType'
+        client_domain:
+          type: string
+        client_name:
+          type: string
+        customers:
+          type: object
+          description: |
+            The Identification info of the sending and receiving customers. If they were created through [SEP-12](https://stellar.org/protocol/sep-12),
+            this object should contain the SEP-12 customer `id`. Otherwise, the `account` address of the customer.
+          properties:
+            sender:
+              $ref: '#/components/schemas/StellarId'
+            receiver:
+              $ref: '#/components/schemas/StellarId'
+        creator:
+          $ref: '#/components/schemas/StellarId'
+    TransactionListSEP31:
+      type: object
+      properties:
+        records:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionSEP31'
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+        id:
+          type: string
+      required:
+        - error

--- a/static/openapi/horizon.yml
+++ b/static/openapi/horizon.yml
@@ -1,0 +1,8251 @@
+openapi: 3.1.0
+info:
+  title: Horizon
+  version: 0.0.1
+  summary: Horizon provides an HTTP API to data in the Stellar network. It ingests and re-serves the data produced by the Stellar network in a form that is easier to consume by the average application relative to the performance-oriented data representations used by Stellar Core. This API serves the bridge between apps and Stellar Core. Projects like wallets, decentralized exchanges, and asset issuers use Horizon to submit transactions, query an account balance, or stream events like transactions to an account.
+  description: |
+    Horizon provides an HTTP API to data in the Stellar network. It ingests and re-serves the data produced by the Stellar network in a form that is easier to consume by the average application relative to the performance-oriented data representations used by [Stellar Core](https://developers.stellar.org/network/core-node). This API serves the bridge between apps and Stellar Core. Projects like wallets, decentralized exchanges, and asset issuers use Horizon to submit transactions, query an account balance, or stream events like transactions to an account.
+
+    Horizon can be accessed via cURL, a browser, or one of the [Stellar SDKs](https://developers.stellar.org/docs/tools/sdks). To reduce the complexity of your project, we recommend you use an SDK instead of making direct API calls.
+
+    This guide describes how to administer a production Horizon instance (refer to the [Developers' Blog](https://www.stellar.org/developers-blog/a-new-sun-on-the-horizon) for some background on the performance and architectural improvements of this major version bump). For information about developing on the Horizon codebase, check out the [Development Guide](https://github.com/stellar/stellar-horizon/blob/main/DEVELOPING.md).
+
+    Before we begin, it's worth reiterating the sentiment echoed in the [Core Node](https://developers.stellar.org/network/core-node) documentation: **we do not endorse running Horizon backed by a standalone Stellar Core instance**, and especially not by a _validating_ Stellar Core. These are two separate concerns, and decoupling them is important for both reliability and performance. Horizon instead manages its own, pared-down version of Stellar Core optimized for its own subset of needs (we'll refer to this as a "Captive Core" instance).
+  termsOfService: https://stellar.org/terms-of-service
+  contact:
+    name: Stellar Development Foundation
+    url: https://stellar.org
+    email: hello@stellar.org
+  license:
+    name: Apache 2.0
+    identifier: Apache-2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: https://horizon-testnet.stellar.org
+    description: The Testnet Network
+  - url: https://horizon-futurenet.stellar.org
+    description: The Futurenet network
+tags:
+  - name: Accounts
+    description: Users interact with the Stellar network through accounts. Everything else in the ledger—assets, offers, trustlines, etc. are owned by accounts, and accounts must authorize all changes to the ledger through signed transactions.
+  - name: Assets
+    description: Assets are representations of value issued on the Stellar network. An asset consists of a type, code, and issuer.
+  - name: Claimable Balances
+    description: A Claimable Balance represents the transfer of ownership of some amount of an asset. Claimable balances provide a mechanism for setting up a payment which can be claimed in the future. This allows you to make payments to accounts which are currently not able to accept them.
+  - name: Effects
+    description: Effects represent specific changes that occur in the ledger as a result of successful operations, but are not necessarily directly reflected in the ledger or history, as transactions and operations are.
+  - name: Fee Stats
+    description: Fee stats are used to predict what fee to set for a transaction before submitting it to the network.
+  - name: Liquidity Pools
+    description: Liquidity Pools provide a simple, non-interactive way to trade large amounts of capital and enable high volumes of trading.
+  - name: Ledgers
+    description: Each ledger stores the state of the network at a point in time and contains all the changes - transactions, operations, effects, etc. - to that state.
+  - name: Offers
+    description: Offers are statements about how much of an asset an account wants to buy or sell.
+  - name: Operations
+    description: 'Operations are objects that represent a desired change to the ledger: payments, offers to exchange currency, changes made to account options, etc. Operations are submitted to the Stellar network grouped in a Transaction.'
+  - name: Order Books
+    description: An order book is a collections of offers for a specific pair of assets.
+  - name: Paths
+    description: Paths provide information about potential path payments. A path can be used to populate the necessary fields for a path payment operation.
+  - name: Payments
+    description: Payments are objects that represent balance transfer from one address to another. Payments are submitted to the Stellar network grouped in a Transaction.
+  - name: Trade Aggregations
+    description: A trade aggregation represents aggregated statistics on an asset pair (base and counter) for a specific time period. Trade aggregations are useful to developers of trading clients and provide historical trade data.
+  - name: Trades
+    description: When an offer is fully or partially fulfilled, a trade happens. Trades can also be caused by successful path payments, because path payments involve fulfilling offers. A trade occurs between two parties—base and counter. Which is which is either arbitrary or determined by the calling query.
+  - name: Transactions
+    description: Transactions are commands that modify the ledger state and consist of one or more operations.
+paths:
+  /accounts:
+    get:
+      tags:
+        - Accounts
+      summary: List all Accounts
+      description: 'This endpoint lists accounts by one of four filters : signer, asset, liquidity pool  or sponsor.'
+      operationId: ListAllAccounts
+      parameters:
+        - $ref: '#/components/parameters/SponsorParam'
+        - $ref: '#/components/parameters/AssetParam'
+        - $ref: '#/components/parameters/SignerParam'
+        - $ref: '#/components/parameters/LiquidityPoolParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: 'Returns accounts based on provided filter: signer , asset, sponser or liquidity pool'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Account'
+              examples:
+                ListAllAccounts:
+                  $ref: '#/components/examples/ListAllAccounts'
+  /accounts/{account_id}:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account
+      description: The single account endpoint provides information on a specific account. The balances section in the response will also list all the trustlines this account has established, including trustlines that haven’t been authorized yet.
+      operationId: RetrieveAnAccount
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+      responses:
+        '200':
+          description: Returns details like balances, sponserships etc. about an account.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Account'
+              examples:
+                RetrieveAnAccount:
+                  $ref: '#/components/examples/RetrieveAnAccount'
+  /accounts/{account_id}/transactions:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Transactions
+      description: This endpoint represents successful transactions for a given account and can be used in streaming mode. Streaming mode allows you to listen for new transactions for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known transaction unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream transactions created since your request time.
+      operationId: GetTransactionsByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Transaction'
+              examples:
+                RetrieveAnAccountsTransactions:
+                  $ref: '#/components/examples/RetrieveAnAccountsTransactions'
+  /accounts/{account_id}/operations:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Operations
+      description: This endpoint represents successful operations for a given account and can be used in streaming mode. Streaming mode allows you to listen for new operations for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream operations created since your request time.
+      operationId: GetOperationsByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - oneOf:
+                      - $ref: '#/components/schemas/CreateAccount'
+                      - $ref: '#/components/schemas/Payment'
+                      - $ref: '#/components/schemas/PathPaymentStrictReceive'
+                      - $ref: '#/components/schemas/PathPaymentStrictSend'
+                      - $ref: '#/components/schemas/AccountMerge'
+              examples:
+                RetrieveAnAccountsOperations:
+                  $ref: '#/components/examples/RetrieveAnAccountsOperations'
+  /accounts/{account_id}/payments:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Payments
+      description: This endpoint represents successful payments for a given account and can be used in streaming mode. Streaming mode allows you to listen for new payments for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known payment unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream payments created since your request time.
+      operationId: GetPaymentsByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Payment'
+              examples:
+                RetrieveAnAccountsPayments:
+                  $ref: '#/components/examples/RetrieveAnAccountsPayments'
+  /accounts/{account_id}/effects:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Effects
+      description: This endpoint returns the effects of a specific account and can be used in streaming mode. Streaming mode allows you to listen for new effects for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known effect unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream effects created since your request time.
+      operationId: GetEffectsByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - oneOf:
+                      - $ref: '#/components/schemas/CreateAccount'
+                      - $ref: '#/components/schemas/Payment'
+                      - $ref: '#/components/schemas/PathPaymentStrictReceive'
+                      - $ref: '#/components/schemas/PathPaymentStrictSend'
+                      - $ref: '#/components/schemas/AccountMerge'
+              examples:
+                RetrieveAnAccountsEffects:
+                  $ref: '#/components/examples/RetrieveAnAccountsEffects'
+  /accounts/{account_id}/offers:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Offers
+      description: This endpoint represents all offers a given account has currently open and can be used in streaming mode. Streaming mode allows you to listen for new offers for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known offer unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream offers created since your request time.
+      operationId: GetOffersByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Offer'
+              examples:
+                RetrieveAnAccountsOffers:
+                  $ref: '#/components/examples/RetrieveAnAccountsOffers'
+  /accounts/{account_id}/trades:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Trades
+      description: This endpoint represents all trades for a given account and can be used in streaming mode. Streaming mode allows you to listen for trades for this account as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream trades created since your request time.
+      operationId: GetTradesByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Trade'
+              examples:
+                RetrieveAnAccountsTrades:
+                  $ref: '#/components/examples/RetrieveAnAccountsTrades'
+  /accounts/{account_id}/data/{key}:
+    get:
+      tags:
+        - Accounts
+      summary: Retrieve an Account's Data
+      description: This endpoint represents a single data for a given account.
+      operationId: GetDataByAccountId
+      parameters:
+        - $ref: '#/components/parameters/AccountIDParam'
+        - $ref: '#/components/parameters/DataParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: string
+              examples:
+                RetrieveAnAccountsData:
+                  $ref: '#/components/examples/RetrieveAnAccountsData'
+  /assets:
+    get:
+      tags:
+        - Assets
+      summary: List all Assets
+      description: This endpoint lists all assets.
+      operationId: ListAllAssets
+      parameters:
+        - $ref: '#/components/parameters/AssetCodeParam'
+        - $ref: '#/components/parameters/AssetIssuerParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Asset'
+              examples:
+                ListAllAssets:
+                  $ref: '#/components/examples/ListAllAssets'
+  /claimable_balances:
+    get:
+      tags:
+        - Claimable Balances
+      summary: List All Claimable Balances
+      description: This endpoint lists all available claimable balances.
+      operationId: ListAllClaimableBalances
+      parameters:
+        - $ref: '#/components/parameters/SponsorParam'
+        - $ref: '#/components/parameters/AssetParam'
+        - $ref: '#/components/parameters/ClaimantParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/ClaimableBalances'
+              examples:
+                ListAllClaimableBalances:
+                  $ref: '#/components/examples/ListAllClaimableBalances'
+  /claimable_balances/{claimable_balance_id}:
+    get:
+      tags:
+        - Claimable Balances
+      summary: Retrieve a Claimable Balance
+      description: The single claimable balance endpoint provides information on a claimable balance.
+      operationId: RetrieveAClaimableBalance
+      parameters:
+        - $ref: '#/components/parameters/ClaimableBalanceIdParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClaimableBalance'
+              examples:
+                RetrieveAClaimableBalance:
+                  $ref: '#/components/examples/RetrieveAClaimableBalance'
+  /claimable_balances/{claimable_balance_id}/transactions:
+    get:
+      tags:
+        - Claimable Balances
+      summary: Retrieve Related Transactions
+      description: This endpoint represents successful transactions referencing a given claimable balance and can be used in streaming mode. Streaming mode allows you to listen for new transactions referencing this claimable balance as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known transaction unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream transactions created since your request time.
+      operationId: CBRetrieveRelatedTransactions
+      parameters:
+        - $ref: '#/components/parameters/ClaimableBalanceIdParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Transaction'
+              examples:
+                CBRetrieveRelatedTransactions:
+                  $ref: '#/components/examples/CBRetrieveRelatedTransactions'
+  /claimable_balances/{claimable_balance_id}/operations:
+    get:
+      tags:
+        - Claimable Balances
+      summary: Retrieve Related Operations
+      description: This endpoint represents successful operations referencing a given claimable balance and can be used in streaming mode. Streaming mode allows you to listen for new operations referencing this claimable balance as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream operations created since your request time.
+      operationId: CBRetrieveRelatedOperations
+      parameters:
+        - $ref: '#/components/parameters/ClaimableBalanceIdParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - oneOf:
+                      - $ref: '#/components/schemas/CreateAccount'
+                      - $ref: '#/components/schemas/Payment'
+                      - $ref: '#/components/schemas/PathPaymentStrictReceive'
+                      - $ref: '#/components/schemas/PathPaymentStrictSend'
+                      - $ref: '#/components/schemas/AccountMerge'
+              examples:
+                CBRetrieveRelatedOperations:
+                  $ref: '#/components/examples/CBRetrieveRelatedOperations'
+  /effects:
+    get:
+      tags:
+        - Effects
+      summary: List All Effects
+      description: This endpoint lists all effects and can be used in streaming mode. Streaming mode allows you to listen for new effects as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known effect unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream effects created since your request time.
+      operationId: ListAllEffects
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Effect'
+              examples:
+                ListAllEffects:
+                  $ref: '#/components/examples/ListAllEffects'
+  /fee_stats:
+    get:
+      tags:
+        - Fee Stats
+      summary: Retrieve Fee Stats
+      description: The fee stats endpoint provides information about per-operation fee stats over the last 5 ledgers.
+      operationId: RetrieveFeeStats
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeeStats'
+              examples:
+                RetrieveFeeStats:
+                  $ref: '#/components/examples/RetrieveFeeStats'
+      x-codeSamples:
+        - lang: JavaScript
+          label: '@stellar/stellar-sdk'
+          source: |
+            var StellarSdk = require("@stellar/stellar-sdk");
+            var server = new StellarSdk.Horizon.Server(
+              "https://horizon-testnet.stellar.org",
+            );
+
+            server
+              .feeStats()
+              .then(function (resp) {
+                console.log(resp);
+              })
+              .catch(function (err) {
+                console.error(err);
+              });
+  /ledgers/{sequence}:
+    get:
+      tags:
+        - Ledgers
+      summary: Retrieve a Ledger
+      description: The single ledger endpoint provides information on a specific ledger.
+      operationId: RetrieveALedger
+      parameters:
+        - $ref: '#/components/parameters/SequenceParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ledger'
+              examples:
+                RetrieveALedger:
+                  $ref: '#/components/examples/RetrieveALedger'
+  /ledgers/{sequence}/transactions:
+    get:
+      tags:
+        - Ledgers
+      summary: Retrieve a Ledger's Transactions
+      description: This endpoint represents successful transactions in a given ledger.
+      operationId: RetrieveALedgersTransactions
+      parameters:
+        - $ref: '#/components/parameters/SequenceParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Transaction'
+              examples:
+                RetrieveALedgersTransactions:
+                  $ref: '#/components/examples/RetrieveALedgersTransactions'
+  /ledgers/{sequence}/payments:
+    get:
+      tags:
+        - Ledgers
+      summary: Retrieve a Ledger's Payments
+      description: 'This endpoint returns all payment-related operations in a specific ledger. Operation types that can be returned by this endpoint include: create_account, payment, path_payment, and account_merge.'
+      operationId: RetrieveALedgersPayments
+      parameters:
+        - $ref: '#/components/parameters/SequenceParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Payment'
+              examples:
+                RetrieveALedgersPayments:
+                  $ref: '#/components/examples/RetrieveALedgersPayments'
+  /ledgers/{sequence}/operations:
+    get:
+      tags:
+        - Ledgers
+      summary: Retrieve a Ledger's Operations
+      description: This endpoint returns successful operations in a specific ledger.
+      operationId: RetrieveALedgersOperations
+      parameters:
+        - $ref: '#/components/parameters/SequenceParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Operation'
+              examples:
+                RetrieveALedgersOperations:
+                  $ref: '#/components/examples/RetrieveALedgersOperations'
+  /ledgers/{sequence}/effects:
+    get:
+      tags:
+        - Ledgers
+      summary: Retrieve a Ledgers's Effects
+      description: This endpoint returns the effects of a specific ledger.
+      operationId: RetrieveALedgersEffects
+      parameters:
+        - $ref: '#/components/parameters/SequenceParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Effect'
+              examples:
+                RetrieveALedgersEffects:
+                  $ref: '#/components/examples/RetrieveALedgersEffects'
+  /ledgers:
+    get:
+      tags:
+        - Ledgers
+      summary: List All Ledgers
+      description: This endpoint lists all ledgers and can be used in streaming mode. Streaming mode allows you to listen for new ledgers as they close. If called in streaming mode, Horizon will start at the earliest known ledger unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream ledgers since your request time.
+      operationId: ListAllLedgers
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ledger'
+              examples:
+                ListAllLedgers:
+                  $ref: '#/components/examples/ListAllLedgers'
+  /liquidity_pools:
+    get:
+      tags:
+        - Liquidity Pools
+      summary: List Liquidity Pools
+      description: This endpoint lists all available liquidity pools.
+      operationId: ListLiquidityPools
+      parameters:
+        - $ref: '#/components/parameters/ReserveParam'
+        - $ref: '#/components/parameters/AccountParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/LiquidityPools'
+              examples:
+                ListLiquidityPools:
+                  $ref: '#/components/examples/ListLiquidityPools'
+  /liquidity_pools/{liquidity_pool_id}:
+    get:
+      tags:
+        - Liquidity Pools
+      summary: Retrieve a Liquidity Pool
+      description: The single liquidity pool endpoint provides information on a liquidity pool.
+      operationId: RetrieveALiquidityPool
+      parameters:
+        - $ref: '#/components/parameters/LiquidityPoolParamId'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LiquidityPool'
+              examples:
+                RetrieveALiquidityPool:
+                  $ref: '#/components/examples/RetrieveALiquidityPool'
+  /liquidity_pools/{liquidity_pool_id}/effects:
+    get:
+      tags:
+        - Liquidity Pools
+      summary: Retrieve Related Effects
+      description: This endpoint represents effects referencing a given liquidity pool and can be used in streaming mode. Streaming mode allows you to listen for new effects referencing this liquidity pool as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known effect unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream effects created since your request time.
+      operationId: RetrieveRelatedEffects
+      parameters:
+        - $ref: '#/components/parameters/LiquidityPoolParamId'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Effect'
+              examples:
+                RetrieveRelatedEffects:
+                  $ref: '#/components/examples/RetrieveRelatedEffects'
+  /liquidity_pools/{liquidity_pool_id}/trades:
+    get:
+      tags:
+        - Liquidity Pools
+      summary: Retrieve Related Trades
+      description: 'This endpoint represents successful trades fulfilled by the given liquidity pool and can be used in streaming mode. Streaming mode allows you to listen for new trades referencing this liquidity pool as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream trade created since your request time. '
+      operationId: RetrieveRelatedTrades
+      parameters:
+        - $ref: '#/components/parameters/LiquidityPoolParamId'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Trade'
+              examples:
+                RetrieveRelatedTrades:
+                  $ref: '#/components/examples/RetrieveRelatedTrades'
+  /liquidity_pools/{liquidity_pool_id}/transactions:
+    get:
+      tags:
+        - Liquidity Pools
+      summary: Retrieve Related Transactions
+      description: This endpoint represents successful transactions referencing a given liquidity pool and can be used in streaming mode. Streaming mode allows you to listen for new transactions referencing this liquidity pool as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known transaction unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream transactions created since your request time.
+      operationId: LPRetrieveRelatedTransactions
+      parameters:
+        - $ref: '#/components/parameters/LiquidityPoolParamId'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Transaction'
+              examples:
+                LPRetrieveRelatedTransactions:
+                  $ref: '#/components/examples/LPRetrieveRelatedTransactions'
+  /liquidity_pools/{liquidity_pool_id}/operations:
+    get:
+      tags:
+        - Liquidity Pools
+      summary: Retrieve Related Operations
+      description: This endpoint represents successful operations referencing a given liquidity pool and can be used in streaming mode. Streaming mode allows you to listen for new operations referencing this liquidity pool as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream operations created since your request time.
+      operationId: LPRetrieveRelatedOperations
+      parameters:
+        - $ref: '#/components/parameters/LiquidityPoolParamId'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Operation'
+              examples:
+                LPRetrieveRelatedOperations:
+                  $ref: '#/components/examples/LPRetrieveRelatedOperations'
+  /offers:
+    get:
+      tags:
+        - Offers
+      summary: List All Offers
+      description: This endpoint lists all currently open offers and can be used in streaming mode. Streaming mode allows you to listen for new offers as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known offer unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream offers created since your request time. When filtering by buying or selling arguments, you must use a combination of selling_asset_type, selling_asset_issuer, and selling_asset_code for the selling asset, or a combination of buying_asset_type, buying_asset_issuer, and buying_asset_code for the buying asset.
+      operationId: GetAllOffers
+      parameters:
+        - $ref: '#/components/parameters/SponsorParam'
+        - $ref: '#/components/parameters/SellerParam'
+        - $ref: '#/components/parameters/SellingAssetTypeParam'
+        - $ref: '#/components/parameters/SellingAssetIssuerParam'
+        - $ref: '#/components/parameters/SellingAssetCodeParam'
+        - $ref: '#/components/parameters/BuyingAssetTypeParam'
+        - $ref: '#/components/parameters/BuyingAssetIssuerParam'
+        - $ref: '#/components/parameters/BuyingAssetCodeParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Offer'
+              examples:
+                GetAllOffers:
+                  $ref: '#/components/examples/GetAllOffers'
+  /offers/{offer_id}:
+    get:
+      tags:
+        - Offers
+      summary: Retrieve an Offer
+      description: The single offer endpoint provides information on a specific offer.
+      operationId: GetOfferByOfferId
+      parameters:
+        - $ref: '#/components/parameters/OfferIDParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Offer'
+              examples:
+                GetOfferByOfferId:
+                  $ref: '#/components/examples/GetOfferByOfferId'
+  /offers/{offer_id}/trades:
+    get:
+      tags:
+        - Offers
+      summary: Retrieve an Offer's Trades
+      description: This endpoint represents all trades for a given offer and can be used in streaming mode. Streaming mode allows you to listen for trades for this offer as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream trades created since your request time.
+      operationId: GetTradesByOfferId
+      parameters:
+        - $ref: '#/components/parameters/OfferIDParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Trade'
+              examples:
+                GetTradesByOfferId:
+                  $ref: '#/components/examples/GetTradesByOfferId'
+  /operations/{id}:
+    get:
+      tags:
+        - Operations
+      summary: Retrieve an Operation
+      description: The single operation endpoint provides information about a specific operation.
+      operationId: RetrieveAnOperation
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+        - $ref: '#/components/parameters/JoinParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Operation'
+              examples:
+                RetrieveAnOperation:
+                  $ref: '#/components/examples/RetrieveAnOperation'
+  /operations/{id}/effects:
+    get:
+      tags:
+        - Operations
+      summary: Retrieve an Operation's Effects
+      description: This endpoint returns the effects of a specific operation.
+      operationId: RetrieveAnOperationsEffects
+      parameters:
+        - $ref: '#/components/parameters/IdParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Effect'
+              examples:
+                RetrieveAnOperationsEffects:
+                  $ref: '#/components/examples/RetrieveAnOperationsEffects'
+  /operations:
+    get:
+      tags:
+        - Operations
+      summary: List All Operations
+      description: This endpoint lists all Successful operations and can be used in streaming mode. Streaming mode allows you to listen for new operations as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known operation unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream operations created since your request time.
+      operationId: ListAllOperations
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Operation'
+              examples:
+                ListAllOperations:
+                  $ref: '#/components/examples/ListAllOperations'
+  /order_book:
+    get:
+      tags:
+        - Order Books
+      summary: Retrieve an Order Book
+      description: |
+        The order book endpoint provides an order book's bids and asks and can be used in [streaming](https://developers.stellar.org/docs/data/apis/horizon/api-reference/structure/streaming) mode.
+
+        When filtering for a specific order book, you must use use all six of these arguments: `base_asset_type`, `base_asset_issuer`, `base_asset_code`, `counter_asset_type`, `counter_asset_issuer`, and `counter_asset_code`. If the base or counter asset is XLM, you only need to indicate the asset type as `native` and do not need to designate the code or the issuer.
+      operationId: RetrieveAnOrderBook
+      parameters:
+        - $ref: '#/components/parameters/SellingAssetTypeRequiredParam'
+        - $ref: '#/components/parameters/SellingAssetIssuerParam'
+        - $ref: '#/components/parameters/SellingAssetCodeParam'
+        - $ref: '#/components/parameters/BuyingAssetTypeParam'
+        - $ref: '#/components/parameters/BuyingAssetIssuerParam'
+        - $ref: '#/components/parameters/BuyingAssetCodeParam'
+        - $ref: '#/components/parameters/OrderBookLimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderBook'
+              examples:
+                RetrieveAnOrderBook:
+                  $ref: '#/components/examples/RetrieveAnOrderBook'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl https://horizon-testnet.stellar.org/order_book?\
+            selling_asset_type=native&\
+            buying_asset_type=credit_alphanum4&\
+            buying_asset_code=USDC&\
+            buying_asset_issuer=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN&\
+            limit=4
+        - lang: JavaScript
+          label: '@stellar/stellar-sdk'
+          source: |
+            var StellarSdk = require("@stellar/stellar-sdk");
+            var server = new StellarSdk.Horizon.Server(
+              "https://horizon-testnet.stellar.org",
+            );
+
+            server
+              .orderbook(
+                new StellarSdk.Asset.native(),
+                new StellarSdk.Asset(
+                  "BB1",
+                  "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN",
+                ),
+              )
+              .call()
+              .then(function (resp) {
+                console.log(resp);
+              })
+              .catch(function (err) {
+                console.error(err);
+              });
+  /paths/strict-receive:
+    get:
+      tags:
+        - Paths
+      summary: List Strict Receive Payment Paths
+      description: |
+        The strict receive payment path endpoint lists the paths a payment can take based on the amount of an asset you want the recipient to receive. The destination asset amount stays constant, and the type and amount of an asset sent varies based on offers in the order books.
+
+        For this search, Horizon loads a list of assets available to the sender (based on `source_account` or `source_assets`) and displays the possible paths from the different source assets to the destination asset. Only paths that satisfy the `destination_amount` are returned.
+      operationId: ListStrictReceivePaymentPaths
+      parameters:
+        - $ref: '#/components/parameters/SourceAccountParam'
+        - $ref: '#/components/parameters/SourceAssetsParam'
+        - $ref: '#/components/parameters/DestinationAssetTypeParam'
+        - $ref: '#/components/parameters/DestinationAssetIssuerParam'
+        - $ref: '#/components/parameters/DestinationAssetCodeParam'
+        - $ref: '#/components/parameters/DestinationAmountParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Path'
+              examples:
+                ListStrictRecievePaymentPaths:
+                  $ref: '#/components/examples/ListStrictReceivePaymentPaths'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl https://horizon-testnet.stellar.org/paths/strict-receive?\
+            source_assets=CNY:GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX&\
+            destination_asset_type=credit_alphanum4&\
+            destination_asset_code=BB1&\
+            destination_asset_issuer=GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN&\
+            destination_amount=5
+        - lang: JavaScript
+          label: '@stellar/stellar-sdk'
+          source: |
+            var StellarSdk = require("stellar-sdk");
+            var server = new StellarSdk.Horizon.Server(
+              "https://horizon-testnet.stellar.org",
+            );
+
+            server
+              .strictReceivePaths(
+                [
+                  new StellarSdk.Asset(
+                    "CNY",
+                    "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX",
+                  ),
+                ],
+                new StellarSdk.Asset(
+                  "BB1",
+                  "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN",
+                ),
+                "5",
+              )
+              .call()
+              .then(function (resp) {
+                console.log(resp);
+              })
+              .catch(function (err) {
+                console.error(err);
+              });
+        - lang: Python
+          label: stellar_sdk
+          source: |
+            from stellar_sdk import Server, Asset
+            server = Server("https://horizon-testnet.stellar.org")
+
+            response = server.strict_receive_paths(
+                source=[
+                    Asset("CNY", "GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX")
+                ],
+                destination_asset=Asset(
+                    "BB1",
+                    "GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN"
+                ),
+                destination_amount="5"
+            ).call()
+
+            print(response)
+  /paths/strict-send:
+    get:
+      tags:
+        - Paths
+      summary: List Strict Send Payment Paths
+      description: |
+        The strict send payment path endpoint lists the paths a payment can take based on the amount of an asset you want to send. The source asset amount stays constant, and the type and amount of an asset received varies based on offers in the order books.
+
+        For this search, Horizon loads a list of assets that the recipient can receive (based on `destination_account` or `destination_assets`) and displays the possible paths from the different source assets to the destination asset. Only paths that satisfy the `source_amount` are returned.
+      operationId: ListStrictSendPaymentPaths
+      parameters:
+        - $ref: '#/components/parameters/SourceAssetTypeParam'
+        - $ref: '#/components/parameters/SourceAssetIssuerParam'
+        - $ref: '#/components/parameters/SourceAssetCodeParam'
+        - $ref: '#/components/parameters/SourceAmountParam'
+        - $ref: '#/components/parameters/DestinationAccountParam'
+        - $ref: '#/components/parameters/DestinationAssetsParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Path'
+              examples:
+                ListStrictSendPaymentPaths:
+                  $ref: '#/components/examples/ListStrictSendPaymentPaths'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl https://horizon-testnet.stellar.org/paths/strict-send?\
+            source_asset_type=credit_alphanum4&\
+            source_asset_code=BRL&\
+            source_asset_issuer=GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP&\
+            source_amount=400&\
+            destination_account=GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+        - lang: JavaScript
+          label: '@stellar/stellar-sdk'
+          source: |
+            var StellarSdk = require("@stellar/stellar-sdk");
+            var server = new StellarSdk.Horizon.Server(
+              "https://horizon-testnet.stellar.org",
+            );
+
+            server
+              .strictSendPaths(
+                new StellarSdk.Asset(
+                  "BRL",
+                  "GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP",
+                ),
+                "400",
+                "GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA",
+              )
+              .call()
+              .then(function (resp) {
+                console.log(resp);
+              })
+              .catch(function (err) {
+                console.error(err);
+              });
+        - lang: Python
+          label: stellar_sdk
+          source: |
+            from stellar_sdk import Server, Asset
+            server = Server("https://horizon-testnet.stellar.org")
+
+            response = server.strict_send_paths(
+                source_asset=Asset(
+                    "BRL",
+                    "GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP"
+                ),
+                source_amount="400",
+                destination="GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA"
+            ).call()
+
+            print(response)
+  /payments:
+    get:
+      tags:
+        - Payments
+      summary: List All Payments
+      description: 'This endpoint lists all Successful payment-related operations and can be used in streaming mode. Streaming mode allows you to listen for new payments as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known payment unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream payments created since your request time. Operations that can be returned by this endpoint include: create_account, payment, path_payment_strict_recieve, path_payment_strict_send, and account_merge .'
+      operationId: ListAllPayments
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - oneOf:
+                      - $ref: '#/components/schemas/CreateAccount'
+                      - $ref: '#/components/schemas/Payment'
+                      - $ref: '#/components/schemas/PathPaymentStrictReceive'
+                      - $ref: '#/components/schemas/PathPaymentStrictSend'
+                      - $ref: '#/components/schemas/AccountMerge'
+                      - $ref: '#/components/schemas/InvokeHostFunction'
+              examples:
+                ListAllPayments:
+                  $ref: '#/components/examples/ListAllPayments'
+  /trade_aggregations:
+    get:
+      tags:
+        - Trade Aggregations
+      summary: List Trade Aggregations
+      description: |
+        This endpoint displays trade data based on filters set in the arguments.
+
+        This is done by dividing a given time range into segments and aggregating statistics, for a given asset pair (base, counter) over each of these segments.
+
+        The duration of the segments is specified with the `resolution` parameter. The start and end of the time range are given by `startTime` and `endTime` respectively, which are both rounded to the nearest multiple of `resolution` since epoch.
+
+        The individual segments are also aligned with multiples of `resolution` since epoch. If you want to change this alignment, the segments can be `offset` by specifying the offset parameter.
+      operationId: ListTradeAggregations
+      parameters:
+        - $ref: '#/components/parameters/StartTimeParam'
+        - $ref: '#/components/parameters/EndTimeParam'
+        - $ref: '#/components/parameters/ResolutionParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/BaseAssetTypeRequiredParam'
+        - $ref: '#/components/parameters/BaseAssetIssuerParam'
+        - $ref: '#/components/parameters/BaseAssetCodeParam'
+        - $ref: '#/components/parameters/CounterAssetTypeRequiredParam'
+        - $ref: '#/components/parameters/CounterAssetIssuerParam'
+        - $ref: '#/components/parameters/CounterAssetCodeParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TradeAggregation'
+              examples:
+                ListTradeAggregations:
+                  $ref: '#/components/examples/ListTradeAggregations'
+      x-codeSamples:
+        - lang: Shell
+          source: |
+            curl https://horizon.stellar.org/trade_aggregations?\
+            base_asset_type=native&\
+            counter_asset_code=EURT&\
+            counter_asset_issuer=GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S&\
+            counter_asset_type=credit_alphanum4&\
+            resolution=3600000&\
+            start_time=1582156800000&\
+            end_time=1582178400000
+        - lang: JavaScript
+          label: '@stellar/stellar-sdk'
+          source: |
+            var StellarSdk = require("@stellar/stellar-sdk");
+            var server = new StellarSdk.Horizon.Server(
+              "https://horizon-testnet.stellar.org",
+            );
+
+            var base = new StellarSdk.Asset.native();
+            var counter = new StellarSdk.Asset(
+              "EURT",
+              "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+            );
+            var startTime = 1582156800000;
+            var endTime = 1582178400000;
+            var resolution = 3600000;
+            var offset = 0;
+
+            server
+              .tradeAggregation(base, counter, startTime, endTime, resolution, offset)
+              .call()
+              .then(function (resp) {
+                console.log(resp);
+              })
+              .catch(function (err) {
+                console.error(err);
+              });
+  /trades:
+    get:
+      tags:
+        - Trades
+      summary: List All Trades
+      description: 'This endpoint lists all trades and can be used in streaming mode. Streaming mode allows you to listen for new trades as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known trade unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream trades created since your request time. When filtering for a specific orderbook, you must use use all six of these arguments: base_asset_type, base_asset_issuer, base_asset_code, counter_asset_type, counter_asset_issuer, and counter_asset_code. If the base or counter asset is XLM, you only need to indicate the asset type as native and do not need to designate the code or the issuer.'
+      operationId: GetAllTrades
+      parameters:
+        - $ref: '#/components/parameters/OfferIdParam'
+        - $ref: '#/components/parameters/BaseAssetTypeParam'
+        - $ref: '#/components/parameters/BaseAssetIssuerParam'
+        - $ref: '#/components/parameters/BaseAssetCodeParam'
+        - $ref: '#/components/parameters/CounterAssetTypeParam'
+        - $ref: '#/components/parameters/CounterAssetIssuerParam'
+        - $ref: '#/components/parameters/CounterAssetCodeParam'
+        - $ref: '#/components/parameters/TradeTypeParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Trade'
+              examples:
+                GetAllTrades:
+                  $ref: '#/components/examples/GetAllTrades'
+  /transactions/{transaction_hash}:
+    get:
+      tags:
+        - Transactions
+      summary: Retrieve a Transaction
+      description: The single transaction endpoint provides information on a specific transaction.
+      operationId: RetrieveATransaction
+      parameters:
+        - $ref: '#/components/parameters/HashParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/schemas-Transaction'
+              examples:
+                RetrieveATransaction:
+                  $ref: '#/components/examples/RetrieveATransaction'
+  /transactions/{transaction_hash}/operations:
+    get:
+      tags:
+        - Transactions
+      summary: Retrieve a Transaction's Operations
+      description: This endpoint returns Successful operations for a specific transaction.
+      operationId: RetrieveATransactionsOperations
+      parameters:
+        - $ref: '#/components/parameters/HashParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+        - $ref: '#/components/parameters/JoinParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Operation'
+              examples:
+                RetrieveATransactionsOperations:
+                  $ref: '#/components/examples/RetrieveATransactionsOperations'
+  /transactions/{transaction_hash}/effects:
+    get:
+      tags:
+        - Transactions
+      summary: Retrieve a Transaction's Effects
+      description: This endpoint returns the effects of a specific transaction.
+      operationId: RetrieveATransactionsEffects
+      parameters:
+        - $ref: '#/components/parameters/HashParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Effect'
+              examples:
+                RetrieveATransactionsEffects:
+                  $ref: '#/components/examples/RetrieveATransactionsEffects'
+  /transactions/{transaction_hash}/payments:
+    get:
+      tags:
+        - Payments
+      summary: Retrieve a Transaction's Payments
+      description: This endpoint returns the payments of a specific transaction.
+      operationId: RetrieveATransactionsPayments
+      parameters:
+        - $ref: '#/components/parameters/HashParam'
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Payment'
+              examples:
+                RetrieveATransactionsPayments:
+                  $ref: '#/components/examples/RetrieveATransactionsPayments'
+  /transactions:
+    get:
+      tags:
+        - Transactions
+      summary: List All Transactions
+      description: This endpoint lists all Successful transactions and can be used in streaming mode. Streaming mode allows you to listen for new transactions as they are added to the Stellar ledger. If called in streaming mode, Horizon will start at the earliest known transaction unless a cursor is set, in which case it will start from that cursor. By setting the cursor value to now, you can stream transactions created since your request time.
+      operationId: ListAllTransactions
+      parameters:
+        - $ref: '#/components/parameters/CursorParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/IncludeFailedParam'
+      x-supports-streaming: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Links'
+                  - $ref: '#/components/schemas/Transaction'
+              examples:
+                ListAllTransactions:
+                  $ref: '#/components/examples/ListAllTransactions'
+    post:
+      tags:
+        - Transactions
+      summary: Submit a Transaction
+      description: 'This endpoint actually submits a transaction to the Stellar network. It only takes a single, required parameter: the signed transaction. Refer to the Transactions page for details on how to craft a proper one. If you submit a transaction that has already been included in a ledger, this endpoint will return the same response as would’ve been returned for the original transaction submission. This allows for safe resubmission of transactions in error scenarios, as highlighted in the error-handling guide.'
+      operationId: SubmitATransaction
+      parameters:
+        - in: query
+          name: tx
+          schema:
+            type: string
+            description: The base64-encoded XDR of the transaction.
+          required: true
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitTransaction'
+              examples:
+                SubmitaTransaction:
+                  $ref: '#/components/examples/SubmitaTransaction'
+  /transactions_async:
+    post:
+      summary: Submit a Transaction Asynchronously
+      description: This endpoint submits transactions to the Stellar network asynchronously. It is designed to allow users to submit transactions without blocking them while waiting for a response from Horizon. At the same time, it also provides clear response status codes from stellar-core to help understand the status of the submitted transaction. You can then use Horizon's [GET transaction endpoint](https://developers.stellar.org/docs/data/apis/horizon/api-reference/resources/retrieve-a-transaction) to wait for the transaction to be included in a ledger and ingested by Horizon.
+      operationId: SubmitAsyncTransaction
+      tags:
+        - Transactions
+      parameters:
+        - in: query
+          name: tx
+          schema:
+            type: string
+            description: The base64-encoded XDR of the transaction.
+          required: true
+      responses:
+        '201':
+          description: Transaction has been received by core and is in pending status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
+              examples:
+                TransactionPending:
+                  summary: Transaction Pending
+                  value:
+                    tx_status: PENDING
+                    hash: 6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165
+        '400':
+          description: Transaction is malformed; ERROR status from core.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
+                  - $ref: '#/components/schemas/Problem'
+              examples:
+                TransactionMalformed:
+                  summary: Transaction Malformed
+                  value:
+                    type: transaction_malformed
+                    title: Transaction Malformed
+                    status: 400
+                    detail: Horizon could not decode the transaction envelope in this request. A transaction should be an XDR TransactionEnvelope struct encoded using base64. The envelope read from this request is echoed in the `extras.envelope_xdr` field of this response for your convenience.
+                    extras:
+                      envelope_xdr: ''
+                TransactionError:
+                  summary: ERROR Status from core
+                  value:
+                    error_result_xdr: AAAAAAAAAGT////7AAAAAA==
+                    tx_status: ERROR
+                    hash: 6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165
+        '403':
+          description: Transaction submission has been disabled for Horizon.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                TransactionSubmissionDisabled:
+                  summary: Transaction Submission Disabled
+                  value:
+                    type: transaction_submission_disabled
+                    title: Transaction Submission Disabled
+                    status: 403
+                    detail: Transaction submission has been disabled for Horizon. To enable it again, remove env variable DISABLE_TX_SUB.
+                    extras:
+                      envelope_xdr: ''
+        '409':
+          description: Transaction is a duplicate of a previously submitted transaction.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
+              examples:
+                TransactionDuplicate:
+                  summary: Transaction Duplicate
+                  value:
+                    tx_status: DUPLICATE
+                    hash: 6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165
+        '500':
+          description: Transaction submission failure, exception or invalid status from core.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+              examples:
+                TransactionFailed:
+                  summary: Transaction Submission Failed
+                  value:
+                    type: transaction_submission_failed
+                    title: Transaction Submission Failed
+                    status: 500
+                    detail: 'Could not submit transaction to stellar-core. The `extras.error` field on this response contains further details. Descriptions of each code can be found at: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_failed'
+                    extras:
+                      envelope_xdr: ''
+                      error: Error details here
+                TransactionException:
+                  summary: Transaction Submission Exception
+                  value:
+                    type: transaction_submission_exception
+                    title: Transaction Submission Exception
+                    status: 500
+                    detail: 'Received exception from stellar-core. The `extras.error` field on this response contains further details. Descriptions of each code can be found at: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_exception'
+                    extras:
+                      envelope_xdr: ''
+                      error: Exception details here
+                TransactionInvalidStatus:
+                  summary: Transaction Submission Invalid Status
+                  value:
+                    type: transaction_submission_invalid_status
+                    title: Transaction Submission Invalid Status
+                    status: 500
+                    detail: 'Received invalid status from stellar-core. The `extras.error` field on this response contains further details.  Descriptions of each code can be found at: https://developers.stellar.org/api/errors/http-status-codes/horizon-specific/transaction-submission-async/transaction_submission_invalid_status'
+                    extras:
+                      envelope_xdr: ''
+                      error: Error details here
+        '503':
+          description: History DB is stale; core is unavailable for transaction submission.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/AsyncTransactionSubmissionResponse'
+                  - $ref: '#/components/schemas/Problem'
+              examples:
+                HistoryDBStale:
+                  summary: Historical DB Is Too Stale
+                  value:
+                    type: stale_history
+                    title: Historical DB Is Too Stale
+                    status: 503
+                    detail: This horizon instance is configured to reject client requests when it can determine that the history database is lagging too far behind the connected instance of Stellar-Core or read replica. It's also possible that Stellar-Core is out of sync. Please try again later.
+                    extras:
+                      envelope_xdr: ''
+                TransactionTryAgainLater:
+                  summary: TRY_AGAIN_LATER Status from core
+                  value:
+                    tx_status: TRY_AGAIN_LATER
+                    hash: 6cbb7f714bd08cea7c30cab7818a35c510cbbfc0a6aa06172a1e94146ecf0165
+components:
+  parameters:
+    SponsorParam:
+      name: sponser
+      in: query
+      required: false
+      description: Account ID of the sponsor. Every account in the response will either be sponsored by the given account ID or have a subentry (trustline, offer, or data entry) which is sponsored by the given account ID.
+      schema:
+        type: string
+        example: GDMQQNJM4UL7QIA66P7R2PZHMQINWZBM77BEBMHLFXD5JEUAHGJ7R4JZ
+    AssetParam:
+      name: asset
+      in: query
+      required: false
+      description: An issued asset represented as “Code:IssuerAccountID”. Every account in the response will have a trustline for the given asset.
+    SignerParam:
+      name: signer
+      in: query
+      required: false
+      description: Account ID of the signer. Every account in the response will have the given account ID as a signer.
+      schema:
+        type: string
+        example: GDMQQNJM4UL7QIA66P7R2PZHMQINWZBM77BEBMHLFXD5JEUAHGJ7R4JZ
+    LiquidityPoolParam:
+      name: liqudity_pool
+      in: query
+      required: false
+      description: With this parameter, the results will include only accounts which have trustlines to the specified liquidity pool.
+    CursorParam:
+      name: cursor
+      in: query
+      required: false
+      description: A number that points to a specific location in a collection of responses and is pulled from the paging_token value of a record.
+      schema:
+        type: integer
+        example: 6606617478959105
+    OrderParam:
+      name: order
+      in: query
+      required: false
+      description: A designation of the order in which records should appear. Options include `asc` (ascending) or `desc` (descending). If this argument isn’t set, it defaults to `asc`.
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of records returned. The limit can range from 1 to 200 - an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 10.
+      schema:
+        type: integer
+        example: 10
+    AccountIDParam:
+      name: account_id
+      in: path
+      required: true
+      description: This account’s public key encoded in a base32 string representation.
+      schema:
+        type: string
+        example: GDMQQNJM4UL7QIA66P7R2PZHMQINWZBM77BEBMHLFXD5JEUAHGJ7R4JZ
+    IncludeFailedParam:
+      name: include_failed
+      in: query
+      required: false
+      description: Set to true to include failed operations in results. Options include true and false.
+      schema:
+        type: boolean
+        enum:
+          - true
+          - false
+    JoinParam:
+      name: join
+      in: query
+      required: false
+      description: Set to transactions to include the transactions which created each of the operations in the response.
+    DataParam:
+      name: key
+      in: path
+      required: true
+      description: The key name for this data.
+      schema:
+        type: string
+        example: config.memo_required
+    AssetCodeParam:
+      name: asset_code
+      in: query
+      required: false
+      description: The code of the asset you would like to filter by.
+    AssetIssuerParam:
+      name: asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the issuer for the asset you would like to filter by.
+    ClaimantParam:
+      name: claimant
+      in: query
+      required: false
+      description: Account ID of the destination address. Only include claimable balances which can be claimed by the given account ID.
+    ClaimableBalanceIdParam:
+      name: claimable_balance_id
+      in: path
+      required: true
+      description: A unique identifier for this claimable balance.
+      schema:
+        type: string
+    SequenceParam:
+      name: sequence
+      in: path
+      required: true
+      description: The sequence number of a specific ledger.
+      schema:
+        type: integer
+        example: 0
+    ReserveParam:
+      name: reserves
+      in: query
+      required: false
+      description: Comma-separated list of assets in canonical form (Code:IssuerAccountID), to only include liquidity pools which have reserves matching all listed assets.
+    AccountParam:
+      name: account
+      in: query
+      required: false
+      description: A Stellar account ID, to only include liquidity pools in which this account is participating in (i.e. holds pool shares to).
+    LiquidityPoolParamId:
+      name: liquidity_pool_id
+      in: path
+      required: true
+      description: A unique identifier for this liquidity pool.
+    SellerParam:
+      name: seller
+      in: query
+      required: false
+      description: The account ID of the offer creator.
+    SellingAssetTypeParam:
+      name: selling_asset_type
+      in: query
+      required: false
+      description: The type for the selling asset. Either native, credit_alphanum4, or credit_alphanum12.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    SellingAssetIssuerParam:
+      name: selling_asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the issuer of the asset being sold (base asset). Required if the `selling_asset_type` is not `native`.
+      schema:
+        type: string
+        example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+    SellingAssetCodeParam:
+      name: selling_asset_code
+      in: query
+      required: false
+      description: The code for the asset being sold (base asset). Required if the `selling_asset_type` is not `native`.
+      schema:
+        type: string
+        example: USD
+    BuyingAssetTypeParam:
+      name: buying_asset_type
+      in: query
+      required: false
+      description: The type for the asset being bought (counter asset). Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    BuyingAssetIssuerParam:
+      name: buying_asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the issuer of the asset being bought (counter asset). Required if the `buying_asset_type` is not `native`.
+      schema:
+        type: string
+        example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+    BuyingAssetCodeParam:
+      name: buying_asset_code
+      in: query
+      required: false
+      description: The code for the asset being bought (counter asset). Required if the `buying_asset_type` is not `native`.
+      schema:
+        type: string
+        example: EUR
+    OfferIDParam:
+      name: offer_id
+      in: path
+      required: true
+      description: A unique identifier for this offer.
+    IdParam:
+      name: id
+      in: path
+      required: true
+      description: The ID number for this operation.
+      schema:
+        type: string
+        example: 121692259040116740
+    SellingAssetTypeRequiredParam:
+      name: selling_asset_type
+      in: query
+      required: true
+      description: The type for the asset being sold (base asset). Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    OrderBookLimitParam:
+      name: limit
+      in: query
+      required: false
+      description: The maximum number of records returned. The limit can range from 1 to 200 — an upper limit that is hardcoded in Horizon for performance reasons. If this argument isn’t designated, it defaults to 20 for order books.
+      schema:
+        type: integer
+        example: 20
+    SourceAccountParam:
+      name: source_account
+      in: query
+      required: false
+      description: The Stellar address of the sender. Any returned path must start with an asset that the sender holds. Using either `source_account` or `source_assets` as an argument is required for strict receive path payments.
+      schema:
+        type: string
+        example: GDMQQNJM4UL7QIA66P7R2PZHMQINWZBM77BEBMHLFXD5JEUAHGJ7R4JZ
+    SourceAssetsParam:
+      name: source_assets
+      in: query
+      required: false
+      description: 'A comma-separated list of assets available to the sender. Any returned path must start with an asset in this list. Each asset is formatted as `CODE:ISSUER_ACCOUNT`. For example: `USD:GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX`. Using either `source_account` or `source_assets` as an argument is required for strict receive path payments.'
+      schema:
+        type: string
+        example: CNY:GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+    DestinationAssetTypeParam:
+      name: destination_asset_type
+      in: query
+      required: true
+      description: The type for the destination asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    DestinationAssetIssuerParam:
+      name: destination_asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the issuer of the destination asset. Required if the `destination_asset_type` is not `native`.
+      schema:
+        type: string
+        example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+    DestinationAssetCodeParam:
+      name: destination_asset_code
+      in: query
+      required: false
+      description: The code for the destination asset. Required if the `destination_asset_type` is not `native`.
+      schema:
+        type: string
+        example: USD
+    DestinationAmountParam:
+      name: destination_amount
+      in: query
+      required: true
+      description: The amount of the destination asset that should be received.
+      schema:
+        type: string
+        example: '5'
+    SourceAssetTypeParam:
+      name: source_asset_type
+      in: query
+      required: true
+      description: The type for the source asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    SourceAssetIssuerParam:
+      name: source_asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the issuer of the source asset. Required if the `source_asset_type` is not `native`.
+      schema:
+        type: string
+        example: GDMQQNJM4UL7QIA66P7R2PZHMQINWZBM77BEBMHLFXD5JEUAHGJ7R4JZ
+    SourceAssetCodeParam:
+      name: source_asset_code
+      in: query
+      required: false
+      description: The code for the source asset. Required if the `source_asset_type` is not `native`.
+      schema:
+        type: string
+        example: USD
+    SourceAmountParam:
+      name: source_amount
+      in: query
+      required: true
+      description: The amount of the source asset that should be sent.
+      schema:
+        type: string
+        example: '5'
+    DestinationAccountParam:
+      name: destination_account
+      in: query
+      required: false
+      description: The Stellar address of the receiver. Any returned path must end with an asset that the recipient can receive. Using either `source_account` or `source_assets` as an argument is required for strict send path payments.
+      schema:
+        type: string
+        example: GDMQQNJM4UL7QIA66P7R2PZHMQINWZBM77BEBMHLFXD5JEUAHGJ7R4JZ
+    DestinationAssetsParam:
+      name: destination_assets
+      in: query
+      required: false
+      description: 'A comma-separated list of assets that the recipient can receive. Any returned path must end with an asset in this list. Each asset is formatted as `CODE:ISSUER_ACCOUNT`. For example: `USD:GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX`. Using either `source_account` or `source_assets` as an argument is required for strict send path payments.'
+      schema:
+        type: string
+        example: CNY:GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+    StartTimeParam:
+      name: start_time
+      in: query
+      required: false
+      description: The lower time boundary represented as milliseconds since epoch.
+      schema:
+        type: integer
+        format: long
+    EndTimeParam:
+      name: end_time
+      in: query
+      required: false
+      description: The upper time boundary represented as milliseconds since epoch.
+      schema:
+        type: integer
+        format: long
+    ResolutionParam:
+      name: resolution
+      in: query
+      required: false
+      description: The segment duration represented as milliseconds. Supported values are 1 minute (60000), 5 minutes (300000), 15 minutes (900000), 1 hour (3600000), 1 day (86400000) and 1 week (604800000).
+      schema:
+        type: integer
+        format: long
+        oneOf:
+          - const: 60000
+            description: 1 minute
+          - const: 300000
+            description: 5 minutes
+          - const: 900000
+            description: 15 minutes
+          - const: 3600000
+            description: 1 hour
+          - const: 86400000
+            description: 1 day
+          - const: 604800000
+            description: 1 week
+    OffsetParam:
+      name: offset
+      in: query
+      required: false
+      description: Segments can be offset using this parameter. Expressed in milliseconds. Can only be used if the resolution is greater than 1 hour. Value must be in whole hours, less than the provided resolution, and less than 24 hours.
+      schema:
+        type: number
+        format: long
+    BaseAssetTypeRequiredParam:
+      name: base_asset_type
+      in: query
+      required: true
+      description: The type for the base asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    BaseAssetIssuerParam:
+      name: base_asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the base asset’s issuer. Required if the `base_asset_type` is not `native`.
+      schema:
+        type: string
+        example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+    BaseAssetCodeParam:
+      name: base_asset_code
+      in: query
+      required: false
+      description: The code for the base asset. Required if the `base_asset_type` is not `native`.
+      schema:
+        type: string
+        example: USD
+    CounterAssetTypeRequiredParam:
+      name: counter_asset_type
+      in: query
+      required: true
+      description: The type for the counter asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    CounterAssetIssuerParam:
+      name: counter_asset_issuer
+      in: query
+      required: false
+      description: The Stellar address of the counter asset’s issuer. Required if the `counter_asset_type` is not `native`.
+      schema:
+        type: string
+        example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+    CounterAssetCodeParam:
+      name: counter_asset_code
+      in: query
+      required: false
+      description: The code for the counter asset. Required if the `counter_asset_type` is not `native`.
+      schema:
+        type: string
+        example: USD
+    OfferIdParam:
+      name: offer_id
+      in: query
+      required: false
+      description: The offer ID. Used to filter for trades originating from a specific offer.
+    BaseAssetTypeParam:
+      name: base_asset_type
+      in: query
+      required: false
+      description: The type for the base asset. Either `native`, `credit_alphanum4`, or `credit_alphanum12`.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    CounterAssetTypeParam:
+      name: counter_asset_type
+      in: query
+      required: false
+      description: The type for the counter asset. Either native, credit_alphanum4, or credit_alphanum12.
+      schema:
+        type: string
+        enum:
+          - native
+          - credit_alphanum4
+          - credit_alphanum12
+    TradeTypeParam:
+      name: trade_type
+      in: query
+      required: false
+      description: Can be set to all, orderbook, or liquidity_pools to filter only trades executed across a given mechanism.
+      schema:
+        type: string
+        enum:
+          - all
+          - orderbook
+          - liquidity_pools
+    HashParam:
+      name: transaction_hash
+      in: path
+      required: true
+      description: Transactions are commands that modify the ledger state and consist of one or more operations.
+      schema:
+        type: string
+        example: 5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc
+  schemas:
+    link:
+      type: object
+      properties:
+        href:
+          type: string
+          format: link
+        templated:
+          type: boolean
+      required:
+        - href
+    Links:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            next:
+              $ref: '#/components/schemas/link'
+            prev:
+              $ref: '#/components/schemas/link'
+    id:
+      type: string
+    address:
+      type: string
+      pattern: G[A-Z0-9]{55}
+    sequence:
+      type: string
+      pattern: '[0-9]+'
+    sequence_ledger:
+      type: integer
+      format: uint32
+    subentry_count:
+      type: integer
+      format: int32
+    last_modified_ledger:
+      type: integer
+      format: uint32
+    thresholds:
+      type: object
+      properties:
+        low_threshold:
+          type: integer
+        med_threshold:
+          type: integer
+        high_threshold:
+          type: integer
+    flags:
+      type: object
+      properties:
+        auth_required:
+          type: boolean
+        auth_revocable:
+          type: boolean
+        auth_immutable:
+          type: boolean
+        auth_clawback_enabled:
+          type: boolean
+    currency:
+      type: string
+      pattern: '[0-9]+\.[0-9]{7}'
+    BalanceLineNative:
+      type: object
+      properties:
+        balance:
+          $ref: '#/components/schemas/currency'
+        liquidity_pool_id:
+          type: string
+        limit:
+          $ref: '#/components/schemas/currency'
+        buying_liabilites:
+          $ref: '#/components/schemas/currency'
+        selling_liabilites:
+          $ref: '#/components/schemas/currency'
+        sponser:
+          type: string
+        last_modified_ledger:
+          $ref: '#/components/schemas/last_modified_ledger'
+        is_authorized:
+          type: boolean
+        is_authorized_to_maintain_liabilites:
+          type: boolean
+        is_clawback_enabled:
+          type: boolean
+        asset_type:
+          type: string
+          enum:
+            - native
+      required:
+        - balance
+        - limit
+        - asset_type
+        - buying_liabilites
+        - selling_liabilites
+        - last_modified_ledger
+        - is_authorized
+        - is_authorized_to_maintain_liabilites
+        - is_clawback_enabled
+    BalanceLineAsset:
+      type: object
+      properties:
+        balance:
+          $ref: '#/components/schemas/currency'
+        limit:
+          $ref: '#/components/schemas/currency'
+        buying_liabilites:
+          $ref: '#/components/schemas/currency'
+        selling_liabilites:
+          $ref: '#/components/schemas/currency'
+        sponser:
+          $ref: '#/components/schemas/address'
+        last_modified_ledger:
+          $ref: '#/components/schemas/last_modified_ledger'
+        is_authorized:
+          type: boolean
+        is_authorized_to_maintain_liabilites:
+          type: boolean
+        is_clawback_enabled:
+          type: boolean
+        asset_type:
+          type: string
+          enum:
+            - native
+            - credit_alphanum4
+            - credit_alphanum12
+        asset_code:
+          type: string
+        asset_issuer:
+          $ref: '#/components/schemas/address'
+      required:
+        - balance
+        - limit
+        - asset_type
+        - asset_code
+        - asset_issuer
+        - buying_liabilites
+        - selling_liabilites
+        - last_modified_ledger
+        - is_authorized
+        - is_authorized_to_maintain_liabilites
+        - is_clawback_enabled
+    BalanceLineLiquidityPool:
+      type: object
+      properties:
+        liquidity_pool_id:
+          type: string
+        asset_type:
+          type: string
+          enum:
+            - liquidity_pool_shares
+        balance:
+          $ref: '#/components/schemas/currency'
+        limit:
+          $ref: '#/components/schemas/currency'
+        last_modified_ledger:
+          $ref: '#/components/schemas/last_modified_ledger'
+        sponser:
+          $ref: '#/components/schemas/address'
+        is_authorized:
+          type: boolean
+        is_authorized_to_maintain_liabilites:
+          type: boolean
+        is_clawback_enabled:
+          type: boolean
+      required:
+        - liquidity_pool_id
+        - balance
+        - limit
+        - asset_type
+        - last_modified_ledger
+        - is_authorized
+        - is_authorized_to_maintain_liabilites
+        - is_clawback_enabled
+    signers:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/address'
+        weight:
+          type: integer
+          format: int32
+        type:
+          type: string
+          enum:
+            - ed25519_public_key
+            - sha256_hash
+            - preauth_tx
+        sponser:
+          $ref: '#/components/schemas/address'
+      required:
+        - key
+        - weight
+        - type
+    Account:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      transactions:
+                        $ref: '#/components/schemas/link'
+                      operations:
+                        $ref: '#/components/schemas/link'
+                      payments:
+                        $ref: '#/components/schemas/link'
+                      effects:
+                        $ref: '#/components/schemas/link'
+                      offers:
+                        $ref: '#/components/schemas/link'
+                      trades:
+                        $ref: '#/components/schemas/link'
+                      data:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - transactions
+                      - operations
+                      - payments
+                      - effects
+                      - offers
+                      - trades
+                      - data
+                  id:
+                    $ref: '#/components/schemas/id'
+                  account_id:
+                    $ref: '#/components/schemas/address'
+                  sequence:
+                    $ref: '#/components/schemas/sequence'
+                  sequence_ledger:
+                    $ref: '#/components/schemas/sequence_ledger'
+                  sequence_time:
+                    type: string
+                  subentry_count:
+                    $ref: '#/components/schemas/subentry_count'
+                  inflation_destination:
+                    $ref: '#/components/schemas/address'
+                  home_domain:
+                    type: string
+                  last_modified_ledger:
+                    $ref: '#/components/schemas/last_modified_ledger'
+                  last_modified_time:
+                    type: string
+                  thresholds:
+                    $ref: '#/components/schemas/thresholds'
+                  flags:
+                    $ref: '#/components/schemas/flags'
+                  balances:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/BalanceLineNative'
+                        - $ref: '#/components/schemas/BalanceLineAsset'
+                        - $ref: '#/components/schemas/BalanceLineLiquidityPool'
+                  signers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/signers'
+                  data:
+                    type: object
+                  num_sponsoring:
+                    type: integer
+                  num_sponsered:
+                    type: integer
+                  sponser:
+                    $ref: '#/components/schemas/address'
+                  paging_token:
+                    type: string
+                required:
+                  - id
+                  - account_id
+                  - sequence
+                  - subentry_count
+                  - last_modified_ledger
+                  - last_modified_time
+                  - thresholds
+                  - flags
+                  - balances
+                  - signers
+                  - data
+                  - num_sponsoring
+                  - num_sponsered
+                  - paging_token
+    signatures:
+      type: array
+      items:
+        type: string
+        pattern: G[A-Z0-9]{55}
+    TransactionPreconditionsTimebounds:
+      type: object
+      properties:
+        min_time:
+          type: string
+        max_time:
+          type: string
+    TransactionPreconditionsLedgerbounds:
+      type: object
+      properties:
+        min_ledger:
+          type: string
+        max_ledger:
+          type: string
+    TransactionPreconditions:
+      type: object
+      properties:
+        timebounds:
+          $ref: '#/components/schemas/TransactionPreconditionsTimebounds'
+        ledgerbounds:
+          $ref: '#/components/schemas/TransactionPreconditionsLedgerbounds'
+        min_account_sequence:
+          type: string
+        min_account_sequence_age:
+          type: string
+        min_account_sequence_ledger_gap:
+          type: integer
+          format: uint32
+        extra_signers:
+          type: array
+          items:
+            type: string
+    hash:
+      type: string
+    FeeBumpTransaction:
+      type: object
+      properties:
+        hash:
+          $ref: '#/components/schemas/hash'
+        signatures:
+          $ref: '#/components/schemas/signatures'
+    InnerTransaction:
+      type: object
+      properties:
+        hash:
+          $ref: '#/components/schemas/hash'
+        signatures:
+          $ref: '#/components/schemas/signatures'
+        max_fee:
+          type: string
+    Transaction:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  memo:
+                    type: string
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      account:
+                        $ref: '#/components/schemas/link'
+                      ledger:
+                        $ref: '#/components/schemas/link'
+                      operations:
+                        $ref: '#/components/schemas/link'
+                      effects:
+                        $ref: '#/components/schemas/link'
+                      precedes:
+                        $ref: '#/components/schemas/link'
+                      succeeds:
+                        $ref: '#/components/schemas/link'
+                      transaction:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - account
+                      - ledger
+                      - operations
+                      - effects
+                      - precedes
+                      - succeeds
+                      - transaction
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    type: string
+                  successful:
+                    type: boolean
+                  hash:
+                    type: string
+                  ledger:
+                    type: integer
+                    format: int32
+                  created_at:
+                    type: string
+                  source_account:
+                    $ref: '#/components/schemas/address'
+                  account_muxed:
+                    type: string
+                  account_muxed_id:
+                    type: string
+                  source_account_sequence:
+                    type: string
+                  fee_account:
+                    $ref: '#/components/schemas/address'
+                  fee_account_muxed:
+                    $ref: '#/components/schemas/address'
+                  fee_account_muxed_id:
+                    type: string
+                  fee_charged:
+                    type: string
+                  max_fee:
+                    type: string
+                  operation_count:
+                    type: integer
+                    format: int32
+                  envelope_xdr:
+                    type: string
+                  result_xdr:
+                    type: string
+                  result_meta_xdr:
+                    type: string
+                  fee_meta_xdr:
+                    type: string
+                  memo_type:
+                    type: string
+                  signatures:
+                    $ref: '#/components/schemas/signatures'
+                  preconditions:
+                    $ref: '#/components/schemas/TransactionPreconditions'
+                  fee_bump_transaction:
+                    $ref: '#/components/schemas/FeeBumpTransaction'
+                  inner_transaction:
+                    $ref: '#/components/schemas/InnerTransaction'
+                required:
+                  - id
+                  - paging_token
+                  - successful
+                  - hash
+                  - ledger
+                  - created_at
+                  - source_account
+                  - source_account_sequence
+                  - fee_account
+                  - fee_charged
+                  - max_fee
+                  - operation_count
+                  - envelope_xdr
+                  - result_xdr
+                  - result_meta_xdr
+                  - memo_type
+                  - signatures
+    CreateAccount:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            transaction:
+              $ref: '#/components/schemas/link'
+            effects:
+              $ref: '#/components/schemas/link'
+            succeeds:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - transaction
+            - effects
+            - succeeds
+            - precedes
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          type: string
+        transaction_successful:
+          type: boolean
+        source_account:
+          $ref: '#/components/schemas/address'
+        type:
+          type: string
+          example: create_account
+        type_i:
+          type: number
+          example: 0
+        created_at:
+          type: string
+        transaction_hash:
+          type: string
+        starting_balance:
+          type: string
+        funder:
+          $ref: '#/components/schemas/address'
+        account:
+          $ref: '#/components/schemas/address'
+      required:
+        - id
+        - paging_token
+        - transaction_successful
+        - source_account
+        - type
+        - type_i
+        - created_at
+        - transaction_hash
+        - starting_balance
+        - funder
+        - account
+    Payment:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      transaction:
+                        $ref: '#/components/schemas/link'
+                      effects:
+                        $ref: '#/components/schemas/link'
+                      succeeds:
+                        $ref: '#/components/schemas/link'
+                      precedes:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - transaction
+                      - effects
+                      - succeeds
+                      - precedes
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    type: string
+                  transaction_successful:
+                    type: boolean
+                  source_account:
+                    $ref: '#/components/schemas/address'
+                  type:
+                    type: string
+                    example: payment
+                  type_i:
+                    type: string
+                  created_at:
+                    type: string
+                  transaction_hash:
+                    type: string
+                  asset_type:
+                    type: string
+                  asset_code:
+                    enum:
+                      - native
+                      - credit_alphanum4
+                      - credit_alphanum12
+                  asset_issuer:
+                    $ref: '#/components/schemas/address'
+                  from:
+                    $ref: '#/components/schemas/address'
+                  to:
+                    $ref: '#/components/schemas/address'
+                  amount:
+                    type: string
+                required:
+                  - id
+                  - paging_token
+                  - transaction_successful
+                  - source_account
+                  - type
+                  - type_i
+                  - created_at
+                  - transaction_hash
+                  - asset_type
+                  - from
+                  - to
+                  - amount
+    PathPaymentStrictReceive:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            transaction:
+              $ref: '#/components/schemas/link'
+            effects:
+              $ref: '#/components/schemas/link'
+            succeeds:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - transaction
+            - effects
+            - succeeds
+            - precedes
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          type: string
+        transaction_successful:
+          type: boolean
+        source_account:
+          $ref: '#/components/schemas/address'
+        type:
+          type: string
+          example: path_payment_strict_receive
+        type_i:
+          type: number
+          example: 2
+        created_at:
+          type: string
+        transaction_hash:
+          type: string
+        asset_type:
+          type: string
+          enum:
+            - native
+            - credit_alphanum4
+            - credit_alphanum12
+        asset_code:
+          type: string
+        asset_issuer:
+          $ref: '#/components/schemas/address'
+        from:
+          $ref: '#/components/schemas/address'
+        to:
+          $ref: '#/components/schemas/address'
+        amount:
+          type: string
+        path:
+          type: array
+          items:
+            type: object
+            properties:
+              asset_type:
+                type: string
+                enum:
+                  - native
+                  - credit_alphanum4
+                  - credit_alphanum12
+              asset_code:
+                type: string
+              asset_issuer:
+                $ref: '#/components/schemas/address'
+        source_amount:
+          type: string
+        destination_min:
+          type: string
+        source_asset_type:
+          type: string
+        source_asset_code:
+          type: string
+        source_asset_issuer:
+          $ref: '#/components/schemas/address'
+      required:
+        - id
+        - paging_token
+        - transaction_successful
+        - source_account
+        - type
+        - type_i
+        - created_at
+        - transaction_hash
+        - from
+        - to
+        - amount
+        - path
+        - source_amount
+        - destination_min
+    PathPaymentStrictSend:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            transaction:
+              $ref: '#/components/schemas/link'
+            effects:
+              $ref: '#/components/schemas/link'
+            succeeds:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - transaction
+            - effects
+            - succeeds
+            - precedes
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          type: string
+        transaction_successful:
+          type: boolean
+        source_account:
+          $ref: '#/components/schemas/address'
+        type:
+          type: string
+          example: path_payment_strict_send
+        type_i:
+          type: number
+          example: 13
+        created_at:
+          type: string
+        transaction_hash:
+          type: string
+        asset_type:
+          type: string
+          enum:
+            - native
+            - credit_alphanum4
+            - credit_alphanum12
+        asset_code:
+          type: string
+        asset_issuer:
+          $ref: '#/components/schemas/address'
+        from:
+          $ref: '#/components/schemas/address'
+        to:
+          $ref: '#/components/schemas/address'
+        amount:
+          type: string
+        path:
+          type: array
+          items:
+            type: object
+            properties:
+              asset_type:
+                type: string
+                enum:
+                  - native
+                  - credit_alphanum4
+                  - credit_alphanum12
+              asset_code:
+                type: string
+              asset_issuer:
+                $ref: '#/components/schemas/address'
+        source_amount:
+          type: string
+        source_max:
+          type: string
+        source_asset_type:
+          type: string
+        source_asset_code:
+          type: string
+        source_asset_issuer:
+          $ref: '#/components/schemas/address'
+      required:
+        - id
+        - paging_token
+        - transaction_successful
+        - source_account
+        - type
+        - type_i
+        - created_at
+        - transaction_hash
+        - from
+        - to
+        - amount
+        - path
+        - source_amount
+        - source_asset_type
+    AccountMerge:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            transaction:
+              $ref: '#/components/schemas/link'
+            effects:
+              $ref: '#/components/schemas/link'
+            succeeds:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - transaction
+            - effects
+            - succeeds
+            - precedes
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          type: string
+        transaction_successful:
+          type: boolean
+        source_account:
+          $ref: '#/components/schemas/address'
+        type:
+          type: string
+          example: account_merge
+        type_i:
+          type: number
+          example: 8
+        created_at:
+          type: string
+        transaction_hash:
+          type: string
+        account:
+          $ref: '#/components/schemas/address'
+        into:
+          $ref: '#/components/schemas/address'
+      required:
+        - id
+        - paging_token
+        - transaction_successful
+        - source_account
+        - type
+        - type_i
+        - created_at
+        - transaction_hash
+        - account
+        - into
+    BaseAsset:
+      type: object
+      properties:
+        asset_type:
+          type: string
+        asset_code:
+          type: string
+        asset_issuer:
+          type: string
+      required:
+        - asset_type
+    Price:
+      type: object
+      properties:
+        'n':
+          type: integer
+          format: int32
+        d:
+          type: integer
+          format: int32
+    Offer:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      offer_maker:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - offer_maker
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    type: string
+                  seller:
+                    $ref: '#/components/schemas/address'
+                  selling:
+                    $ref: '#/components/schemas/BaseAsset'
+                  buying:
+                    $ref: '#/components/schemas/BaseAsset'
+                  amount:
+                    type: string
+                  price_r:
+                    $ref: '#/components/schemas/Price'
+                  price:
+                    type: string
+                  last_modified_ledger:
+                    $ref: '#/components/schemas/last_modified_ledger'
+                  last_modified_time:
+                    type: string
+                  sponser:
+                    type: string
+                required:
+                  - id
+                  - paging_token
+                  - seller
+                  - selling
+                  - buying
+                  - amount
+                  - price_r
+                  - price
+                  - last_modified_ledger
+                  - last_modified_time
+    paging_token:
+      type: string
+    tradePrice:
+      type: object
+      properties:
+        'n':
+          type: string
+        d:
+          type: string
+    Trade:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      base:
+                        $ref: '#/components/schemas/link'
+                      counter:
+                        $ref: '#/components/schemas/link'
+                      operation:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - base
+                      - counter
+                      - operation
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    $ref: '#/components/schemas/paging_token'
+                  ledger_close_time:
+                    type: string
+                  offer_id:
+                    type: string
+                  trade_type:
+                    type: string
+                  liquidity_pool_fee_bp:
+                    type: number
+                    format: uint32
+                  base_liquidity_pool_id:
+                    type: string
+                  base_offer_id:
+                    type: string
+                  base_account:
+                    $ref: '#/components/schemas/address'
+                  base_amount:
+                    type: string
+                  base_asset_type:
+                    type: string
+                  base_asset_code:
+                    type: string
+                  base_asset_issuer:
+                    type: string
+                  counter_liquidity_pool_id:
+                    type: string
+                  counter_offer_id:
+                    type: string
+                  counter_account:
+                    $ref: '#/components/schemas/address'
+                  counter_amount:
+                    type: string
+                  counter_asset_type:
+                    type: string
+                  counter_asset_code:
+                    type: string
+                  counter_asset_issuer:
+                    $ref: '#/components/schemas/address'
+                  base_is_seller:
+                    type: boolean
+                  price:
+                    $ref: '#/components/schemas/tradePrice'
+                    required:
+                      - id
+                      - paging_token
+                      - ledger_close_time
+                      - trade_type
+                      - base_amount
+                      - base_asset_type
+                      - counter_amount
+                      - counter_asset_type
+                      - base_is_seller
+    Asset:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      toml:
+                        $ref: '#/components/schemas/link'
+                  asset_type:
+                    type: string
+                  asset_issuer:
+                    $ref: '#/components/schemas/address'
+                  paging_token:
+                    type: string
+                  accounts:
+                    type: object
+                    properties:
+                      authorized:
+                        type: integer
+                      authorized_to_maintain_liabilities:
+                        type: integer
+                      unauthorized:
+                        type: integer
+                  num_claimable_balances:
+                    type: integer
+                  num_contracts:
+                    type: integer
+                  num_liquidity_pools:
+                    type: integer
+                  balances:
+                    type: object
+                    properties:
+                      authorized:
+                        type: string
+                      authorized_to_maintain_liabilities:
+                        type: string
+                      unauthorized:
+                        type: string
+                  claimable_balances_amount:
+                    type: string
+                  contracts_amount:
+                    type: string
+                  liquidity_pools_amount:
+                    type: string
+                  flags:
+                    type: object
+                    properties:
+                      auth_required:
+                        type: boolean
+                      auth_revocable:
+                        type: boolean
+                      auth_immutable:
+                        type: boolean
+    ClaimableBalances:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      operations:
+                        $ref: '#/components/schemas/link'
+                      transactions:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - operations
+                      - transactions
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    type: string
+                  asset:
+                    type: string
+                  amount:
+                    type: string
+                  sponsor:
+                    type: string
+                  last_modified_ledger:
+                    type: string
+                  last_modified_time:
+                    type: string
+                  claimants:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        destination:
+                          $ref: '#/components/schemas/address'
+                        predicate:
+                          type: object
+                          properties:
+                            and:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  or:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        relBefore:
+                                          type: string
+                                        absBefore:
+                                          type: string
+                                        absBeforeEpoch:
+                                          type: string
+                                  not:
+                                    type: object
+                                    properties:
+                                      unconditional:
+                                        type: boolean
+                                      relBefore:
+                                        type: string
+                                      absBefore:
+                                        type: string
+                                      absBeforeEpoch:
+                                        type: string
+                  flags:
+                    type: integer
+                required:
+                  - id
+                  - paging_token
+                  - asset
+                  - amount
+                  - last_modified_ledger
+                  - last_modified_time
+    ClaimableBalance:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            operations:
+              $ref: '#/components/schemas/link'
+            transactions:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - operations
+            - transactions
+        id:
+          $ref: '#/components/schemas/id'
+        asset:
+          type: string
+        amount:
+          type: string
+        sponsor:
+          type: string
+        last_modified_ledger:
+          type: string
+        last_modified_time:
+          type: string
+        claimants:
+          type: array
+          items:
+            type: object
+            properties:
+              destination:
+                $ref: '#/components/schemas/address'
+              predicate:
+                type: object
+                properties:
+                  and:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        or:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              relBefore:
+                                type: string
+                              absBefore:
+                                type: string
+                              absBeforeEpoch:
+                                type: string
+                        not:
+                          type: object
+                          properties:
+                            unconditional:
+                              type: boolean
+                            relBefore:
+                              type: string
+                            absBefore:
+                              type: string
+                            absBeforeEpoch:
+                              type: string
+        flags:
+          type: integer
+        paging_token:
+          type: string
+      required:
+        - id
+        - paging_token
+        - asset
+        - amount
+        - last_modified_ledger
+        - last_modified_time
+    Effect:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      operation:
+                        $ref: '#/components/schemas/link'
+                      succeeds:
+                        $ref: '#/components/schemas/link'
+                      precedes:
+                        $ref: '#/components/schemas/link'
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    $ref: '#/components/schemas/paging_token'
+                  account:
+                    $ref: '#/components/schemas/address'
+                  type:
+                    type: string
+                    enum:
+                      - Account Created
+                      - Account Removed
+                      - Account Credited
+                      - Account Debited
+                      - Account Thresholds Updated
+                      - Account Home Domain Updated
+                      - Account Flags Updated
+                      - Account Inflation Destination Updated
+                      - Signer Created
+                      - Signer Removed
+                      - Signer Updated
+                      - Trustline Created
+                      - Trustline Removed
+                      - Trustline Updated
+                      - Trustline Authorized
+                      - Trustline Deauthorized
+                      - Offer Created
+                      - Offer Removed
+                      - Offer Updated
+                      - Trade
+                      - Data Created
+                      - Data Removed
+                      - Data Updated
+                      - Claimable Balance Created
+                      - Claimable Balance Claimant Created
+                      - Claimable Balance Claimed
+                      - Account Sponsorship Created
+                      - Account Sponsorship Updated
+                      - Account Sponsorship Removed
+                      - Trustline Sponsorship Created
+                      - Trustline Sponsorship Updated
+                      - Trustline Sponsorship Removed
+                      - Account Data Sponsorship Created
+                      - Account Data Sponsorship Updated
+                      - Account Data Sponsorship Removed
+                      - Claimable Balance Sponsorship Created
+                      - Claimable Balance Sponsorship Updated
+                      - Claimable Balance Sponsorship Removed
+                      - Account Signer Sponsorship Created
+                      - Account Signer Sponsorship Updated
+                      - Account Signer Sponsorship Removed
+                      - Liquidity Pool Created
+                      - Liquidity Pool Removed
+                      - Liquidity Pool Revoked
+                      - Liquidity Pool Deposited
+                      - Liquidity Pool Withdraw
+                      - Liquidity Pool Trade
+                      - Sequence Bumped
+                  type_i:
+                    type: number
+                    example: 1
+                  created_at:
+                    type: string
+          required:
+            - id
+            - paging_token
+            - account
+            - type
+            - type_i
+            - created_at
+    BaseFeeDistribution:
+      type: object
+      properties:
+        max:
+          type: string
+        min:
+          type: string
+        mode:
+          type: string
+        p10:
+          type: string
+        p20:
+          type: string
+        p30:
+          type: string
+        p40:
+          type: string
+        p50:
+          type: string
+        p60:
+          type: string
+        p70:
+          type: string
+        p80:
+          type: string
+        p90:
+          type: string
+        p95:
+          type: string
+        p99:
+          type: string
+    ChargedFeeDistribution:
+      allOf:
+        - $ref: '#/components/schemas/BaseFeeDistribution'
+        - type: object
+          properties:
+            max:
+              description: Maximum (highest) fee charged over the last 5 ledgers.
+            min:
+              description: Minimum (lowest) fee charged over the last 5 ledgers.
+            mode:
+              description: Mode (middle) fee charged over the last 5 ledgers.
+            p10:
+              description: 10th percentile fee charged over the last 5 ledgers.
+            p20:
+              description: 20th percentile fee charged over the last 5 ledgers.
+            p30:
+              description: 30th percentile fee charged over the last 5 ledgers.
+            p40:
+              description: 40th percentile fee charged over the last 5 ledgers.
+            p50:
+              description: 50th percentile fee charged over the last 5 ledgers.
+            p60:
+              description: 60th percentile fee charged over the last 5 ledgers.
+            p70:
+              description: 70th percentile fee charged over the last 5 ledgers.
+            p80:
+              description: 80th percentile fee charged over the last 5 ledgers.
+            p90:
+              description: 90th percentile fee charged over the last 5 ledgers.
+            p95:
+              description: 95th percentile fee charged over the last 5 ledgers.
+            p99:
+              description: 99th percentile fee charged over the last 5 ledgers.
+    MaxFeeDistribution:
+      allOf:
+        - $ref: '#/components/schemas/BaseFeeDistribution'
+        - type: object
+          properties:
+            max:
+              description: Maximum (highest) value of the maximum fee bid over the last 5 ledgers.
+            min:
+              description: Minimum (lowest) value of the maximum fee bid over the last 5 ledgers.
+            mode:
+              description: Mode (middle) value of the maximum fee bid over the last 5 ledgers.
+            p10:
+              description: 10th percentile value of the maximum fee bid over the last 5 ledgers.
+            p20:
+              description: 20th percentile value of the maximum fee bid over the last 5 ledgers.
+            p30:
+              description: 30th percentile value of the maximum fee bid over the last 5 ledgers.
+            p40:
+              description: 40th percentile value of the maximum fee bid over the last 5 ledgers.
+            p50:
+              description: 50th percentile value of the maximum fee bid over the last 5 ledgers.
+            p60:
+              description: 60th percentile value of the maximum fee bid over the last 5 ledgers.
+            p70:
+              description: 70th percentile value of the maximum fee bid over the last 5 ledgers.
+            p80:
+              description: 80th percentile value of the maximum fee bid over the last 5 ledgers.
+            p90:
+              description: 90th percentile value of the maximum fee bid over the last 5 ledgers.
+            p95:
+              description: 95th percentile value of the maximum fee bid over the last 5 ledgers.
+            p99:
+              description: 99th percentile value of the maximum fee bid over the last 5 ledgers.
+    FeeStats:
+      type: object
+      properties:
+        last_ledger:
+          type: string
+          description: The last ledger's sequence number.
+        last_ledger_base_fee:
+          type: string
+          description: The base fee as defined in the last ledger.
+        ledger_capacity_usage:
+          type: string
+          description: The average capacity usage over the last 5 ledgers (0 is no usage, 1.0 is completely full ledgers).
+        fee_charged:
+          allOf:
+            - description: Information about the fee charged for transactions in the last 5 ledgers.
+            - $ref: '#/components/schemas/ChargedFeeDistribution'
+        max_fee:
+          allOf:
+            - description: Information about max fee bid for transactions over the last 5 ledgers.
+            - $ref: '#/components/schemas/MaxFeeDistribution'
+    Ledger:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      transactions:
+                        $ref: '#/components/schemas/link'
+                      operations:
+                        $ref: '#/components/schemas/link'
+                      payments:
+                        $ref: '#/components/schemas/link'
+                      effects:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - transactions
+                      - operations
+                      - effects
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    $ref: '#/components/schemas/paging_token'
+                  hash:
+                    $ref: '#/components/schemas/hash'
+                  pre_hash:
+                    $ref: '#/components/schemas/hash'
+                  sequence:
+                    type: integer
+                    format: int32
+                  successful_transaction_count:
+                    type: integer
+                    format: int32
+                  failed_transaction_count:
+                    type: integer
+                    format: int32
+                  operation_count:
+                    type: integer
+                    format: int32
+                  tx_set_operation_count:
+                    type: integer
+                    format: int32
+                  closed_at:
+                    type: string
+                  total_coins:
+                    type: string
+                  fee_pool:
+                    type: string
+                  base_fee_in_stroops:
+                    type: integer
+                    format: int32
+                  base_reserve_in_stroops:
+                    type: integer
+                    format: int32
+                  max_tx_set_size:
+                    type: integer
+                    format: int32
+                  protocol_version:
+                    type: integer
+                    format: int32
+                  header_xdr:
+                    type: string
+          required:
+            - id
+            - paging_token
+            - hash
+            - sequence
+            - successful_transaction_count
+            - failed_transaction_count
+            - operation_count
+            - tx_set_operation_count
+            - closed_at
+            - total_coins
+            - fee_pool
+            - base_fee_in_stroops
+            - base_reserve_in_stroops
+            - max_tx_set_size
+            - protocol_version
+            - header_xdr
+    Operation:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            effects:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+            self:
+              $ref: '#/components/schemas/link'
+            succeds:
+              $ref: '#/components/schemas/link'
+            transaction:
+              $ref: '#/components/schemas/link'
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          $ref: '#/components/schemas/paging_token'
+        type_i:
+          type: number
+          example: 0
+        type:
+          type: string
+          example: create_account
+    LiquidityPools:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    $ref: '#/components/schemas/paging_token'
+                  fee_bp:
+                    type: integer
+                    format: uint32
+                  type:
+                    type: string
+                  total_trustlines:
+                    type: string
+                  total_shares:
+                    type: string
+                  reserves:
+                    type: object
+                    properties:
+                      asset:
+                        type: string
+                      amount:
+                        type: string
+                  last_modified_ledger:
+                    type: string
+                  last_modified_time:
+                    type: string
+                required:
+                  - id
+                  - paging_token
+                  - fee_bp
+                  - type
+                  - total_trustlines
+                  - total_shares
+                  - reserves
+                  - last_modified_ledger
+                  - last_modified_time
+    LiquidityPool:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            transactions:
+              $ref: '#/components/schemas/link'
+            operations:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - operations
+            - transactions
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          $ref: '#/components/schemas/paging_token'
+        fee_bp:
+          type: integer
+          format: uint32
+        type:
+          type: string
+        total_trustlines:
+          type: string
+        total_shares:
+          type: string
+        reserves:
+          type: object
+          properties:
+            asset:
+              type: string
+            amount:
+              type: string
+        last_modified_ledger:
+          type: string
+        last_modified_time:
+          type: string
+      required:
+        - id
+        - paging_token
+        - fee_bp
+        - type
+        - total_trustlines
+        - total_shares
+        - reserves
+        - last_modified_ledger
+        - last_modified_time
+    OrderBook:
+      type: object
+      properties:
+        bids:
+          type: array
+          items:
+            type: object
+            properties:
+              price_r:
+                type: object
+                properties:
+                  'n':
+                    type: integer
+                  d:
+                    type: integer
+              price:
+                type: string
+              amount:
+                type: string
+        asks:
+          type: array
+          items:
+            type: object
+            properties:
+              price_r:
+                type: object
+                properties:
+                  'n':
+                    type: integer
+                  d:
+                    type: integer
+              price:
+                type: string
+              amount:
+                type: string
+        base:
+          type: object
+          properties:
+            asset_type:
+              type: string
+        counter:
+          type: object
+          properties:
+            asset_type:
+              type: string
+            asset_code:
+              type: string
+            asset_issuer:
+              $ref: '#/components/schemas/address'
+    schemas-Asset:
+      type: object
+      properties:
+        asset_type:
+          type: string
+        asset_code:
+          type: string
+        asset_issuer:
+          $ref: '#/components/schemas/address'
+      required:
+        - asset_type
+    Path:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  source_asset_type:
+                    type: string
+                  source_asset_code:
+                    type: string
+                  source_asset_issuer:
+                    $ref: '#/components/schemas/address'
+                  source_amount:
+                    type: string
+                  destination_asset_type:
+                    type: string
+                  destination_asset_code:
+                    type: string
+                  destination_asset_issuer:
+                    $ref: '#/components/schemas/address'
+                  destination_amount:
+                    type: string
+                  path:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/schemas-Asset'
+              required:
+                - source_asset_type
+                - source_amount
+                - destination_asset_type
+                - destination_amount
+                - path
+    host_function_parameter:
+      type: object
+      properties:
+        value:
+          type: string
+        type:
+          type: string
+      required:
+        - value
+        - type
+    asset_balance_change:
+      type: object
+      properties:
+        asset_type:
+          type: string
+        asset_code:
+          enum:
+            - native
+            - credit_alphanum4
+            - credit_alphanum12
+        asset_issuer:
+          $ref: '#/components/schemas/address'
+        type:
+          type: string
+          enum:
+            - transfer
+            - mint
+            - clawback
+            - burn
+        from:
+          type: string
+        to:
+          type: string
+        amount:
+          type: string
+      required:
+        - asset_type
+        - type
+        - amount
+    InvokeHostFunction:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            transaction:
+              $ref: '#/components/schemas/link'
+            effects:
+              $ref: '#/components/schemas/link'
+            succeeds:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - transaction
+            - effects
+            - succeeds
+            - precedes
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          type: string
+        transaction_successful:
+          type: boolean
+        source_account:
+          $ref: '#/components/schemas/address'
+        type:
+          type: string
+          example: invoke_host_function
+        type_i:
+          type: number
+          example: 0
+        created_at:
+          type: string
+        transaction_hash:
+          type: string
+        function:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/host_function_parameter'
+        address:
+          type: string
+        salt:
+          type: string
+        asset_balance_changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/asset_balance_change'
+      required:
+        - id
+        - paging_token
+        - transaction_successful
+        - source_account
+        - type
+        - type_i
+        - created_at
+        - transaction_hash
+        - function
+    TradeAggregation:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  timestamp:
+                    type: string
+                  trade_count:
+                    type: string
+                  base_volume:
+                    type: string
+                  counter_volume:
+                    type: string
+                  avg:
+                    type: string
+                  high:
+                    type: string
+                  high_r:
+                    $ref: '#/components/schemas/tradePrice'
+                  low:
+                    type: string
+                  low_r:
+                    $ref: '#/components/schemas/tradePrice'
+                  open:
+                    type: string
+                  open_r:
+                    $ref: '#/components/schemas/tradePrice'
+                  close:
+                    type: string
+                  close_r:
+                    $ref: '#/components/schemas/tradePrice'
+    schemas-Transaction:
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              $ref: '#/components/schemas/link'
+            account:
+              $ref: '#/components/schemas/link'
+            ledger:
+              $ref: '#/components/schemas/link'
+            operations:
+              $ref: '#/components/schemas/link'
+            effects:
+              $ref: '#/components/schemas/link'
+            precedes:
+              $ref: '#/components/schemas/link'
+            succeeds:
+              $ref: '#/components/schemas/link'
+          required:
+            - self
+            - account
+            - ledger
+            - operations
+            - effects
+            - precedes
+            - succeeds
+        id:
+          $ref: '#/components/schemas/id'
+        paging_token:
+          type: string
+        successful:
+          type: boolean
+        hash:
+          type: string
+        ledger:
+          type: integer
+          format: int32
+        created_at:
+          type: string
+        source_account:
+          $ref: '#/components/schemas/address'
+        account_muxed:
+          type: string
+        account_muxed_id:
+          type: string
+        source_account_sequence:
+          type: string
+        fee_account:
+          $ref: '#/components/schemas/address'
+        fee_account_muxed:
+          $ref: '#/components/schemas/address'
+        fee_account_muxed_id:
+          type: string
+        fee_charged:
+          type: string
+        max_fee:
+          type: string
+        operation_count:
+          type: integer
+          format: int32
+        envelope_xdr:
+          type: string
+        result_xdr:
+          type: string
+        result_meta_xdr:
+          type: string
+        fee_meta_xdr:
+          type: string
+        memo_type:
+          type: string
+        signatures:
+          $ref: '#/components/schemas/signatures'
+    SubmitTransaction:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            records:
+              type: array
+              items:
+                type: object
+                properties:
+                  memo:
+                    type: string
+                  memo_bytes:
+                    type: string
+                  _links:
+                    type: object
+                    properties:
+                      self:
+                        $ref: '#/components/schemas/link'
+                      account:
+                        $ref: '#/components/schemas/link'
+                      ledger:
+                        $ref: '#/components/schemas/link'
+                      operations:
+                        $ref: '#/components/schemas/link'
+                      effects:
+                        $ref: '#/components/schemas/link'
+                      precedes:
+                        $ref: '#/components/schemas/link'
+                      succeeds:
+                        $ref: '#/components/schemas/link'
+                      transaction:
+                        $ref: '#/components/schemas/link'
+                    required:
+                      - self
+                      - account
+                      - ledger
+                      - operations
+                      - effects
+                      - precedes
+                      - succeeds
+                      - transaction
+                  id:
+                    $ref: '#/components/schemas/id'
+                  paging_token:
+                    type: string
+                  successful:
+                    type: boolean
+                  hash:
+                    type: string
+                  ledger:
+                    type: integer
+                    format: int32
+                  created_at:
+                    type: string
+                  source_account:
+                    $ref: '#/components/schemas/address'
+                  account_muxed:
+                    type: string
+                  account_muxed_id:
+                    type: string
+                  source_account_sequence:
+                    type: string
+                  fee_account:
+                    $ref: '#/components/schemas/address'
+                  fee_account_muxed:
+                    $ref: '#/components/schemas/address'
+                  fee_account_muxed_id:
+                    type: string
+                  fee_charged:
+                    type: string
+                  max_fee:
+                    type: string
+                  operation_count:
+                    type: integer
+                    format: int32
+                  envelope_xdr:
+                    type: string
+                  result_xdr:
+                    type: string
+                  result_meta_xdr:
+                    type: string
+                  fee_meta_xdr:
+                    type: string
+                  memo_type:
+                    type: string
+                  signatures:
+                    $ref: '#/components/schemas/signatures'
+                  preconditions:
+                    $ref: '#/components/schemas/TransactionPreconditions'
+                  fee_bump_transaction:
+                    $ref: '#/components/schemas/FeeBumpTransaction'
+                  inner_transaction:
+                    $ref: '#/components/schemas/InnerTransaction'
+                required:
+                  - id
+                  - paging_token
+                  - successful
+                  - hash
+                  - ledger
+                  - created_at
+                  - source_account
+                  - source_account_sequence
+                  - fee_account
+                  - fee_charged
+                  - max_fee
+                  - operation_count
+                  - envelope_xdr
+                  - result_xdr
+                  - result_meta_xdr
+                  - memo_type
+                  - signatures
+    AsyncTransactionSubmissionResponse:
+      type: object
+      properties:
+        error_result_xdr:
+          type: string
+          nullable: true
+          description: TransactionResult XDR string which is present only if the submission status from core is an ERROR.
+        tx_status:
+          type: string
+          enum:
+            - ERROR
+            - PENDING
+            - DUPLICATE
+            - TRY_AGAIN_LATER
+          description: Status of the transaction submission.
+        hash:
+          type: string
+          description: Hash of the transaction.
+    Problem:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Identifies the problem type.
+        title:
+          type: string
+          description: A short, human-readable summary of the problem type.
+        status:
+          type: integer
+          description: The HTTP status code for this occurrence of the problem.
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence of the problem.
+        extras:
+          type: object
+          additionalProperties: true
+          description: Additional details that might help the client understand the error(s) that occurred.
+  examples:
+    ListAllAccounts:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts?cursor=&limit=10&order=asc&signer=GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+          next:
+            href: https://horizon-testnet.stellar.org/accounts?cursor=GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U&limit=10&order=asc&signer=GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+          prev:
+            href: https://horizon-testnet.stellar.org/accounts?cursor=GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U&limit=10&order=desc&signer=GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+                transactions:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/operations{?cursor,limit,order}
+                  templated: true
+                payments:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/payments{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/effects{?cursor,limit,order}
+                  templated: true
+                offers:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/offers{?cursor,limit,order}
+                  templated: true
+                trades:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/trades{?cursor,limit,order}
+                  templated: true
+                data:
+                  href: https://horizon-testnet.stellar.org/accounts/GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U/data/{key}
+                  templated: true
+              id: GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+              account_id: GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+              sequence: '24739097524306474'
+              subentry_count: 3
+              inflation_destination: GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+              home_domain: tempo.eu.com
+              last_modified_ledger: 40074676
+              last_modified_time: '2022-03-17T23:13:54Z'
+              thresholds:
+                low_threshold: 5
+                med_threshold: 0
+                high_threshold: 0
+              flags:
+                auth_required: false
+                auth_revocable: true
+                auth_immutable: false
+                auth_clawback_enabled: false
+              balances:
+                - balance: '0.0000000'
+                  limit: '922337203685.4775807'
+                  buying_liabilities: '0.0000000'
+                  selling_liabilities: '0.0000000'
+                  last_modified_ledger: 40074670
+                  is_authorized: true
+                  is_authorized_to_maintain_liabilities: true
+                  asset_type: credit_alphanum4
+                  asset_code: EURT
+                  asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                - balance: '0.0000000'
+                  limit: '922337203685.4775807'
+                  buying_liabilities: '0.0000000'
+                  selling_liabilities: '0.0000000'
+                  last_modified_ledger: 20213845
+                  is_authorized: true
+                  is_authorized_to_maintain_liabilities: true
+                  asset_type: credit_alphanum4
+                  asset_code: NGN
+                  asset_issuer: GCC4YLCR7DDWFCIPTROQM7EB2QMFD35XRWEQVIQYJQHVW6VE5MJZXIGW
+                - balance: '0.0000000'
+                  limit: '922337203685.4775807'
+                  buying_liabilities: '0.0000000'
+                  selling_liabilities: '0.0000000'
+                  last_modified_ledger: 7877447
+                  is_authorized: false
+                  is_authorized_to_maintain_liabilities: false
+                  asset_type: credit_alphanum4
+                  asset_code: PHP
+                  asset_issuer: GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+                - balance: '80.8944518'
+                  buying_liabilities: '0.0000000'
+                  selling_liabilities: '0.0000000'
+                  asset_type: native
+              signers:
+                - weight: 10
+                  key: GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+                  type: ed25519_public_key
+              data: {}
+              num_sponsoring: 0
+              num_sponsored: 0
+              paging_token: GDI73WJ4SX7LOG3XZDJC3KCK6ED6E5NBYK2JUBQSPBCNNWEG3ZN7T75U
+    RetrieveAnAccount:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+          transactions:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/transactions{?cursor,limit,order}
+            templated: true
+          operations:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/operations{?cursor,limit,order}
+            templated: true
+          payments:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/payments{?cursor,limit,order}
+            templated: true
+          effects:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/effects{?cursor,limit,order}
+            templated: true
+          offers:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/offers{?cursor,limit,order}
+            templated: true
+          trades:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/trades{?cursor,limit,order}
+            templated: true
+          data:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/data/{key}
+            templated: true
+        id: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+        account_id: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+        sequence: '120192344791187470'
+        subentry_count: 5
+        last_modified_ledger: 28105812
+        num_sponsoring: 0
+        num_sponsored: 0
+        thresholds:
+          low_threshold: 0
+          med_threshold: 0
+          high_threshold: 0
+        flags:
+          auth_required: false
+          auth_revocable: false
+          auth_immutable: false
+          auth_clawback_enabled: false
+        balances:
+          - balance: '3.0000000'
+            limit: '922337203685.4775807'
+            buying_liabilities: '0.0000000'
+            selling_liabilities: '0.0000000'
+            last_modified_ledger: 27984507
+            is_authorized: true
+            is_clawback_enabled: false
+            asset_type: credit_alphanum4
+            asset_code: EURT
+            asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+          - balance: '4.0000000'
+            limit: '922337203685.4775807'
+            buying_liabilities: '0.0000000'
+            selling_liabilities: '0.0000000'
+            last_modified_ledger: 27985131
+            is_authorized: true
+            is_clawback_enabled: true
+            asset_type: credit_alphanum4
+            asset_code: USD
+            asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+          - balance: '72.8563792'
+            buying_liabilities: '0.0000000'
+            selling_liabilities: '0.0000000'
+            asset_type: native
+        signers:
+          - weight: 1
+            key: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            type: ed25519_public_key
+        data: {}
+        paging_token: ''
+    RetrieveAnAccountsTransactions:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU/transactions?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU/transactions?cursor=122152984477229056&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU/transactions?cursor=94658837230923776&limit=10&order=desc
+        _embedded:
+          records:
+            - memo: ''
+              memo_bytes: ''
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/4826a3d41a5a795bf795767d0fb5e39c4abbcf695cf888b3578aa126b5b257ee
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBYSOAM7D42RMUN4LCKCFYNXZU3F7TJVKD2NMR672J4372BCH6DE4BKR
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/22039478
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/4826a3d41a5a795bf795767d0fb5e39c4abbcf695cf888b3578aa126b5b257ee/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/4826a3d41a5a795bf795767d0fb5e39c4abbcf695cf888b3578aa126b5b257ee/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=94658837230923776
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=94658837230923776
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/4826a3d41a5a795bf795767d0fb5e39c4abbcf695cf888b3578aa126b5b257ee
+              id: 4826a3d41a5a795bf795767d0fb5e39c4abbcf695cf888b3578aa126b5b257ee
+              paging_token: '94658837230923776'
+              successful: true
+              hash: 4826a3d41a5a795bf795767d0fb5e39c4abbcf695cf888b3578aa126b5b257ee
+              ledger: 22039478
+              created_at: '2019-01-18T14:40:47Z'
+              source_account: GBYSOAM7D42RMUN4LCKCFYNXZU3F7TJVKD2NMR672J4372BCH6DE4BKR
+              source_account_sequence: '90296735301107721'
+              fee_account: GBYSOAM7D42RMUN4LCKCFYNXZU3F7TJVKD2NMR672J4372BCH6DE4BKR
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAHEnAZ8fNRZRvFiUIuG3zTZfzTVQ9NZH39J5v+giP4ZOAAAAZAFAzGcAAAAJAAAAAQAAAAAAAAAAAAAAAFxB5cMAAAABAAAAAAAAAAEAAAAAAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAAC+vCAAAAAAAAAAAEiP4ZOAAAAQO421wcb/JYfBpnYEJzHpMyQnrM8rHd4PUoyHXpPlvQAUGzARqwbX8hcLSM4tlk51AwbuZOaZfWCaFQfzFZJuAA=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAVBLtgAAAAAAAAAAcScBnx81FlG8WJQi4bfNNl/NNVD01kff0nm/6CI/hk4AAAAAI9MEZAFAzGcAAAAIAAAAAAAAAAEAAAAA7Nxp7lmV7taqQfqoSP+tlqjOHWeANaQYFqhDkCQERZQAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAVBLtgAAAAAAAAAAcScBnx81FlG8WJQi4bfNNl/NNVD01kff0nm/6CI/hk4AAAAAI9MEZAFAzGcAAAAJAAAAAAAAAAEAAAAA7Nxp7lmV7taqQfqoSP+tlqjOHWeANaQYFqhDkCQERZQAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMBUEu2AAAAAAAAAABxJwGfHzUWUbxYlCLht802X801UPTWR9/Seb/oIj+GTgAAAAAj0wRkAUDMZwAAAAkAAAAAAAAAAQAAAADs3GnuWZXu1qpB+qhI/62WqM4dZ4A1pBgWqEOQJARFlAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBUEu2AAAAAAAAAABxJwGfHzUWUbxYlCLht802X801UPTWR9/Seb/oIj+GTgAAAAAg2BPkAUDMZwAAAAkAAAAAAAAAAQAAAADs3GnuWZXu1qpB+qhI/62WqM4dZ4A1pBgWqEOQJARFlAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABUEu2AAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAAC+vCAAVBLtgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBUCemAAAAAAAAAABxJwGfHzUWUbxYlCLht802X801UPTWR9/Seb/oIj+GTgAAAAAj0wTIAUDMZwAAAAgAAAAAAAAAAQAAAADs3GnuWZXu1qpB+qhI/62WqM4dZ4A1pBgWqEOQJARFlAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBUEu2AAAAAAAAAABxJwGfHzUWUbxYlCLht802X801UPTWR9/Seb/oIj+GTgAAAAAj0wRkAUDMZwAAAAgAAAAAAAAAAQAAAADs3GnuWZXu1qpB+qhI/62WqM4dZ4A1pBgWqEOQJARFlAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - 7jbXBxv8lh8GmdgQnMekzJCeszysd3g9SjIdek+W9ABQbMBGrBtfyFwtIzi2WTnUDBu5k5pl9YJoVB/MVkm4AA==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1547822531'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/ec8d5d6e64dc4df1bc8d8c200e048d6740d1e9f680612baeda0f78678c9ca666
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GAL62GEDMQFWRQLZXJKT4WFRFTIKPPTC2ALSD45VMK7ZUUZVBXWWXUAX
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/23895910
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/ec8d5d6e64dc4df1bc8d8c200e048d6740d1e9f680612baeda0f78678c9ca666/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/ec8d5d6e64dc4df1bc8d8c200e048d6740d1e9f680612baeda0f78678c9ca666/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=102632151958179840
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=102632151958179840
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/ec8d5d6e64dc4df1bc8d8c200e048d6740d1e9f680612baeda0f78678c9ca666
+              id: ec8d5d6e64dc4df1bc8d8c200e048d6740d1e9f680612baeda0f78678c9ca666
+              paging_token: '102632151958179840'
+              successful: true
+              hash: ec8d5d6e64dc4df1bc8d8c200e048d6740d1e9f680612baeda0f78678c9ca666
+              ledger: 23895910
+              created_at: '2019-05-17T14:43:53Z'
+              source_account: GAL62GEDMQFWRQLZXJKT4WFRFTIKPPTC2ALSD45VMK7ZUUZVBXWWXUAX
+              source_account_sequence: '93143259236270083'
+              fee_account: GAL62GEDMQFWRQLZXJKT4WFRFTIKPPTC2ALSD45VMK7ZUUZVBXWWXUAX
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAABftGINkC2jBebpVPlixLNCnvmLQFyHztWK/mlM1De1rAAAAZAFK6U0AAAADAAAAAQAAAAAAAAAAAAAAAFzeydEAAAAAAAAAAQAAAAAAAAABAAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAAAAAAALLQXgAAAAAAAAAAAE1De1rAAAAQLFFYK9rGA2Um2Vwguj4Ra3T6gaeturf4Qw/0LcG/qa/oXZeu6s7ZrB3wVVJu0m123Z7zirYoo576IS8agzLKQQ=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAWyfZgAAAAAAAAAAF+0Yg2QLaMF5ulU+WLEs0Ke+YtAXIfO1Yr+aUzUN7WsAAAAC1fwL1AFK6U0AAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAWyfZgAAAAAAAAAAF+0Yg2QLaMF5ulU+WLEs0Ke+YtAXIfO1Yr+aUzUN7WsAAAAC1fwL1AFK6U0AAAADAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBUEu2AAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAAC+vCAAVBLtgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBbJ9mAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALOPGiAAVBLtgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBbJ9mAAAAAAAAAAAX7RiDZAtowXm6VT5YsSzQp75i0Bch87Viv5pTNQ3tawAAAALV/AvUAUrpTQAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBbJ9mAAAAAAAAAAAX7RiDZAtowXm6VT5YsSzQp75i0Bch87Viv5pTNQ3tawAAAAAKupPUAUrpTQAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBS+8PAAAAAAAAAAAX7RiDZAtowXm6VT5YsSzQp75i0Bch87Viv5pTNQ3tawAAAALV/Aw4AUrpTQAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBbJ9mAAAAAAAAAAAX7RiDZAtowXm6VT5YsSzQp75i0Bch87Viv5pTNQ3tawAAAALV/AvUAUrpTQAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - sUVgr2sYDZSbZXCC6PhFrdPqBp626t/hDD/Qtwb+pr+hdl67qztmsHfBVUm7SbXbdnvOKtiijnvohLxqDMspBA==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1558104529'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/5427d2719db9ca33706e9c06c04f91bd353e0e6f5185c6f47b517b338b8d81b2
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/27114571
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/5427d2719db9ca33706e9c06c04f91bd353e0e6f5185c6f47b517b338b8d81b2/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/5427d2719db9ca33706e9c06c04f91bd353e0e6f5185c6f47b517b338b8d81b2/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=116456195690164224
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=116456195690164224
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/5427d2719db9ca33706e9c06c04f91bd353e0e6f5185c6f47b517b338b8d81b2
+              id: 5427d2719db9ca33706e9c06c04f91bd353e0e6f5185c6f47b517b338b8d81b2
+              paging_token: '116456195690164224'
+              successful: true
+              hash: 5427d2719db9ca33706e9c06c04f91bd353e0e6f5185c6f47b517b338b8d81b2
+              ledger: 27114571
+              created_at: '2019-12-04T22:03:41Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911489'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAABAAAAAQAAAAAAAAAAAAAAAF3oLZMAAAAAAAAAAQAAAAAAAAABAAAAAARD8QZr6wa97ii5JeeuMJEXycVsEO1dBekjRTcI9AadAAAAAAAAAAABMS0AAAAAAAAAAAGXebqxAAAAQND+muz3883MoHmTtuhsDb4awF1U3EDJ2FQn8Ia2C9L+Rz62Z9EvH8rl81d3oPxrjUnedZmjOnptn6Agm5alHwc=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAZ28SwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACzjxoHAFQS7YAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAZ28SwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACzjxoHAFQS7YAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBnbwPAAAAAAAAAAAEQ/EGa+sGve4ouSXnrjCRF8nFbBDtXQXpI0U3CPQGnQAAAABxZQNiAZtraAAAABsAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBnbxLAAAAAAAAAAAEQ/EGa+sGve4ouSXnrjCRF8nFbBDtXQXpI0U3CPQGnQAAAAByljBiAZtraAAAABsAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBnbxLAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALOPGgcAVBLtgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBnbxLAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALNCzscAVBLtgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBbJ9mAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALOPGiAAVBLtgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBnbxLAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALOPGgcAVBLtgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - 0P6a7PfzzcygeZO26GwNvhrAXVTcQMnYVCfwhrYL0v5HPrZn0S8fyuXzV3eg/GuNSd51maM6em2foCCblqUfBw==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1575497107'
+            - memo: hello universe
+              memo_bytes: aGVsbG8gdW5pdmVyc2U=
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/27984461
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=120192344791343104
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=120192344791343104
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894
+              id: ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894
+              paging_token: '120192344791343104'
+              successful: true
+              hash: ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894
+              ledger: 27984461
+              created_at: '2020-01-29T19:43:59Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911490'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAACAAAAAQAAAAAAAAAAAAAAAF4x4NYAAAABAAAADmhlbGxvIHVuaXZlcnNlAAAAAAABAAAAAAAAAAAAAAAAMOWtdEZJweWBDrIVGDQOVodinrlXbfzBfquR7AFtxW4AAAAAATEtAAAAAAAAAAABl3m6sQAAAEDwdDlpQv5IfweTkLjytpWIa+bpQv7BAHRFpMCHscM3g+WBKjXPVEnSP1BghLuy3uhvgv4LnCkI+gFEDZxwV/YF
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAasCTQAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACzQs6uAFQS7YAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAasCTQAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACzQs6uAFQS7YAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMBqwJNAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALNCzq4AVBLtgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBqwJNAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALL2g24AVBLtgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABqwJNAAAAAAAAAAAw5a10RknB5YEOshUYNA5Wh2KeuVdt/MF+q5HsAW3FbgAAAAABMS0AAasCTQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBnbxLAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALNCzscAVBLtgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBqwJNAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALNCzq4AVBLtgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - 8HQ5aUL+SH8Hk5C48raViGvm6UL+wQB0RaTAh7HDN4PlgSo1z1RJ0j9QYIS7st7ob4L+C5wpCPoBRA2ccFf2BQ==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1580327126'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/27984467
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=120192370561220608
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=120192370561220608
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589
+              id: c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589
+              paging_token: '120192370561220608'
+              successful: true
+              hash: c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589
+              ledger: 27984467
+              created_at: '2020-01-29T19:44:36Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911491'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAADAAAAAQAAAAAAAAAAAAAAAF4x4PoAAAAAAAAAAQAAAAAAAAABAAAAADDlrXRGScHlgQ6yFRg0DlaHYp65V238wX6rkewBbcVuAAAAAAAAAAB3NZQAAAAAAAAAAAGXebqxAAAAQMzdIubro9XQUTkhf0YbDBNM5tqC/zS7fGb0BLFq+QxXT7VAS7dDMno9A2f1df4nnyeHqVl+CuKcpwwwS04JSgE=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAasCUwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACy9oNVAFQS7YAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAasCUwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACy9oNVAFQS7YAAAADAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBqwJNAAAAAAAAAAAw5a10RknB5YEOshUYNA5Wh2KeuVdt/MF+q5HsAW3FbgAAAAABMS0AAasCTQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBqwJTAAAAAAAAAAAw5a10RknB5YEOshUYNA5Wh2KeuVdt/MF+q5HsAW3FbgAAAAB4ZsEAAasCTQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBqwJTAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALL2g1UAVBLtgAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBqwJTAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJUpHlUAVBLtgAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBqwJNAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALL2g24AVBLtgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBqwJTAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAALL2g1UAVBLtgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - zN0i5uuj1dBROSF/RhsME0zm2oL/NLt8ZvQEsWr5DFdPtUBLt0Myej0DZ/V1/iefJ4epWX4K4pynDDBLTglKAQ==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1580327162'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/e0f3d6e327a6de01223a8f0e2b88e97abeaf1f514f95f8e7c55f18b951f09dbe
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/28000615
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/e0f3d6e327a6de01223a8f0e2b88e97abeaf1f514f95f8e7c55f18b951f09dbe/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/e0f3d6e327a6de01223a8f0e2b88e97abeaf1f514f95f8e7c55f18b951f09dbe/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=120261725693136896
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=120261725693136896
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/e0f3d6e327a6de01223a8f0e2b88e97abeaf1f514f95f8e7c55f18b951f09dbe
+              id: e0f3d6e327a6de01223a8f0e2b88e97abeaf1f514f95f8e7c55f18b951f09dbe
+              paging_token: '120261725693136896'
+              successful: true
+              hash: e0f3d6e327a6de01223a8f0e2b88e97abeaf1f514f95f8e7c55f18b951f09dbe
+              ledger: 28000615
+              created_at: '2020-01-30T21:45:07Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911492'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAAEAAAAAQAAAAAAAAAAAAAAAF4zTrgAAAAAAAAAAQAAAAAAAAABAAAAABhkaLZ/GHrh4vaarKkeK7PX2c581NvMfPvtTyATuVziAAAAAAAAAAAF9eEAAAAAAAAAAAGXebqxAAAAQB9XBu17Olvry7c8CqLJXqvK5csy2r3lGiP3HyR5JcryL8QQjSuwGr/LEFFKIS5Afo/jh9fCzGzJzZQ4DN1KPgs=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAatBZwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACVKR48AFQS7YAAAADAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAatBZwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACVKR48AFQS7YAAAAEAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBq0EQAAAAAAAAAAAYZGi2fxh64eL2mqypHiuz19nOfNTbzHz77U8gE7lc4gAAAAACYljUAatBDAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBq0FnAAAAAAAAAAAYZGi2fxh64eL2mqypHiuz19nOfNTbzHz77U8gE7lc4gAAAAAIWDnUAatBDAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBq0FnAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJUpHjwAVBLtgAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBq0FnAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJOrpfwAVBLtgAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBqwJTAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJUpHlUAVBLtgAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBq0FnAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJUpHjwAVBLtgAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - H1cG7Xs6W+vLtzwKosleq8rlyzLaveUaI/cfJHklyvIvxBCNK7Aav8sQUUohLkB+j+OH18LMbMnNlDgM3Uo+Cw==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1580420792'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/329ae48814ae29ed6d9c0bb6e398932e6a178cac21623b63fbf5d8245261c041
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/28000619
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/329ae48814ae29ed6d9c0bb6e398932e6a178cac21623b63fbf5d8245261c041/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/329ae48814ae29ed6d9c0bb6e398932e6a178cac21623b63fbf5d8245261c041/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=120261742872928256
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=120261742872928256
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/329ae48814ae29ed6d9c0bb6e398932e6a178cac21623b63fbf5d8245261c041
+              id: 329ae48814ae29ed6d9c0bb6e398932e6a178cac21623b63fbf5d8245261c041
+              paging_token: '120261742872928256'
+              successful: true
+              hash: 329ae48814ae29ed6d9c0bb6e398932e6a178cac21623b63fbf5d8245261c041
+              ledger: 28000619
+              created_at: '2020-01-30T21:45:29Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911493'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAAFAAAAAQAAAAAAAAAAAAAAAF4zTtEAAAAAAAAAAQAAAAAAAAABAAAAABhkaLZ/GHrh4vaarKkeK7PX2c581NvMfPvtTyATuVziAAAAAAAAAAAO5rKAAAAAAAAAAAGXebqxAAAAQFaUIoWWXLurZRFty6iBHmm65K2w5EZjldQcMsB/KeQl1Rh0UkZ7Q44JCDCvntnIhWfkl1Qipr6jZk/I4c+pjw8=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAatBawAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACTq6XjAFQS7YAAAAEAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAatBawAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACTq6XjAFQS7YAAAAFAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBq0FnAAAAAAAAAAAYZGi2fxh64eL2mqypHiuz19nOfNTbzHz77U8gE7lc4gAAAAAIWDnUAatBDAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBq0FrAAAAAAAAAAAYZGi2fxh64eL2mqypHiuz19nOfNTbzHz77U8gE7lc4gAAAAAXPuxUAatBDAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBq0FrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJOrpeMAVBLtgAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBq0FrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAI/x+UMAVBLtgAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBq0FnAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJOrpfwAVBLtgAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBq0FrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAJOrpeMAVBLtgAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - VpQihZZcu6tlEW3LqIEeabrkrbDkRmOV1BwywH8p5CXVGHRSRntDjgkIMK+e2ciFZ+SXVCKmvqNmT8jhz6mPDw==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1580420817'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/2b8a77c7e42997280b8454e39bd7c681c58ab5b7cc288ff836c1c4b6152dccfe
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/28210091
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/2b8a77c7e42997280b8454e39bd7c681c58ab5b7cc288ff836c1c4b6152dccfe/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/2b8a77c7e42997280b8454e39bd7c681c58ab5b7cc288ff836c1c4b6152dccfe/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=121161418262413312
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=121161418262413312
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/2b8a77c7e42997280b8454e39bd7c681c58ab5b7cc288ff836c1c4b6152dccfe
+              id: 2b8a77c7e42997280b8454e39bd7c681c58ab5b7cc288ff836c1c4b6152dccfe
+              paging_token: '121161418262413312'
+              successful: true
+              hash: 2b8a77c7e42997280b8454e39bd7c681c58ab5b7cc288ff836c1c4b6152dccfe
+              ledger: 28210091
+              created_at: '2020-02-13T18:54:50Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911494'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAAGAAAAAQAAAAAAAAAAAAAAAF5Fm9EAAAAAAAAAAQAAAAAAAAAAAAAAADKjrtXFaprjtdoV8mYex4557fEGVYkp83K0vfUwEyVnAAAAAAvrwgAAAAAAAAAAAZd5urEAAABAKCO0IAmQ8hUJVMMfIxu1Q/DgZebmn09dROCFCKSEUZGYuzqlfJPYMrcOJRtf41wwMFK8Wj1g70EAw+ZDhKhJDA==
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAa5zqwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACP8fkqAFQS7YAAAAFAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAa5zqwAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACP8fkqAFQS7YAAAAGAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMBrnOrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAI/x+SoAVBLtgAAAAYAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBrnOrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIz3CKoAVBLtgAAAAYAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABrnOrAAAAAAAAAAAyo67VxWqa47XaFfJmHseOee3xBlWJKfNytL31MBMlZwAAAAAL68IAAa5zqwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBq0FrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAI/x+UMAVBLtgAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBrnOrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAI/x+SoAVBLtgAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - KCO0IAmQ8hUJVMMfIxu1Q/DgZebmn09dROCFCKSEUZGYuzqlfJPYMrcOJRtf41wwMFK8Wj1g70EAw+ZDhKhJDA==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1581620177'
+            - memo: hello world
+              memo_bytes: aGVsbG8gd29ybGQ=
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/729e441893075fe40b6a6db0acbe38dd39243417cc8717f968414934331a6260
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/28211677
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/729e441893075fe40b6a6db0acbe38dd39243417cc8717f968414934331a6260/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/729e441893075fe40b6a6db0acbe38dd39243417cc8717f968414934331a6260/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=121168230080335872
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=121168230080335872
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/729e441893075fe40b6a6db0acbe38dd39243417cc8717f968414934331a6260
+              id: 729e441893075fe40b6a6db0acbe38dd39243417cc8717f968414934331a6260
+              paging_token: '121168230080335872'
+              successful: true
+              hash: 729e441893075fe40b6a6db0acbe38dd39243417cc8717f968414934331a6260
+              ledger: 28211677
+              created_at: '2020-02-13T21:21:01Z'
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              source_account_sequence: '94658837230911495'
+              fee_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGpZ5X06Hz48sKzzVFo//X67YFenBLxaxzuJcPuXebqxAAAAZAFQS7YAAAAHAAAAAQAAAAAAAAAAAAAAAF5Fvg4AAAABAAAAC2hlbGxvIHdvcmxkAAAAAAEAAAAAAAAAAAAAAAD7exWPWaCVKiygoj7vEoUox3IdGR0BGEwgrfvu7xj49gAAAAAL68IAAAAAAAAAAAGXebqxAAAAQPNJSRhqEmEaKqtigW3PTPmm0SPF2befw+hH+j7hhDW9L7xDA6FDZlEvFESKAQxWBMQeV9r3D/7Y8tx5uW2WwQk=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAa553QAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACM9wiRAFQS7YAAAAGAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAa553QAAAAAAAAAAalnlfTofPjywrPNUWj/9frtgV6cEvFrHO4lw+5d5urEAAAACM9wiRAFQS7YAAAAHAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMBrnndAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIz3CJEAVBLtgAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBrnndAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIn8GBEAVBLtgAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAABrnndAAAAAAAAAAD7exWPWaCVKiygoj7vEoUox3IdGR0BGEwgrfvu7xj49gAAAAAL68IAAa553QAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBrnOrAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIz3CKoAVBLtgAAAAYAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBrnndAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIz3CJEAVBLtgAAAAYAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - 80lJGGoSYRoqq2KBbc9M+abRI8XZt5/D6Ef6PuGENb0vvEMDoUNmUS8URIoBDFYExB5X2vcP/tjy3Hm5bZbBCQ==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+                  max_time: '1581628942'
+            - memo: Airdrop invite✅xlmget.org
+              memo_bytes: QWlyZHJvcCBpbnZpdGXinIV4bG1nZXQub3Jn
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/849fc553ad0a55e75a27ad5a80047a45baa54c321043686cb7f55fa9ef3f7d59
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBRW5XFS5PANVBWVOHXTR6D6KZN3CEKA2JIROR5NRYQMHT5K67B3SYU7
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/28440958
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/849fc553ad0a55e75a27ad5a80047a45baa54c321043686cb7f55fa9ef3f7d59/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/849fc553ad0a55e75a27ad5a80047a45baa54c321043686cb7f55fa9ef3f7d59/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=122152984477229056
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=122152984477229056
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/849fc553ad0a55e75a27ad5a80047a45baa54c321043686cb7f55fa9ef3f7d59
+              id: 849fc553ad0a55e75a27ad5a80047a45baa54c321043686cb7f55fa9ef3f7d59
+              paging_token: '122152984477229056'
+              successful: true
+              hash: 849fc553ad0a55e75a27ad5a80047a45baa54c321043686cb7f55fa9ef3f7d59
+              ledger: 28440958
+              created_at: '2020-02-28T16:28:42Z'
+              source_account: GBRW5XFS5PANVBWVOHXTR6D6KZN3CEKA2JIROR5NRYQMHT5K67B3SYU7
+              source_account_sequence: '122138905574114388'
+              fee_account: GBRW5XFS5PANVBWVOHXTR6D6KZN3CEKA2JIROR5NRYQMHT5K67B3SYU7
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAGNu3LLrwNqG1XHvOPh+VluxEUDSURdHrY4gw8+q98O5AAAAZAGx7LAAAARUAAAAAAAAAAEAAAAbQWlyZHJvcCBpbnZpdGXinIV4bG1nZXQub3JnAAAAAAEAAAAAAAAAAQAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAAAAAAAAAGGoAAAAAAAAAABqvfDuQAAAECzK8e8L+dHqGZWsoOwNLgTnFD+Omu3DcVJ4Gwb71ZKsokaH+2hPLf65I6GgIX4pcyz1SgRNuhi0Utg4tGkfGUA
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAbH5fgAAAAAAAAAAY27csuvA2obVce84+H5WW7ERQNJRF0etjiDDz6r3w7kAAAAAGGO7UAGx7LAAAARTAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAbH5fgAAAAAAAAAAY27csuvA2obVce84+H5WW7ERQNJRF0etjiDDz6r3w7kAAAAAGGO7UAGx7LAAAARUAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBrnndAAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIn8GBEAVBLtgAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBsfl+AAAAAAAAAABqWeV9Oh8+PLCs81RaP/1+u2BXpwS8Wsc7iXD7l3m6sQAAAAIn8ebkAVBLtgAAAAcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMBsfl+AAAAAAAAAABjbtyy68DahtVx7zj4flZbsRFA0lEXR62OIMPPqvfDuQAAAAAYY7tQAbHssAAABFQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBsfl+AAAAAAAAAABjbtyy68DahtVx7zj4flZbsRFA0lEXR62OIMPPqvfDuQAAAAAYYjSwAbHssAAABFQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMBsfl8AAAAAAAAAABjbtyy68DahtVx7zj4flZbsRFA0lEXR62OIMPPqvfDuQAAAAAYY7u0AbHssAAABFMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBsfl+AAAAAAAAAABjbtyy68DahtVx7zj4flZbsRFA0lEXR62OIMPPqvfDuQAAAAAYY7tQAbHssAAABFMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - syvHvC/nR6hmVrKDsDS4E5xQ/jprtw3FSeBsG+9WSrKJGh/toTy3+uSOhoCF+KXMs9UoETboYtFLYOLRpHxlAA==
+    RetrieveAnAccountsOperations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/operations?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/operations?cursor=120194466505179137&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/accounts/GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA/operations?cursor=120192344791343105&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192344791343105
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192344791343105/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192344791343105
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192344791343105
+              id: '120192344791343105'
+              paging_token: '120192344791343105'
+              transaction_successful: true
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              type: create_account
+              type_i: 0
+              created_at: '2020-01-29T19:43:59Z'
+              transaction_hash: ef0fe04ac3c7de7228ca2598886059868ad05c224a041e8b2d9ee2a8a9dd6894
+              starting_balance: '2.0000000'
+              funder: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192370561220609
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192370561220609/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192370561220609
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192370561220609
+              id: '120192370561220609'
+              paging_token: '120192370561220609'
+              transaction_successful: true
+              source_account: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              type: payment
+              type_i: 1
+              created_at: '2020-01-29T19:44:36Z'
+              transaction_hash: c1cb850f413e4038c4120bd9badc07bb8ef85a46649a4d5c9c16e578a2d30589
+              asset_type: native
+              from: GBVFTZL5HIPT4PFQVTZVIWR77V7LWYCXU4CLYWWHHOEXB64XPG5LDMTU
+              to: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              amount: '200.0000000'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192452165550081
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/0e6bc30f2b2f50ca0ecedef5a527309c74964e7daa6018976cd2c686c5df4be3
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192452165550081/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192452165550081
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192452165550081
+              id: '120192452165550081'
+              paging_token: '120192452165550081'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: change_trust
+              type_i: 6
+              created_at: '2020-01-29T19:46:20Z'
+              transaction_hash: 0e6bc30f2b2f50ca0ecedef5a527309c74964e7daa6018976cd2c686c5df4be3
+              asset_type: credit_alphanum4
+              asset_code: USD
+              asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              limit: '922337203685.4775807'
+              trustee: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              trustor: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192477935251457
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/ec4116595bdfa8c1039c40af425e497c91fcf387c2a2a0cfa1f3bf64733f1f23
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192477935251457/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192477935251457
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192477935251457
+              id: '120192477935251457'
+              paging_token: '120192477935251457'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: change_trust
+              type_i: 6
+              created_at: '2020-01-29T19:46:55Z'
+              transaction_hash: ec4116595bdfa8c1039c40af425e497c91fcf387c2a2a0cfa1f3bf64733f1f23
+              asset_type: credit_alphanum4
+              asset_code: NGNT
+              asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              limit: '922337203685.4775807'
+              trustee: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              trustor: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192490820268033
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/81f2b857cb47d7c63ca12e2ec3466f6f17b4990bf492ef752c9c6d2035ca11ff
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192490820268033/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192490820268033
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192490820268033
+              id: '120192490820268033'
+              paging_token: '120192490820268033'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: change_trust
+              type_i: 6
+              created_at: '2020-01-29T19:47:11Z'
+              transaction_hash: 81f2b857cb47d7c63ca12e2ec3466f6f17b4990bf492ef752c9c6d2035ca11ff
+              asset_type: credit_alphanum4
+              asset_code: EURT
+              asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              limit: '922337203685.4775807'
+              trustee: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              trustor: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192499410071553
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/34b28df891c6a09968a2f0a6b410300b08b09c5f58cd12fe64fda59d29688f6e
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192499410071553/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192499410071553
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192499410071553
+              id: '120192499410071553'
+              paging_token: '120192499410071553'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: change_trust
+              type_i: 6
+              created_at: '2020-01-29T19:47:22Z'
+              transaction_hash: 34b28df891c6a09968a2f0a6b410300b08b09c5f58cd12fe64fda59d29688f6e
+              asset_type: credit_alphanum4
+              asset_code: BB1
+              asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              limit: '922337203685.4775807'
+              trustee: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              trustor: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192508000047105
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/12a8e8f11a697ee06a092eb0700c2b713fe07d29ffab190988d5bb248caf1917
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192508000047105/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192508000047105
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192508000047105
+              id: '120192508000047105'
+              paging_token: '120192508000047105'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: change_trust
+              type_i: 6
+              created_at: '2020-01-29T19:47:33Z'
+              transaction_hash: 12a8e8f11a697ee06a092eb0700c2b713fe07d29ffab190988d5bb248caf1917
+              asset_type: credit_alphanum4
+              asset_code: CNY
+              asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              limit: '922337203685.4775807'
+              trustee: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              trustor: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192542359883777
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/36b9c9aa3c4a22a1e8274f69b1bbfdd5764e55b80804a8d9c6b35c14e4147580
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192542359883777/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192542359883777
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192542359883777
+              id: '120192542359883777'
+              paging_token: '120192542359883777'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: manage_buy_offer
+              type_i: 12
+              created_at: '2020-01-29T19:48:16Z'
+              transaction_hash: 36b9c9aa3c4a22a1e8274f69b1bbfdd5764e55b80804a8d9c6b35c14e4147580
+              amount: '3.0000000'
+              price: '18.1088911'
+              price_r:
+                'n': 181088911
+                d: 10000000
+              buying_asset_type: credit_alphanum4
+              buying_asset_code: EURT
+              buying_asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              selling_asset_type: native
+              offer_id: '0'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120192568129794049
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/f0362887d2b9b853e7b464b174adfceb4c73ffb6a45e10b7cb3bff9cfa808340
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120192568129794049/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120192568129794049
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120192568129794049
+              id: '120192568129794049'
+              paging_token: '120192568129794049'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: manage_buy_offer
+              type_i: 12
+              created_at: '2020-01-29T19:48:54Z'
+              transaction_hash: f0362887d2b9b853e7b464b174adfceb4c73ffb6a45e10b7cb3bff9cfa808340
+              amount: '200.0000000'
+              price: '0.0459893'
+              price_r:
+                'n': 459893
+                d: 10000000
+              buying_asset_type: credit_alphanum4
+              buying_asset_code: NGNT
+              buying_asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              selling_asset_type: native
+              offer_id: '0'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120194466505179137
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/a470f40ba0c1fd17cb957e0b438bd873b110ffb808b8133a5144cea3f5a66d0d
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120194466505179137/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120194466505179137
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120194466505179137
+              id: '120194466505179137'
+              paging_token: '120194466505179137'
+              transaction_successful: true
+              source_account: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+              type: change_trust
+              type_i: 6
+              created_at: '2020-01-29T20:31:28Z'
+              transaction_hash: a470f40ba0c1fd17cb957e0b438bd873b110ffb808b8133a5144cea3f5a66d0d
+              asset_type: credit_alphanum4
+              asset_code: CNY
+              asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              limit: '0.0000000'
+              trustee: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              trustor: GAYOLLLUIZE4DZMBB2ZBKGBUBZLIOYU6XFLW37GBP2VZD3ABNXCW4BVA
+    RetrieveAnAccountsPayments:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE/payments?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE/payments?cursor=148289273518190684&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE/payments?cursor=110694007436259329&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259329
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259329/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=110694007436259329
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=110694007436259329
+              id: '110694007436259329'
+              paging_token: '110694007436259329'
+              transaction_successful: true
+              source_account: GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI
+              type: create_account
+              type_i: 0
+              created_at: '2019-09-11T13:16:44Z'
+              transaction_hash: 26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7
+              starting_balance: '1.0000000'
+              funder: GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259330
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259330/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=110694007436259330
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=110694007436259330
+              id: '110694007436259330'
+              paging_token: '110694007436259330'
+              transaction_successful: true
+              source_account: GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI
+              type: account_merge
+              type_i: 8
+              created_at: '2019-09-11T13:16:44Z'
+              transaction_hash: 26c996aa6afb299b6761f2335277196715160ade6aa001a755116448b145d3a7
+              account: GB44UMO65PK5NWMRP4S2OSZA5BD4ACOW5KQ6TWLLO2MP7S7N5MJ2MJVI
+              into: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/115354197276323841
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/c09d4cee993d60d73c80f036666966738a26b8f3b25d7275b93fd995505b5e5b
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/115354197276323841/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=115354197276323841
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=115354197276323841
+              id: '115354197276323841'
+              paging_token: '115354197276323841'
+              transaction_successful: true
+              source_account: GDV4KECLSZLKRVH4ZTWVAS4I3W2LPAPV66ADFFUZKGIVOTK6GMKGJT53
+              type: payment
+              type_i: 1
+              created_at: '2019-11-18T19:59:40Z'
+              transaction_hash: c09d4cee993d60d73c80f036666966738a26b8f3b25d7275b93fd995505b5e5b
+              asset_type: native
+              from: GDV4KECLSZLKRVH4ZTWVAS4I3W2LPAPV66ADFFUZKGIVOTK6GMKGJT53
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '688.4065454'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/117356420835532801
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/c25dd84798076ee8ea126c78407d61c7e8f3efdf8739274f56b07a7029500b00
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/117356420835532801/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=117356420835532801
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=117356420835532801
+              id: '117356420835532801'
+              paging_token: '117356420835532801'
+              transaction_successful: true
+              source_account: GDV4KECLSZLKRVH4ZTWVAS4I3W2LPAPV66ADFFUZKGIVOTK6GMKGJT53
+              type: payment
+              type_i: 1
+              created_at: '2019-12-18T08:23:35Z'
+              transaction_hash: c25dd84798076ee8ea126c78407d61c7e8f3efdf8739274f56b07a7029500b00
+              asset_type: native
+              from: GDV4KECLSZLKRVH4ZTWVAS4I3W2LPAPV66ADFFUZKGIVOTK6GMKGJT53
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '355.3887598'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/119400713599217665
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/b9d7c534b5fa168570a5bffe0f2089de150d00bf8cbd19ec93e897c565958f3f
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/119400713599217665/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=119400713599217665
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=119400713599217665
+              id: '119400713599217665'
+              paging_token: '119400713599217665'
+              transaction_successful: true
+              source_account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: payment
+              type_i: 1
+              created_at: '2020-01-17T20:32:38Z'
+              transaction_hash: b9d7c534b5fa168570a5bffe0f2089de150d00bf8cbd19ec93e897c565958f3f
+              asset_type: credit_alphanum4
+              asset_code: USD
+              asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              from: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              to: GASWJWFRYE55KC7MGANZMMRBK5NPXT3HMPDQ6SEXZN6ZPWYXVVYBFRTE
+              amount: '84.9410878'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/147350483860869151
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/b53cd1d3a95ad2fd7141b3b800e8cd3af1658d2d72b2274d1bd116cf0e58f193
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/147350483860869151/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=147350483860869151
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=147350483860869151
+              id: '147350483860869151'
+              paging_token: '147350483860869151'
+              transaction_successful: true
+              source_account: GBDSJHAGNQDL2WZ5LBRSIVI6MUHJO6CLKF5XFVUK7GMPUQ4NBLSYVAHX
+              type: payment
+              type_i: 1
+              created_at: '2021-03-06T19:27:33Z'
+              transaction_hash: b53cd1d3a95ad2fd7141b3b800e8cd3af1658d2d72b2274d1bd116cf0e58f193
+              asset_type: native
+              from: GBDSJHAGNQDL2WZ5LBRSIVI6MUHJO6CLKF5XFVUK7GMPUQ4NBLSYVAHX
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '0.0000001'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/147354181828010015
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/1be9f5f3dcd28c4fa70f5f5ed79d7332da14741e55a5abe4132d4c04da7b6f1e
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/147354181828010015/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=147354181828010015
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=147354181828010015
+              id: '147354181828010015'
+              paging_token: '147354181828010015'
+              transaction_successful: true
+              source_account: GCVZ5PHDFGUV6YXN7I735RE5AJSFOOWPT4A2WHCGTGXOQ6KVWM3TYEQC
+              type: payment
+              type_i: 1
+              created_at: '2021-03-06T20:49:34Z'
+              transaction_hash: 1be9f5f3dcd28c4fa70f5f5ed79d7332da14741e55a5abe4132d4c04da7b6f1e
+              asset_type: native
+              from: GCVZ5PHDFGUV6YXN7I735RE5AJSFOOWPT4A2WHCGTGXOQ6KVWM3TYEQC
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '0.0000001'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/147355590577238047
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/ba6bca6dce0c01d9d9cebcc79466c986b18a8cb3b67030f6424b6563778ab947
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/147355590577238047/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=147355590577238047
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=147355590577238047
+              id: '147355590577238047'
+              paging_token: '147355590577238047'
+              transaction_successful: true
+              source_account: GBDSJHAGNQDL2WZ5LBRSIVI6MUHJO6CLKF5XFVUK7GMPUQ4NBLSYVAHX
+              type: payment
+              type_i: 1
+              created_at: '2021-03-06T21:19:49Z'
+              transaction_hash: ba6bca6dce0c01d9d9cebcc79466c986b18a8cb3b67030f6424b6563778ab947
+              asset_type: native
+              from: GBDSJHAGNQDL2WZ5LBRSIVI6MUHJO6CLKF5XFVUK7GMPUQ4NBLSYVAHX
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '0.0000001'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/148286782436462682
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/74afe177a6ecf466899bbdbd339a796e1995a3c8c4084c556849a702759bb7c1
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/148286782436462682/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=148286782436462682
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=148286782436462682
+              id: '148286782436462682'
+              paging_token: '148286782436462682'
+              transaction_successful: true
+              source_account: GDAXCWDQAYP2VC2UR2KRLVD7JQYIYMQ7BGFY647BCG4CFANT7JYNSO4S
+              type: payment
+              type_i: 1
+              created_at: '2021-03-20T12:48:24Z'
+              transaction_hash: 74afe177a6ecf466899bbdbd339a796e1995a3c8c4084c556849a702759bb7c1
+              asset_type: native
+              from: GDAXCWDQAYP2VC2UR2KRLVD7JQYIYMQ7BGFY647BCG4CFANT7JYNSO4S
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '0.0000001'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/148289273518190684
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/de50646ece611a9fbd2b222b910f020f94e654064d64fd54f50358d3d13e7f49
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/148289273518190684/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=148289273518190684
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=148289273518190684
+              id: '148289273518190684'
+              paging_token: '148289273518190684'
+              transaction_successful: true
+              source_account: GC2LS7Z564TGWRVCIHTSEIZBO5WUZSNR2MA544FE4JPXMAUMDQI2JR6N
+              type: payment
+              type_i: 1
+              created_at: '2021-03-20T13:42:07Z'
+              transaction_hash: de50646ece611a9fbd2b222b910f020f94e654064d64fd54f50358d3d13e7f49
+              asset_type: native
+              from: GC2LS7Z564TGWRVCIHTSEIZBO5WUZSNR2MA544FE4JPXMAUMDQI2JR6N
+              to: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              amount: '0.0000001'
+    RetrieveAnAccountsEffects:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE/effects?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE/effects?cursor=147350483860869151-1&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/accounts/GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE/effects?cursor=110694007436259329-1&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259329
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=110694007436259329-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=110694007436259329-1
+              id: 0110694007436259329-0000000001
+              paging_token: 110694007436259329-1
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: account_created
+              type_i: 0
+              created_at: '2019-09-11T13:16:44Z'
+              starting_balance: '1.0000000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259329
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=110694007436259329-3
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=110694007436259329-3
+              id: 0110694007436259329-0000000003
+              paging_token: 110694007436259329-3
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: signer_created
+              type_i: 10
+              created_at: '2019-09-11T13:16:44Z'
+              weight: 1
+              public_key: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              key: ''
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/110694007436259330
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=110694007436259330-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=110694007436259330-2
+              id: 0110694007436259330-0000000002
+              paging_token: 110694007436259330-2
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: account_credited
+              type_i: 2
+              created_at: '2019-09-11T13:16:44Z'
+              asset_type: native
+              amount: '355.2904739'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/115354197276323841
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=115354197276323841-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=115354197276323841-1
+              id: 0115354197276323841-0000000001
+              paging_token: 115354197276323841-1
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: account_credited
+              type_i: 2
+              created_at: '2019-11-18T19:59:40Z'
+              asset_type: native
+              amount: '688.4065454'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/117356420835532801
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=117356420835532801-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=117356420835532801-1
+              id: 0117356420835532801-0000000001
+              paging_token: 117356420835532801-1
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: account_credited
+              type_i: 2
+              created_at: '2019-12-18T08:23:35Z'
+              asset_type: native
+              amount: '355.3887598'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/119399833130811393
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=119399833130811393-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=119399833130811393-1
+              id: 0119399833130811393-0000000001
+              paging_token: 119399833130811393-1
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: trustline_created
+              type_i: 20
+              created_at: '2020-01-17T20:13:22Z'
+              asset_type: credit_alphanum4
+              asset_code: USD
+              asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              limit: '922337203685.4775000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/119399833130811394
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=119399833130811394-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=119399833130811394-1
+              id: 0119399833130811394-0000000001
+              paging_token: 119399833130811394-1
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: trade
+              type_i: 33
+              created_at: '2020-01-17T20:13:22Z'
+              seller: GCM4PT6XDZBWOOENDS6FOU22GJQLJPV2GC7VRVII4TFGZBA3ZXNM55SV
+              offer_id: '147625249'
+              sold_amount: '539.0320108'
+              sold_asset_type: native
+              bought_amount: '32.8490620'
+              bought_asset_type: credit_alphanum4
+              bought_asset_code: USD
+              bought_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/119399833130811394
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=119399833130811394-3
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=119399833130811394-3
+              id: 0119399833130811394-0000000003
+              paging_token: 119399833130811394-3
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: trade
+              type_i: 33
+              created_at: '2020-01-17T20:13:22Z'
+              seller: GBDVKE33GVVMBXX73OHIBRP6RAHKHHW2P4PQVV6UNOKQCOXU7GNUM4QI
+              offer_id: '147618811'
+              sold_amount: '854.9537682'
+              sold_asset_type: native
+              bought_amount: '52.0920258'
+              bought_asset_type: credit_alphanum4
+              bought_asset_code: USD
+              bought_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/119400713599217665
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=119400713599217665-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=119400713599217665-2
+              id: 0119400713599217665-0000000002
+              paging_token: 119400713599217665-2
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: account_debited
+              type_i: 3
+              created_at: '2020-01-17T20:32:38Z'
+              asset_type: credit_alphanum4
+              asset_code: USD
+              asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              amount: '84.9410878'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/147350483860869151
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=147350483860869151-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=147350483860869151-1
+              id: 0147350483860869151-0000000001
+              paging_token: 147350483860869151-1
+              account: GCNL55IJTH2HX26HLNIGYD2JIQLTBAQL3SVPNZA6PXK7NAVHU423WOTE
+              type: account_credited
+              type_i: 2
+              created_at: '2021-03-06T19:27:33Z'
+              asset_type: native
+              amount: '0.0000001'
+    RetrieveAnAccountsOffers:
+      value:
+        _links:
+          self:
+            href: "https://\thorizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K/offers?cursor=&limit=10&order=asc"
+          next:
+            href: "https://\thorizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K/offers?cursor=164943216&limit=10&order=asc"
+          prev:
+            href: "https://\thorizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K/offers?cursor=164555927&limit=10&order=desc"
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: "https://\thorizon-testnet.stellar.org/offers/164555927"
+                offer_maker:
+                  href: "https://\thorizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K"
+              id: 164555927
+              paging_token: '164555927'
+              seller: GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+              selling:
+                asset_type: native
+              buying:
+                asset_type: credit_alphanum4
+                asset_code: BB1
+                asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              amount: '214.9999939'
+              price_r:
+                'n': 10000000
+                d: 86000001
+              price: '0.1162791'
+              last_modified_ledger: 28383147
+              last_modified_time: '2020-02-24T22:58:38Z'
+            - _links:
+                self:
+                  href: "https://\thorizon-testnet.stellar.org/offers/164943216"
+                offer_maker:
+                  href: "https://\thorizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K"
+              id: 164943216
+              paging_token: '164943216'
+              seller: GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+              selling:
+                asset_type: credit_alphanum4
+                asset_code: BB1
+                asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              buying:
+                asset_type: native
+              amount: '24.9999990'
+              price_r:
+                'n': 32224991
+                d: 2500000
+              price: '12.8899964'
+              last_modified_ledger: 28394149
+              last_modified_time: '2020-02-25T15:49:57Z'
+    RetrieveAnAccountsTrades:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K/trades?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K/trades?cursor=107449584845914113-0&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K/trades?cursor=107449468881756161-0&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GCO7OW5P2PP7WDN6YUDXUUOPAR4ZHJSDDCZTIAQRTRZHKQWV45WUPBWX
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/107449468881756161
+              id: 107449468881756161-0
+              paging_token: 107449468881756161-0
+              ledger_close_time: '2019-07-26T09:17:02Z'
+              trade_type: orderbook
+              base_offer_id: '104078276'
+              base_account: GCO7OW5P2PP7WDN6YUDXUUOPAR4ZHJSDDCZTIAQRTRZHKQWV45WUPBWX
+              base_amount: '4433.2000000'
+              base_asset_type: native
+              counter_offer_id: '4719135487309144065'
+              counter_account: GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+              counter_amount: '443.3200000'
+              counter_asset_type: credit_alphanum4
+              counter_asset_code: BB1
+              counter_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              base_is_seller: true
+              price:
+                'n': '1'
+                d: '10'
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GCQDOTIILRG634IRWAODTUS6H6Q7VUUNKZINBDJOXGJFR7YZ57FGYV7B
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/107449486061649921
+              id: 107449486061649921-0
+              paging_token: 107449486061649921-0
+              ledger_close_time: '2019-07-26T09:17:25Z'
+              trade_type: orderbook
+              base_offer_id: '104273938'
+              base_account: GCQDOTIILRG634IRWAODTUS6H6Q7VUUNKZINBDJOXGJFR7YZ57FGYV7B
+              base_amount: '10.0000000'
+              base_asset_type: native
+              counter_offer_id: '4719135504489037825'
+              counter_account: GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+              counter_amount: '1.0000000'
+              counter_asset_type: credit_alphanum4
+              counter_asset_code: BB1
+              counter_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              base_is_seller: true
+              price:
+                'n': '1'
+                d: '10'
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GAMU5TQFUMDGVKYQPPDCD2MKKUUWELSQAEKNNU4RFQCWFSRBPJA2MAGQ
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/107449584845914113
+              id: 107449584845914113-0
+              paging_token: 107449584845914113-0
+              ledger_close_time: '2019-07-26T09:19:30Z'
+              trade_type: orderbook
+              base_offer_id: '104299223'
+              base_account: GAMU5TQFUMDGVKYQPPDCD2MKKUUWELSQAEKNNU4RFQCWFSRBPJA2MAGQ
+              base_amount: '748.5338945'
+              base_asset_type: native
+              counter_offer_id: '104299548'
+              counter_account: GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+              counter_amount: '74.8533887'
+              counter_asset_type: credit_alphanum4
+              counter_asset_code: BB1
+              counter_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              base_is_seller: true
+              price:
+                'n': '10000000'
+                d: '100000001'
+    RetrieveAnAccountsData:
+      value:
+        value: MQ==
+    ListAllAssets:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/assets?asset_code=CNY&cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/assets?asset_code=CNY&cursor=CNY_GABGBJYLIC2OGATH3DVW22UEB66TFMWC3VKTAPFIOINVESRZLFKIHA4I_credit_alphanum4&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/assets?asset_code=CNY&cursor=CNY_GA6VXTS64XUOCQZSBAYHD24ZYJYPNB3KJ2CVKSYIE43P2DQQIX74UT2A_credit_alphanum4&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                toml:
+                  href: https://swisscustodys.org/.well-known/stellar.toml
+              asset_type: credit_alphanum4
+              asset_code: CNY
+              asset_issuer: GA6VXTS64XUOCQZSBAYHD24ZYJYPNB3KJ2CVKSYIE43P2DQQIX74UT2A
+              paging_token: CNY_GA6VXTS64XUOCQZSBAYHD24ZYJYPNB3KJ2CVKSYIE43P2DQQIX74UT2A_credit_alphanum4
+              num_claimable_balances: 0
+              num_contracts: 0
+              num_liquidity_pools: 0
+              accounts:
+                authorized: 10
+                authorized_to_maintain_liabilities: 0
+                unauthorized: 0
+              claimable_balances_amount: '0.0000000'
+              contracts_amount: '0.0000000'
+              liquidity_pools_amount: '0.0000000'
+              balances:
+                authorized: '899996000000.0000000'
+                authorized_to_maintain_liabilities: '0.0000000'
+                unauthorized: '0.0000000'
+              flags:
+                auth_required: false
+                auth_revocable: false
+                auth_immutable: false
+                auth_clawback_enabled: false
+            - _links:
+                toml:
+                  href: https://StellarAssets.org/fx/.well-known/stellar.toml
+              asset_type: credit_alphanum4
+              asset_code: CNY
+              asset_issuer: GAASPHILC6DCBPP2P4T66QNSYF6C6OGN6DK36NY4G5SBR7AWH75TJG7N
+              paging_token: CNY_GAASPHILC6DCBPP2P4T66QNSYF6C6OGN6DK36NY4G5SBR7AWH75TJG7N_credit_alphanum4
+              num_claimable_balances: 0
+              num_contracts: 0
+              num_liquidity_pools: 0
+              accounts:
+                authorized: 43
+                authorized_to_maintain_liabilities: 0
+                unauthorized: 0
+              claimable_balances_amount: '0.0000000'
+              contracts_amount: '0.0000000'
+              liquidity_pools_amount: '0.0000000'
+              balances:
+                authorized: '1.0000000'
+                authorized_to_maintain_liabilities: '0.0000000'
+                unauthorized: '0.0000000'
+              flags:
+                auth_required: false
+                auth_revocable: true
+                auth_immutable: false
+                auth_clawback_enabled: true
+            - _links:
+                toml:
+                  href: https://masterstellar.com/.well-known/stellar.toml
+              asset_type: credit_alphanum4
+              asset_code: CNY
+              asset_issuer: GABGBJYLIC2OGATH3DVW22UEB66TFMWC3VKTAPFIOINVESRZLFKIHA4I
+              paging_token: CNY_GABGBJYLIC2OGATH3DVW22UEB66TFMWC3VKTAPFIOINVESRZLFKIHA4I_credit_alphanum4
+              num_claimable_balances: 0
+              num_contracts: 0
+              num_liquidity_pools: 0
+              accounts:
+                authorized: 1
+                authorized_to_maintain_liabilities: 0
+                unauthorized: 0
+              claimable_balances_amount: '0.0000000'
+              contracts_amount: '0.0000000'
+              liquidity_pools_amount: '0.0000000'
+              balances:
+                authorized: '65000000000.0000000'
+                authorized_to_maintain_liabilities: '0.0000000'
+                unauthorized: '0.0000000'
+              flags:
+                auth_required: false
+                auth_revocable: false
+                auth_immutable: false
+                auth_clawback_enabled: false
+    ListAllClaimableBalances:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/claimable_balances?asset=native&cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/claimable_balances?asset=native&cursor=35938300-0000000017b9a95e25aa60200b52cc04f75c496dca76dc19fec21c942dfb35cce23c3eba&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/claimable_balances?asset=native&cursor=33324106-00000000691787983bc3ea12361092fe49ae83cbbe37804ee1590fe2b9b3e3860fc8261f&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000691787983bc3ea12361092fe49ae83cbbe37804ee1590fe2b9b3e3860fc8261f
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000691787983bc3ea12361092fe49ae83cbbe37804ee1590fe2b9b3e3860fc8261f/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000691787983bc3ea12361092fe49ae83cbbe37804ee1590fe2b9b3e3860fc8261f/operations{?cursor,limit,order}
+                  templated: true
+              id: 00000000691787983bc3ea12361092fe49ae83cbbe37804ee1590fe2b9b3e3860fc8261f
+              asset: native
+              amount: '0.1000000'
+              sponsor: GDOZMXWISPB57FITUQIGTFH2KNNW7QTFESXF5DZEAMZK6QHE3KVO5TRT
+              last_modified_ledger: 33324106
+              last_modified_time: '2020-12-30T23:02:56Z'
+              claimants:
+                - destination: GCD3T6UIQLYZPGRCYVSE7LKQB5HYYNVT7ENY6RCSFRFQYR5JTBDCECO3
+                  predicate:
+                    and:
+                      - abs_before: '2020-12-30T23:03:56Z'
+                        abs_before_epoch: '1609369436'
+                      - not:
+                          abs_before: '2020-12-30T23:05:56Z'
+                          abs_before_epoch: '1609369556'
+              flags:
+                clawback_enabled: false
+              paging_token: 33324106-00000000691787983bc3ea12361092fe49ae83cbbe37804ee1590fe2b9b3e3860fc8261f
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/000000003a9a08342ca45d96abc011278644d83d1718ab16e44209fa1952829b66017c28
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/000000003a9a08342ca45d96abc011278644d83d1718ab16e44209fa1952829b66017c28/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/000000003a9a08342ca45d96abc011278644d83d1718ab16e44209fa1952829b66017c28/operations{?cursor,limit,order}
+                  templated: true
+              id: 000000003a9a08342ca45d96abc011278644d83d1718ab16e44209fa1952829b66017c28
+              asset: native
+              amount: '1.0000000'
+              sponsor: GA5ACYSBFH5AFWMZ5T34FLT5W3X6Z4FT4PMN3NUDT3G2JCYJXYGD72EF
+              last_modified_ledger: 33505955
+              last_modified_time: '2021-01-12T21:02:00Z'
+              claimants:
+                - destination: GCXAULI3NAFEUKIXUQTD3HXGCTTLM6KVGKTUBZIHVUDP6WXEF7RWJV67
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 33505955-000000003a9a08342ca45d96abc011278644d83d1718ab16e44209fa1952829b66017c28
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/0000000063036dcfa438cb51180bea16e36850e3699efc934577b07322c818157e4d5411
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/0000000063036dcfa438cb51180bea16e36850e3699efc934577b07322c818157e4d5411/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/0000000063036dcfa438cb51180bea16e36850e3699efc934577b07322c818157e4d5411/operations{?cursor,limit,order}
+                  templated: true
+              id: 0000000063036dcfa438cb51180bea16e36850e3699efc934577b07322c818157e4d5411
+              asset: native
+              amount: '0.0010000'
+              sponsor: GBIIQM26JJS774T7CSP3WBFVUXHUCTZCV5ZPGMKL57POWMFPMLYOKOZQ
+              last_modified_ledger: 34254613
+              last_modified_time: '2021-03-03T10:36:28Z'
+              claimants:
+                - destination: GBIIQM26JJS774T7CSP3WBFVUXHUCTZCV5ZPGMKL57POWMFPMLYOKOZQ
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 34254613-0000000063036dcfa438cb51180bea16e36850e3699efc934577b07322c818157e4d5411
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000d076fe2df3e6cc5e5c28e7bf257c11eb209d703a681c58bb867b78b67235c694
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000d076fe2df3e6cc5e5c28e7bf257c11eb209d703a681c58bb867b78b67235c694/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000d076fe2df3e6cc5e5c28e7bf257c11eb209d703a681c58bb867b78b67235c694/operations{?cursor,limit,order}
+                  templated: true
+              id: 00000000d076fe2df3e6cc5e5c28e7bf257c11eb209d703a681c58bb867b78b67235c694
+              asset: native
+              amount: '0.0010000'
+              sponsor: GANVXZ2DQ2FFLVCBSVMBBNVWSXS6YVEDP247EN4C3CM3I32XR4U3OU2I
+              last_modified_ledger: 34255259
+              last_modified_time: '2021-03-03T11:35:31Z'
+              claimants:
+                - destination: GANVXZ2DQ2FFLVCBSVMBBNVWSXS6YVEDP247EN4C3CM3I32XR4U3OU2I
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 34255259-00000000d076fe2df3e6cc5e5c28e7bf257c11eb209d703a681c58bb867b78b67235c694
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000da8ed8d0dccacce237c5395eb07bb845d2bb96425d18d168d535063316d99e7f
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000da8ed8d0dccacce237c5395eb07bb845d2bb96425d18d168d535063316d99e7f/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000da8ed8d0dccacce237c5395eb07bb845d2bb96425d18d168d535063316d99e7f/operations{?cursor,limit,order}
+                  templated: true
+              id: 00000000da8ed8d0dccacce237c5395eb07bb845d2bb96425d18d168d535063316d99e7f
+              asset: native
+              amount: '1.0000000'
+              sponsor: GB7OYQFQI7GH622CKCFWPH4WSZUGOXXNY2XWV5K27S3SW2JHOWCCWEJ4
+              last_modified_ledger: 35023766
+              last_modified_time: '2021-04-20T19:00:04Z'
+              claimants:
+                - destination: GAV2USD4ELGLRWBT67V7N37QAJKOPLHUJL3AVFW5NHWDHVXL4EQPSWZ5
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 35023766-00000000da8ed8d0dccacce237c5395eb07bb845d2bb96425d18d168d535063316d99e7f
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000c551a949d0fb5199b05cb8220b4ba7dad4cd7968c849ab0fb51f744daab864fe
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000c551a949d0fb5199b05cb8220b4ba7dad4cd7968c849ab0fb51f744daab864fe/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000c551a949d0fb5199b05cb8220b4ba7dad4cd7968c849ab0fb51f744daab864fe/operations{?cursor,limit,order}
+                  templated: true
+              id: 00000000c551a949d0fb5199b05cb8220b4ba7dad4cd7968c849ab0fb51f744daab864fe
+              asset: native
+              amount: '0.2091529'
+              sponsor: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+              last_modified_ledger: 35530330
+              last_modified_time: '2021-05-22T17:04:31Z'
+              claimants:
+                - destination: GCSZDAUKEX3IZXXUEEMERIYTVKHDTVTWK7LHXHELZE5B472QMGGXQLHD
+                  predicate:
+                    unconditional: true
+                - destination: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 35530330-00000000c551a949d0fb5199b05cb8220b4ba7dad4cd7968c849ab0fb51f744daab864fe
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000d1f2ad9c1ff9124de62f9721ed5811f1f0d7705660c5a7daaa174ad5100c6b4d
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000d1f2ad9c1ff9124de62f9721ed5811f1f0d7705660c5a7daaa174ad5100c6b4d/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000d1f2ad9c1ff9124de62f9721ed5811f1f0d7705660c5a7daaa174ad5100c6b4d/operations{?cursor,limit,order}
+                  templated: true
+              id: 00000000d1f2ad9c1ff9124de62f9721ed5811f1f0d7705660c5a7daaa174ad5100c6b4d
+              asset: native
+              amount: '0.2091529'
+              sponsor: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+              last_modified_ledger: 35530330
+              last_modified_time: '2021-05-22T17:04:31Z'
+              claimants:
+                - destination: GBO4FL74OZTOCTABWFS2PH4LGI2CHFABDZ2LBPRH6UECXBAIU5LUIOF2
+                  predicate:
+                    unconditional: true
+                - destination: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 35530330-00000000d1f2ad9c1ff9124de62f9721ed5811f1f0d7705660c5a7daaa174ad5100c6b4d
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/000000001b53636a29ca25d28d1c5bb165f55280167d53cfefb0ce297d98032b32f772d0
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/000000001b53636a29ca25d28d1c5bb165f55280167d53cfefb0ce297d98032b32f772d0/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/000000001b53636a29ca25d28d1c5bb165f55280167d53cfefb0ce297d98032b32f772d0/operations{?cursor,limit,order}
+                  templated: true
+              id: 000000001b53636a29ca25d28d1c5bb165f55280167d53cfefb0ce297d98032b32f772d0
+              asset: native
+              amount: '4.2696061'
+              sponsor: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+              last_modified_ledger: 35686528
+              last_modified_time: '2021-06-01T13:29:59Z'
+              claimants:
+                - destination: GD54EZPKQCBZKPI6F4KKYYLGLDWBOVKPXBL3BLFGYNCLTBFGFZZGVMRT
+                  predicate:
+                    unconditional: true
+                - destination: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 35686528-000000001b53636a29ca25d28d1c5bb165f55280167d53cfefb0ce297d98032b32f772d0
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000ff1bb4a01b1d4e62ba23bcfd4e2c2289c63fe5ae0368f85b79d74a2224f8ab6c
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000ff1bb4a01b1d4e62ba23bcfd4e2c2289c63fe5ae0368f85b79d74a2224f8ab6c/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/00000000ff1bb4a01b1d4e62ba23bcfd4e2c2289c63fe5ae0368f85b79d74a2224f8ab6c/operations{?cursor,limit,order}
+                  templated: true
+              id: 00000000ff1bb4a01b1d4e62ba23bcfd4e2c2289c63fe5ae0368f85b79d74a2224f8ab6c
+              asset: native
+              amount: '29.8872425'
+              sponsor: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+              last_modified_ledger: 35686528
+              last_modified_time: '2021-06-01T13:29:59Z'
+              claimants:
+                - destination: GB2QQWOA32GRILAOZ57H5Z5MO52KNUO3WHJWVZZHWSN66LLDPXQMSILD
+                  predicate:
+                    unconditional: true
+                - destination: GA5WWLUYCR4XJKS4ZYKWATKC7E3AVM3FZLWXWSKOBZWAGDROF5MUQXAT
+                  predicate:
+                    unconditional: true
+              flags:
+                clawback_enabled: false
+              paging_token: 35686528-00000000ff1bb4a01b1d4e62ba23bcfd4e2c2289c63fe5ae0368f85b79d74a2224f8ab6c
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/0000000017b9a95e25aa60200b52cc04f75c496dca76dc19fec21c942dfb35cce23c3eba
+                transactions:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/0000000017b9a95e25aa60200b52cc04f75c496dca76dc19fec21c942dfb35cce23c3eba/transactions{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: https://horizon-testnet.stellar.org/claimable_balances/0000000017b9a95e25aa60200b52cc04f75c496dca76dc19fec21c942dfb35cce23c3eba/operations{?cursor,limit,order}
+                  templated: true
+              id: 0000000017b9a95e25aa60200b52cc04f75c496dca76dc19fec21c942dfb35cce23c3eba
+              asset: native
+              amount: '0.0000400'
+              sponsor: GB6DNEWWSSPQAX7SR5MCWUTRVQPJBAERJTUQAZOVXXJDU2E6PIMKGMO2
+              last_modified_ledger: 35938300
+              last_modified_time: '2021-06-17T10:37:03Z'
+              claimants:
+                - destination: GC2CMMOQ2BUFI33PPOLNJKMQYJGAXUP2KMZXEXE6TGE37JSXQPHI4UAE
+                  predicate:
+                    and:
+                      - abs_before: '2021-07-16T21:00:00Z'
+                        abs_before_epoch: '1626469200'
+                      - abs_before: '2021-08-16T21:00:00Z'
+                        abs_before_epoch: '1629147600'
+              flags:
+                clawback_enabled: false
+              paging_token: 35938300-0000000017b9a95e25aa60200b52cc04f75c496dca76dc19fec21c942dfb35cce23c3eba
+    RetrieveAClaimableBalance:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/claimable_balances/000000000102030000000000000000000000000000000000000000000000000000000000
+          operations:
+            href: https://horizon-testnet.stellar.org/claimable_balances/000000000102030000000000000000000000000000000000000000000000000000000000/operations{?cursor,limit,order}
+            templated: true
+          transactions:
+            href: https://horizon-testnet.stellar.org/claimable_balances/000000000102030000000000000000000000000000000000000000000000000000000000/transactions{?cursor,limit,order}
+            templated: true
+        id: '000000000102030000000000000000000000000000000000000000000000000000000000'
+        paging_token: '000000000102030000000000000000000000000000000000000000000000000000000000'
+        asset: native
+        amount: '10.0000000'
+        claimants:
+          - destination: GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML
+            predicate:
+              and:
+                - or:
+                    - relBefore: '12'
+                    - absBefore: '2020-08-26T11:15:39Z'
+                      absBeforeEpoch: '1598440539'
+                - not:
+                    unconditional: true
+        last_modified_ledger: 28411995
+        last_modified_time: '2020-02-26T19:29:16Z'
+    CBRetrieveRelatedTransactions:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/transactions?cursor=&limit=2&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/transactions?cursor=140648659841806336&limit=2&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/transactions?cursor=140648659841806336&limit=2&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GDCJIHD3623OCYNH65UUQC3NLG2D6YCNCDPZULRLCLOA76TBQRL6A3TF
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/32747318
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=140648659841806336
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=140648659841806336
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8
+              id: fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8
+              paging_token: '140648659841806336'
+              successful: true
+              hash: fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8
+              ledger: 32747318
+              created_at: '2020-11-23T16:02:38Z'
+              source_account: GDCJIHD3623OCYNH65UUQC3NLG2D6YCNCDPZULRLCLOA76TBQRL6A3TF
+              source_account_sequence: '140646847365513218'
+              fee_account: GDCJIHD3623OCYNH65UUQC3NLG2D6YCNCDPZULRLCLOA76TBQRL6A3TF
+              fee_charged: '100'
+              max_fee: '100'
+              operation_count: 1
+              envelope_xdr: AAAAAgAAAADElBx79rbhYaf3aUgLbVm0P2BNEN+aLisS3A/6YYRX4AAAAGQB862QAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAADgAAAAJCT0RISQAAAAAAAAAAAAAAxJQce/a24WGn92lIC21ZtD9gTRDfmi4rEtwP+mGEV+AAAAAAAA9CQAAAAAEAAAAAAAAAAElBqA1BXzKd9k9nuPoodv0YBKY+Hgh6Uz/UxozgnvyzAAAAAAAAAAAAAAABYYRX4AAAAEDf41ykW+eq8IVpJNOc4iDaht5Beil8NpQB8WMHkOxW3rocUBF3EHKqUXDIsD9CzzY7Xr1PbzVk5FZ4iBKNF4MM
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAOAAAAAAAAAAAXiCb7/jOeH1xTQXxv7f4sBei+wUMDFD7EaziYGwnD+QAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAfOvNgAAAAAAAAAAxJQce/a24WGn92lIC21ZtD9gTRDfmi4rEtwP+mGEV+AAAAAAAcnCVAHzrZAAAAABAAAAAAAAAAAAAAAAAAAAD2dpdmluZ2JvZGhpLm9yZwABAAAAAAAAAAAAAAAAAAAAAAAAAQHzrzYAAAAAAAAAAMSUHHv2tuFhp/dpSAttWbQ/YE0Q35ouKxLcD/phhFfgAAAAAAHJwlQB862QAAAAAgAAAAAAAAAAAAAAAAAAAA9naXZpbmdib2RoaS5vcmcAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAwHzrzYAAAAAAAAAAMSUHHv2tuFhp/dpSAttWbQ/YE0Q35ouKxLcD/phhFfgAAAAAAHJwlQB862QAAAAAgAAAAAAAAAAAAAAAAAAAA9naXZpbmdib2RoaS5vcmcAAQAAAAAAAAAAAAAAAAAAAAAAAAEB8682AAAAAAAAAADElBx79rbhYaf3aUgLbVm0P2BNEN+aLisS3A/6YYRX4AAAAAABycJUAfOtkAAAAAIAAAAAAAAAAAAAAAAAAAAPZ2l2aW5nYm9kaGkub3JnAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAfOvNgAAAAQAAAAAF4gm+/4znh9cU0F8b+3+LAXovsFDAxQ+xGs4mBsJw/kAAAABAAAAAAAAAABJQagNQV8ynfZPZ7j6KHb9GASmPh4IelM/1MaM4J78swAAAAAAAAACQk9ESEkAAAAAAAAAAAAAAMSUHHv2tuFhp/dpSAttWbQ/YE0Q35ouKxLcD/phhFfgAAAAAAAPQkAAAAAAAAAAAQAAAAEAAAAAxJQce/a24WGn92lIC21ZtD9gTRDfmi4rEtwP+mGEV+AAAAAAAAAAAA==
+              fee_meta_xdr: AAAAAgAAAAMB866UAAAAAAAAAADElBx79rbhYaf3aUgLbVm0P2BNEN+aLisS3A/6YYRX4AAAAAABycK4AfOtkAAAAAEAAAAAAAAAAAAAAAAAAAAPZ2l2aW5nYm9kaGkub3JnAAEAAAAAAAAAAAAAAAAAAAAAAAABAfOvNgAAAAAAAAAAxJQce/a24WGn92lIC21ZtD9gTRDfmi4rEtwP+mGEV+AAAAAAAcnCVAHzrZAAAAABAAAAAAAAAAAAAAAAAAAAD2dpdmluZ2JvZGhpLm9yZwABAAAAAAAAAAAAAAAAAAAA
+              memo_type: none
+              signatures:
+                - 3+NcpFvnqvCFaSTTnOIg2obeQXopfDaUAfFjB5DsVt66HFARdxByqlFwyLA/Qs82O169T281ZORWeIgSjReDDA==
+              preconditions:
+                timebounds:
+                  min_time: '0'
+    CBRetrieveRelatedOperations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/operations?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/operations?cursor=140648659841806337&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/operations?cursor=140648659841806337&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/140648659841806337
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/140648659841806337/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=140648659841806337
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=140648659841806337
+              id: '140648659841806337'
+              paging_token: '140648659841806337'
+              transaction_successful: true
+              source_account: GDCJIHD3623OCYNH65UUQC3NLG2D6YCNCDPZULRLCLOA76TBQRL6A3TF
+              type: create_claimable_balance
+              type_i: 14
+              created_at: '2020-11-23T16:02:38Z'
+              transaction_hash: fc5a98fc3869df408ebd4ac1c2e3fefec8b0a858e82ff1d14e362676708b91e8
+              sponsor: GDCJIHD3623OCYNH65UUQC3NLG2D6YCNCDPZULRLCLOA76TBQRL6A3TF
+              asset: BODHI:GDCJIHD3623OCYNH65UUQC3NLG2D6YCNCDPZULRLCLOA76TBQRL6A3TF
+              amount: '0.1000000'
+              claimants:
+                - destination: GBEUDKANIFPTFHPWJ5T3R6RIO36RQBFGHYPAQ6STH7KMNDHAT36LHOLD
+                  predicate:
+                    unconditional: true
+    ListAllEffects:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/effects?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/effects?cursor=33676838572034-1&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/effects?cursor=12884905985-1&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985-1
+              id: 0000000012884905985-0000000001
+              paging_token: 12884905985-1
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              type: account_created
+              type_i: 0
+              created_at: '2015-09-30T17:15:54Z'
+              starting_balance: '20.0000000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985-2
+              id: 0000000012884905985-0000000002
+              paging_token: 12884905985-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: account_debited
+              type_i: 3
+              created_at: '2015-09-30T17:15:54Z'
+              asset_type: native
+              amount: '20.0000000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985-3
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985-3
+              id: 0000000012884905985-0000000003
+              paging_token: 12884905985-3
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              type: signer_created
+              type_i: 10
+              created_at: '2015-09-30T17:15:54Z'
+              weight: 1
+              public_key: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              key: ''
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905986
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905986-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905986-1
+              id: 0000000012884905986-0000000001
+              paging_token: 12884905986-1
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              type: account_credited
+              type_i: 2
+              created_at: '2015-09-30T17:15:54Z'
+              asset_type: native
+              amount: '99999999959.9999700'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905986
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905986-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905986-2
+              id: 0000000012884905986-0000000002
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: account_debited
+              type_i: 3
+              created_at: '2015-09-30T17:15:54Z'
+              asset_type: native
+              amount: '99999999959.9999700'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905987
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905987-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905987-1
+              id: 0000000012884905987-0000000001
+              paging_token: 12884905987-1
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: signer_removed
+              type_i: 11
+              created_at: '2015-09-30T17:15:54Z'
+              weight: 0
+              public_key: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              key: ''
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/33676838572033
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=33676838572033-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=33676838572033-1
+              id: 0000033676838572033-0000000001
+              paging_token: 33676838572033-1
+              account: GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4
+              type: account_created
+              type_i: 0
+              created_at: '2015-10-01T04:15:01Z'
+              starting_balance: '20.0000000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/33676838572033
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=33676838572033-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=33676838572033-2
+              id: 0000033676838572033-0000000002
+              paging_token: 33676838572033-2
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              type: account_debited
+              type_i: 3
+              created_at: '2015-10-01T04:15:01Z'
+              asset_type: native
+              amount: '20.0000000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/33676838572033
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=33676838572033-3
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=33676838572033-3
+              id: 0000033676838572033-0000000003
+              paging_token: 33676838572033-3
+              account: GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4
+              type: signer_created
+              type_i: 10
+              created_at: '2015-10-01T04:15:01Z'
+              weight: 1
+              public_key: GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4
+              key: ''
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/33676838572034
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=33676838572034-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=33676838572034-1
+              id: 0000033676838572034-0000000001
+              paging_token: 33676838572034-1
+              account: GCZTBYH66ISTZKUPVJWTMHWBH4S4JIJ7WNLQJXCTQJKWY3FIT34BWZCJ
+              type: account_created
+              type_i: 0
+              created_at: '2015-10-01T04:15:01Z'
+              starting_balance: '20.0000000'
+    RetrieveFeeStats:
+      value:
+        last_ledger: '43277313'
+        last_ledger_base_fee: '100'
+        ledger_capacity_usage: '1'
+        fee_charged:
+          max: '5500'
+          min: '5000'
+          mode: '5000'
+          p10: '5000'
+          p20: '5000'
+          p30: '5000'
+          p40: '5000'
+          p50: '5001'
+          p60: '5001'
+          p70: '5066'
+          p80: '5066'
+          p90: '5500'
+          p95: '5500'
+          p99: '5500'
+        max_fee:
+          max: '616065406'
+          min: '5000'
+          mode: '10003'
+          p10: '10000'
+          p20: '10003'
+          p30: '10003'
+          p40: '20005'
+          p50: '20005'
+          p60: '50020'
+          p70: '50020'
+          p80: '150000'
+          p90: '500000'
+          p95: '500000'
+          p99: '1490000'
+    RetrieveALedger:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/ledgers/27146933
+          transactions:
+            href: https://horizon-testnet.stellar.org/ledgers/27146933/transactions{?cursor,limit,order}
+            templated: true
+          operations:
+            href: https://horizon-testnet.stellar.org/ledgers/27146933/operations{?cursor,limit,order}
+            templated: true
+          payments:
+            href: https://horizon-testnet.stellar.org/ledgers/27146933/payments{?cursor,limit,order}
+            templated: true
+          effects:
+            href: https://horizon-testnet.stellar.org/ledgers/27146933/effects{?cursor,limit,order}
+            templated: true
+        id: e1218a337cecda05526fba902c61d3d7130baa58d8db41f544bf563f779b6329
+        paging_token: '116595189421703168'
+        hash: e1218a337cecda05526fba902c61d3d7130baa58d8db41f544bf563f779b6329
+        prev_hash: 9eac16fecd885147067b58b7684f60d216f931b813f651265bbc97de4cea313d
+        sequence: 27146933
+        successful_transaction_count: 26
+        failed_transaction_count: 9
+        operation_count: 67
+        closed_at: '2019-12-06T22:39:32Z'
+        total_coins: '105443902087.3472865'
+        fee_pool: '1807264.7509661'
+        base_fee_in_stroops: 100
+        base_reserve_in_stroops: 5000000
+        max_tx_set_size: 1000
+        protocol_version: 12
+        header_xdr: AAAADJ6sFv7NiFFHBntYt2hPYNIW+TG4E/ZRJlu8l95M6jE9bsvzId+Gtul2mNMW4UZQ+KqSb/nbN8F1CTxAfQsyUy8AAAAAXerYpAAAAAAAAAAAXQNpS8daKGZUeY5quYUcIiJZBMB7LiLsZJsEx9qw79fx99Bu/lk+sIePNUNcuOC2euthzfhLuWJ1nZBuoQFDjgGeOrUOoh6z7HlbYQAAEG/dvCadAAABFgAAAAAIOwAqAAAAZABMS0AAAAPooSNtHXJNJKKWlBtgkAM1LBxzlzYjIlS0xwpjP+uCi76fQj59wgTy0+xtx7O1qTb+W6zcI2zWZnrUU/8v8RZHFBfoo20QYKh95+wWr348yZAexZpdrjhyCxbChxlVTZOX6nZfIgcYBMnZRkOTCLdPO76yeqpDhqu9KrPe3YPTO3wAAAAA
+    RetrieveALedgersTransactions:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/ledgers/27147222/transactions?cursor=&limit=2&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/ledgers/27147222/transactions?cursor=116596430667259904&limit=2&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/ledgers/27147222/transactions?cursor=116596430667255808&limit=2&order=desc
+        _embedded:
+          records:
+            - memo: FadBcV0owHrsLQif/V2TxZKGA2YiX+MoifI7oB/UjJM=
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GBKTEASNXABG2NC4TY6N3IA5UFC6YW53Y4KTIKY3CUEKQ2W5EIYRMYVB
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/27147222
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=116596430667255808
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=116596430667255808
+              id: 3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0
+              paging_token: '116596430667255808'
+              successful: true
+              hash: 3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0
+              ledger: 27147222
+              created_at: '2019-12-06T23:05:38Z'
+              source_account: GBKTEASNXABG2NC4TY6N3IA5UFC6YW53Y4KTIKY3CUEKQ2W5EIYRMYVB
+              source_account_sequence: '113943107245989112'
+              fee_charged: 100
+              max_fee: 100
+              operation_count: 1
+              envelope_xdr: AAAAAFUyAk24Am00XJ483aAdoUXsW7vHFTQrGxUIqGrdIjEWAAAAZAGUzqcAAFz4AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAADFadBcV0owHrsLQif/V2TxZKGA2YiX+MoifI7oB/UjJMAAAABAAAAAQAAAADhZHiqD/Q3uSTgjYEWGVRfCCHYvFmeqJU12G9SkzJYEQAAAAEAAAAAB77j4CQxLlm5aPrq/PDwFhGNs2ldqbdCZwkSfzXhUhYAAAABTk9ETAAAAAB1jYLXrFzNBOWCoPnZSHI3PJAhHtc1TrCaiPuZwSf5pgAAAAAAAABNAAAAAAAAAALw9Tl2AAAAQLSLnL3XT3F6dq5m2WHZ7tH3HBrK/e+p2G7Hrl3WXQToUsgxKIRH6bhHT/mIWwnrfLZ9nlVjMCFoZPqVKrI2lgLdIjEWAAAAQCrZ9IbjDAB408VgQaqNpwX8hXr/OUsoEexkWGkN9PjcBG2nf4bKWdbjiaqHZ+LrvM+DdmhxtA3L9bzmCie8NgA=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+              result_meta_xdr: AAAAAQAAAAIAAAADAZ471gAAAAAAAAAAVTICTbgCbTRcnjzdoB2hRexbu8cVNCsbFQioat0iMRYAAAAAB5tToAGUzqcAAFz3AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAZ471gAAAAAAAAAAVTICTbgCbTRcnjzdoB2hRexbu8cVNCsbFQioat0iMRYAAAAAB5tToAGUzqcAAFz4AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAMBnju+AAAAAQAAAAAHvuPgJDEuWblo+ur88PAWEY2zaV2pt0JnCRJ/NeFSFgAAAAFOT0RMAAAAAHWNgtesXM0E5YKg+dlIcjc8kCEe1zVOsJqI+5nBJ/mmAAAAAAAIP38ASptjhEiAAAAAAAEAAAAAAAAAAAAAAAEBnjvWAAAAAQAAAAAHvuPgJDEuWblo+ur88PAWEY2zaV2pt0JnCRJ/NeFSFgAAAAFOT0RMAAAAAHWNgtesXM0E5YKg+dlIcjc8kCEe1zVOsJqI+5nBJ/mmAAAAAAAIP8wASptjhEiAAAAAAAEAAAAAAAAAAAAAAAMBnjvVAAAAAQAAAADhZHiqD/Q3uSTgjYEWGVRfCCHYvFmeqJU12G9SkzJYEQAAAAFOT0RMAAAAAHWNgtesXM0E5YKg+dlIcjc8kCEe1zVOsJqI+5nBJ/mmAAAALEhqMpZ//////////wAAAAEAAAAAAAAAAAAAAAEBnjvWAAAAAQAAAADhZHiqD/Q3uSTgjYEWGVRfCCHYvFmeqJU12G9SkzJYEQAAAAFOT0RMAAAAAHWNgtesXM0E5YKg+dlIcjc8kCEe1zVOsJqI+5nBJ/mmAAAALEhqMkl//////////wAAAAEAAAAAAAAAAA==
+              fee_meta_xdr: AAAAAgAAAAMBnjvKAAAAAAAAAABVMgJNuAJtNFyePN2gHaFF7Fu7xxU0KxsVCKhq3SIxFgAAAAAHm1QEAZTOpwAAXPcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBnjvWAAAAAAAAAABVMgJNuAJtNFyePN2gHaFF7Fu7xxU0KxsVCKhq3SIxFgAAAAAHm1OgAZTOpwAAXPcAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: hash
+              signatures:
+                - tIucvddPcXp2rmbZYdnu0fccGsr976nYbseuXdZdBOhSyDEohEfpuEdP+YhbCet8tn2eVWMwIWhk+pUqsjaWAg==
+                - Ktn0huMMAHjTxWBBqo2nBfyFev85SygR7GRYaQ30+NwEbad/hspZ1uOJqodn4uu8z4N2aHG0Dcv1vOYKJ7w2AA==
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GDUHYA43LEQWXLJ5GQGNDJHZY6TZN2OK3KA4YQXQ47BRMRDRIUUC4IU5
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/27147222
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=116596430667259904
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=116596430667259904
+              id: 83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479
+              paging_token: '116596430667259904'
+              successful: true
+              hash: 83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479
+              ledger: 27147222
+              created_at: '2019-12-06T23:05:38Z'
+              source_account: GDUHYA43LEQWXLJ5GQGNDJHZY6TZN2OK3KA4YQXQ47BRMRDRIUUC4IU5
+              source_account_sequence: '113383696345604336'
+              fee_charged: 100
+              max_fee: 100
+              operation_count: 1
+              envelope_xdr: AAAAAOh8A5tZIWutPTQM0aT5x6eW6cragcxC8OfDFkRxRSguAAAAZAGS0d8AACDwAAAAAQAAAAAAAAAAAAAAAF3q3zYAAAAAAAAAAQAAAAEAAAAASe2g7z3OqB0F+vr+sM6vGMHgnomyJOLJeGMMjT1jgPcAAAADAAAAAVJNVAAAAAAAyGdd4j3sXGNb4PWMyeROuBvzRJJbU+On/O1oSxFvcqwAAAAAAAAAAAAAABcAB2UNAJiWgAAAAAAAAAAAAAAAAAAAAAJxRSguAAAAQG/ksOk2naI/PrA/6qes3c0IhoOpnBghd038S62rayiophPSs3HyUbgbOEpYQCkJezrf1bP+s2fFXVCEXbgveQk9Y4D3AAAAQAINPdxGV1VIeQ1OUDDlqtrSy8FrWQ/+CtRxqVHcHg98SYh5co/gd83R4IGDxukCByTbYapkrUOD0XDJKC/hcg4=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAADAAAAAAAAAAAAAAACAAAAAA==
+              result_meta_xdr: AAAAAQAAAAIAAAADAZ471gAAAAAAAAAA6HwDm1kha609NAzRpPnHp5bpytqBzELw58MWRHFFKC4AAAAAAKovMAGS0d8AACDvAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAZ471gAAAAAAAAAA6HwDm1kha609NAzRpPnHp5bpytqBzELw58MWRHFFKC4AAAAAAKovMAGS0d8AACDwAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAA==
+              fee_meta_xdr: AAAAAgAAAAMBnjukAAAAAAAAAADofAObWSFrrT00DNGk+cenlunK2oHMQvDnwxZEcUUoLgAAAAAAqi+UAZLR3wAAIO8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEBnjvWAAAAAAAAAADofAObWSFrrT00DNGk+cenlunK2oHMQvDnwxZEcUUoLgAAAAAAqi8wAZLR3wAAIO8AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - b+Sw6Tadoj8+sD/qp6zdzQiGg6mcGCF3TfxLratrKKimE9KzcfJRuBs4SlhAKQl7Ot/Vs/6zZ8VdUIRduC95CQ==
+                - Ag093EZXVUh5DU5QMOWq2tLLwWtZD/4K1HGpUdweD3xJiHlyj+B3zdHggYPG6QIHJNthqmStQ4PRcMkoL+FyDg==
+    RetrieveALedgersPayments:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/ledgers/27521176/payments?cursor=&limit=1&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/ledgers/27521176/payments?cursor=118202550867476481&limit=1&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/ledgers/27521176/payments?cursor=118202550867476481&limit=1&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/118202550867476481
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/971454b84a82baa38afa975e9eb4ff2632821b5a3e7f7993a7e20bbd9d7633ea
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/118202550867476481/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=118202550867476481
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=118202550867476481
+              id: '118202550867476481'
+              paging_token: '118202550867476481'
+              transaction_successful: true
+              source_account: GDQWI6FKB72DPOJE4CGYCFQZKRPQQIOYXRMZ5KEVGXMG6UUTGJMBCASH
+              type: payment
+              type_i: 1
+              created_at: '2019-12-30T22:35:49Z'
+              transaction_hash: 971454b84a82baa38afa975e9eb4ff2632821b5a3e7f7993a7e20bbd9d7633ea
+              asset_type: credit_alphanum4
+              asset_code: NODL
+              asset_issuer: GB2Y3AWXVROM2BHFQKQPTWKIOI3TZEBBD3LTKTVQTKEPXGOBE742NODL
+              from: GDQWI6FKB72DPOJE4CGYCFQZKRPQQIOYXRMZ5KEVGXMG6UUTGJMBCASH
+              to: GDGJS7AXAUFDZARIRDVZ5V7CFW6XY47WSBE2OVLCCGCDWOE7INKYN3PS
+              amount: '0.0000017'
+    RetrieveALedgersOperations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/ledgers/27147222/operations?cursor=&limit=2&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/ledgers/27147222/operations?cursor=116596430667259905&limit=2&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/ledgers/27147222/operations?cursor=116596430667255809&limit=2&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/116596430667255809
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/116596430667255809/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=116596430667255809
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=116596430667255809
+              id: '116596430667255809'
+              paging_token: '116596430667255809'
+              transaction_successful: true
+              source_account: GDQWI6FKB72DPOJE4CGYCFQZKRPQQIOYXRMZ5KEVGXMG6UUTGJMBCASH
+              type: payment
+              type_i: 1
+              created_at: '2019-12-06T23:05:38Z'
+              transaction_hash: 3a644389bbec63dd2b107a03c16711563fc549daa7b7f56f951a2e470f81f2e0
+              asset_type: credit_alphanum4
+              asset_code: NODL
+              asset_issuer: GB2Y3AWXVROM2BHFQKQPTWKIOI3TZEBBD3LTKTVQTKEPXGOBE742NODL
+              from: GDQWI6FKB72DPOJE4CGYCFQZKRPQQIOYXRMZ5KEVGXMG6UUTGJMBCASH
+              to: GAD35Y7AEQYS4WNZND5OV7HQ6ALBDDNTNFO2TN2CM4ERE7ZV4FJBNXZ6
+              amount: '0.0000077'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/116596430667259905
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/116596430667259905/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=116596430667259905
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=116596430667259905
+              id: '116596430667259905'
+              paging_token: '116596430667259905'
+              transaction_successful: true
+              source_account: GBE63IHPHXHKQHIF7L5P5MGOV4MMDYE6RGZCJYWJPBRQZDJ5MOAPOX7A
+              type: manage_offer
+              type_i: 3
+              created_at: '2019-12-06T23:05:38Z'
+              transaction_hash: 83eabfa824b57436eda49bb9ac28675285f6d945325f69db41792078a83d3479
+              amount: '0.0000023'
+              price: '0.0484621'
+              price_r:
+                'n': 484621
+                d: 10000000
+              buying_asset_type: native
+              selling_asset_type: credit_alphanum4
+              selling_asset_code: RMT
+              selling_asset_issuer: GDEGOXPCHXWFYY234D2YZSPEJ24BX42ESJNVHY5H7TWWQSYRN5ZKZE3N
+              offer_id: 0
+    RetrieveALedgersEffects:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/ledgers/0/effects?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/ledgers/0/effects?cursor=33676838572034-1&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/ledgers/0/effects?cursor=12884905985-1&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985-1
+              id: 0000000012884905985-0000000001
+              paging_token: 12884905985-1
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              type: account_created
+              type_i: 0
+              created_at: '2015-09-30T17:15:54Z'
+              starting_balance: '20.0000000'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985-2
+              id: 0000000012884905985-0000000002
+              paging_token: 12884905985-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: account_debited
+              type_i: 3
+              created_at: '2015-09-30T17:15:54Z'
+              asset_type: native
+              amount: '20.0000000'
+    ListAllLedgers:
+      value:
+        _embedded:
+          records:
+            - _links:
+                effects:
+                  href: /ledgers/1/effects/{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: /ledgers/1/operations/{?cursor,limit,order}
+                  templated: true
+                self:
+                  href: /ledgers/1
+                transactions:
+                  href: /ledgers/1/transactions/{?cursor,limit,order}
+                  templated: true
+              id: e8e10918f9c000c73119abe54cf089f59f9015cc93c49ccf00b5e8b9afb6e6b1
+              paging_token: '4294967296'
+              hash: e8e10918f9c000c73119abe54cf089f59f9015cc93c49ccf00b5e8b9afb6e6b1
+              sequence: 1
+              transaction_count: 0
+              successful_transaction_count: 0
+              failed_transaction_count: 0
+              operation_count: 0
+              tx_set_operation_count: 0
+              closed_at: '1970-01-01T00:00:00Z'
+              total_coins: '100000000000.0000000'
+              fee_pool: '0.0000000'
+              base_fee_in_stroops: 100
+              base_reserve_in_stroops: 100000000
+              max_tx_set_size: 50
+            - _links:
+                effects:
+                  href: /ledgers/2/effects/{?cursor,limit,order}
+                  templated: true
+                operations:
+                  href: /ledgers/2/operations/{?cursor,limit,order}
+                  templated: true
+                self:
+                  href: /ledgers/2
+                transactions:
+                  href: /ledgers/2/transactions/{?cursor,limit,order}
+                  templated: true
+              id: e12e5809ab8c59d8256e691cb48a024dd43960bc15902d9661cd627962b2bc71
+              paging_token: '8589934592'
+              hash: e12e5809ab8c59d8256e691cb48a024dd43960bc15902d9661cd627962b2bc71
+              prev_hash: e8e10918f9c000c73119abe54cf089f59f9015cc93c49ccf00b5e8b9afb6e6b1
+              sequence: 2
+              transaction_count: 0
+              successful_transaction_count: 0
+              failed_transaction_count: 0
+              operation_count: 0
+              closed_at: '2015-07-16T23:49:00Z'
+              total_coins: '100000000000.0000000'
+              fee_pool: '0.0000000'
+              base_fee_in_stroops: 100
+              base_reserve_in_stroops: 100000000
+              max_tx_set_size: 100
+        _links:
+          next:
+            href: /ledgers?order=asc&limit=2&cursor=8589934592
+          prev:
+            href: /ledgers?order=desc&limit=2&cursor=4294967296
+          self:
+            href: /ledgers?order=asc&limit=2&cursor=
+    ListLiquidityPools:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/liquidity_pools?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/liquidity_pools?cursor=66835-00000000c582697b67cbec7f9ce64f4dc67bfb2bfd26318bb9f964f4d70e3f41f650b1e6&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/liquidity_pools?cursor=38888-00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072&limit=10&order=desc
+        _embedded:
+          records:
+            - id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+              paging_token: '113725249324879873'
+              fee_bp: 30
+              type: constant_product
+              total_trustlines: '300'
+              total_shares: '5000'
+              reserves:
+                - amount: '1000.0000005'
+                  asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                - amount: '2000.0000000'
+                  asset: PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+            - id: 14be5a5b3d3f5e1e74380ab0a3bf9c172b7246fdf7753b172cbacd4d66143c08
+              paging_token: '113725249324879874'
+              fee_bp: 30
+              type: constant_product
+              total_trustlines: '200'
+              total_shares: '3500'
+              reserves:
+                - amount: '1000.0000005'
+                  asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                - amount: '1200.0000000'
+                  asset: USDC:GC5W3BH2MQRQK2H4A6LP3SXDSAAY2W2W64OWKKVNQIAOVWSAHFDEUSDC
+    RetrieveALiquidityPool:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+          effects:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/effects{?cursor,limit,order}
+            templated: true
+          operations:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/operations{?cursor,limit,order}
+            templated: true
+          transactions:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/transactions{?cursor,limit,order}
+            templated: true
+        id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+        paging_token: '113725249324879873'
+        fee_bp: 30
+        type: constant_product
+        total_trustlines: '300'
+        total_shares: '5000'
+        reserves:
+          - amount: '1000.0000005'
+            asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+          - amount: '2000.0000000'
+            asset: PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+    RetrieveRelatedEffects:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/effects?cursor=&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/effects?cursor=120192370561220608&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/effects?cursor=120192344791343104&order=desc
+        _embedded:
+          records:
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/3849085266190337
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=3849085266190337-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=3849085266190337-1
+              id: 0000000012884905986-0000000001
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: liquidity_pool_deposited
+              type_i: 81
+              created_at: '2021-11-18T03:15:54Z'
+              liquidity_pool:
+                id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+                fee_bp: 30
+                type: constant_product
+                total_trustlines: '300'
+                total_shares: '5000'
+                reserves:
+                  - amount: '1000.0000005'
+                    asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  - amount: '2000.0000000'
+                    asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+              reserves_deposited:
+                - asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  amount: '2378.0000005'
+                - asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+                  amount: '983.0000005'
+              shares_received: '1000'
+            - id: 0000000012884905986-0000000002
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: liquidity_pool_withdrew
+              type_i: 82
+              created_at: '2021-11-18T03:15:54Z'
+              liquidity_pool:
+                id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+                fee_bp: 30
+                type: constant_product
+                total_trustlines: '299'
+                total_shares: '4000'
+                reserves:
+                  - amount: '7.0000005'
+                    asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  - amount: '1.0000000'
+                    asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+              reserves_received:
+                - asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  amount: '2478.0000005'
+                - asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+                  amount: '993.0000005'
+              shares_redeemed: '1000'
+            - id: 0000000012884905986-0000000003
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: liquidity_pool_trade
+              type_i: 83
+              created_at: '2021-11-18T03:15:54Z'
+              liquidity_pool:
+                id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+                fee_bp: 30
+                type: constant_product
+                total_trustlines: '300'
+                total_shares: '5000'
+                reserves:
+                  - amount: '1000.0000005'
+                    asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  - amount: '2000.0000000'
+                    asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+              sold:
+                asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+                amount: '983.0000005'
+              bought:
+                asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                amount: '2378.0000005'
+            - id: 0000000012884905986-0000000004
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: liquidity_pool_created
+              type_i: 84
+              created_at: '2021-11-18T03:15:54Z'
+              liquidity_pool:
+                id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+                fee_bp: 30
+                type: constant_product
+                total_trustlines: '1'
+                total_shares: '0'
+                reserves:
+                  - amount: '0'
+                    asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  - amount: '0'
+                    asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+            - id: 0000000012884905986-0000000005
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: liquidity_pool_removed
+              type_i: 85
+              created_at: '2021-11-18T03:15:54Z'
+              liquidity_pool_id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+            - id: 0000000012884905986-0000000006
+              paging_token: 12884905986-2
+              account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: liquidity_pool_revoked
+              type_i: 86
+              created_at: '2021-11-18T03:15:54Z'
+              liquidity_pool:
+                id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+                fee_bp: 30
+                type: constant_product
+                total_trustlines: '299'
+                total_shares: '4000'
+                reserves:
+                  - amount: '7.0000005'
+                    asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  - amount: '1.0000000'
+                    asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+              reserves_revoked:
+                - asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  amount: '2478.0000005'
+                  claimable_balance_id: idcbd1234
+                - asset: PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP
+                  amount: '993.0000005'
+                  claimable_balance_id: cbid1235
+              shares_revoked: '1000'
+            - id: 0000000012884905986-0000000007
+              paging_token: 157639717969326081-1
+              account: GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG
+              type: trustline_created
+              type_i: 20
+              created_at: '2021-08-04T20:01:24Z'
+              asset_type: liquidity_pool_shares
+              liquidity_pool_id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+              limit: '1000'
+            - id: 0000000012884905986-0000000008
+              paging_token: 157639717969326081-1
+              account: GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG
+              type: trustline_updated
+              type_i: 22
+              created_at: '2021-08-04T20:01:24Z'
+              asset_type: liquidity_pool_shares
+              liquidity_pool_id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+              limit: '2000'
+            - id: 0000000012884905986-0000000009
+              paging_token: 157639717969326081-1
+              account: GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG
+              type: trustline_removed
+              type_i: 21
+              created_at: '2021-08-04T20:01:24Z'
+              asset_type: liquidity_pool_shares
+              liquidity_pool_id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+              limit: '0.0000000'
+    RetrieveRelatedTrades:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4/trades?cursor=&limit=2&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4/trades?cursor=120192370561220608&limit=2&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4/trades?cursor=120192344791343104&limit=2&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/3697472920621057
+              id: 3697472920621057-0
+              paging_token: 3697472920621057-0
+              ledger_close_time: '2015-11-18T03:47:47Z'
+              offer_id: '9'
+              base_offer_id: '9'
+              base_account: GAVH5JM5OKXGMQDS7YPRJ4MQCPXJUGH26LYQPQJ4SOMOJ4SXY472ZM7G
+              base_amount: '10.0000000'
+              base_asset_type: native
+              counter_liquidity_pool: 3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4
+              liquidity_pool_fee_bp: '30'
+              counter_amount: '2.6700000'
+              counter_asset_type: credit_alphanum4
+              counter_asset_code: JPY
+              counter_asset_issuer: GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM
+              base_is_seller: true
+              price:
+                'n': '267'
+                d: '1000'
+              trade_type: liquidity_pool
+    LPRetrieveRelatedTransactions:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4/transactions?cursor=&limit=2&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4/transactions?cursor=120192370561220608&limit=2&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/3b476aff8a406a6ec3b61d5c038009cef85f2ddfaf616822dc4fec92845149b4/transactions?cursor=120192344791343104&limit=2&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/895788
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908/operations
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908/effects
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=3847380164161536
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=3847380164161536
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908
+              id: 2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908
+              paging_token: '3847380164161536'
+              successful: true
+              hash: 2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908
+              ledger: 895788
+              created_at: '2021-08-09T20:53:11Z'
+              source_account: GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7
+              source_account_sequence: '3847371574214658'
+              fee_account: GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7
+              fee_charged: '10000'
+              max_fee: '10001'
+              operation_count: 1
+              envelope_xdr: AAAAAgAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAJxEADasqAAAAAgAAAAAAAAAAAAAAAQAAAAEAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAGAAAAAVNFQwAAAAAAm6XFaVsf8OSuS9C9gMplyTjagE9jAnnqwxSDJ6fin6IAsaK8LsUAAAAAAAAAAAAB9uVOlAAAAECXmRsoXmRiJjUrtbkDZYRnzac5s1CVV4g2RlIgBIuQty21npz3A1VhUcSmAx+GmsyGxVFvIrcdstTawJlmy9kF
+              result_xdr: AAAAAAAAJxAAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=
+              result_meta_xdr: AAAAAgAAAAIAAAADAA2rLAAAAAAAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAAGtJNDAANqyoAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA2rLAAAAAAAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAAGtJNDAANqyoAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAIAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADassAAAAAQAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAFTRUMAAAAAAJulxWlbH/DkrkvQvYDKZck42oBPYwJ56sMUgyen4p+iAAAAAAAAAAAAsaK8LsUAAAAAAAEAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMADasrAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0nQcAA2rKgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: none
+              signatures:
+                - l5kbKF5kYiY1K7W5A2WEZ82nObNQlVeINkZSIASLkLcttZ6c9wNVYVHEpgMfhprMhsVRbyK3HbLU2sCZZsvZBQ==
+    LPRetrieveRelatedOperations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/operations?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/operations?cursor=120192452165550081&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/liquidity_pools/67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9/operations?cursor=120192344791343105&limit=3&order=desc
+        _embedded:
+          records:
+            - id: '3697472920621057'
+              paging_token: '3697472920621057'
+              transaction_successful: true
+              source_account: GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L
+              type: liquidity_pool_withdraw
+              type_i: 23
+              created_at: '2021-11-18T03:47:47Z'
+              transaction_hash: 43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378
+              liquidity_pool_id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+              reserves_min:
+                - asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  min: '1000.0000005'
+                - asset: PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  min: '3000.0000005'
+              shares: '200'
+              reserves_received:
+                - asset: EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  amount: '993.0000005'
+                - asset: PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+                  amount: '2478.0000005'
+            - id: '157639717969326081'
+              paging_token: '157639717969326081'
+              transaction_successful: true
+              source_account: GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG
+              type: change_trust
+              type_i: 6
+              created_at: '2021-08-04T20:01:24Z'
+              transaction_hash: 941f2fa2101d1265696a3c7d35e7688cd210324114e96b64a386ab55f65e488f
+              asset_type: liquidity_pool_shares
+              liquidity_pool_id: 67260c4c1807b262ff851b0a3fe141194936bb0215b2f77447f1df11998eabb9
+              limit: '1000'
+              trustor: GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG
+    GetAllOffers:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/offers?cursor=&limit=3&order=asc&selling_asset_code=USD&selling_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&selling_asset_type=credit_alphanum4
+          next:
+            href: https://horizon-testnet.stellar.org/offers?cursor=88345152&limit=3&order=asc&selling_asset_code=USD&selling_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&selling_asset_type=credit_alphanum4
+          prev:
+            href: https://horizon-testnet.stellar.org/offers?cursor=71673427&limit=3&order=desc&selling_asset_code=USD&selling_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&selling_asset_type=credit_alphanum4
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/offers/71673427
+                offer_maker:
+                  href: https://horizon-testnet.stellar.org/accounts/GBJPWEIFX6KO4H52BF3QJDYRCLXB2P3Z3QTKWUGFOOFH5MSRZV4WLRZ7
+              id: 71673427
+              paging_token: '71673427'
+              seller: GBJPWEIFX6KO4H52BF3QJDYRCLXB2P3Z3QTKWUGFOOFH5MSRZV4WLRZ7
+              selling:
+                asset_type: credit_alphanum4
+                asset_code: USD
+                asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              buying:
+                asset_type: credit_alphanum4
+                asset_code: BTC
+                asset_issuer: GAUTUYY2THLF7SGITDFMXJVYH3LHDSMGEAKSBU267M2K7A3W543CKUEF
+              amount: '25.6545775'
+              price_r:
+                'n': 289696073
+                d: 25654776
+              price: '11.2920913'
+              last_modified_ledger: 26981646
+              last_modified_time: '2019-11-26T13:42:10Z'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/offers/88328208
+                offer_maker:
+                  href: https://horizon-testnet.stellar.org/accounts/GBSYMLHG5TGQ4O3NSPIO4DSCS4AC6YRJOQWQC3EW7O257RAUHI5SA45R
+              id: 88328208
+              paging_token: '88328208'
+              seller: GBSYMLHG5TGQ4O3NSPIO4DSCS4AC6YRJOQWQC3EW7O257RAUHI5SA45R
+              selling:
+                asset_type: credit_alphanum4
+                asset_code: USD
+                asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              buying:
+                asset_type: credit_alphanum4
+                asset_code: BTC
+                asset_issuer: GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5
+              amount: '2.4664893'
+              price_r:
+                'n': 500
+                d: 1233
+              price: '0.4055150'
+              last_modified_ledger: 23886660
+              last_modified_time: '2019-05-17T00:33:16Z'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/offers/88345152
+                offer_maker:
+                  href: https://horizon-testnet.stellar.org/accounts/GACTQP5TAWIXF2LV4GWGJWIUNHKDWZ2ITCFDP37FIGOFPR3ORMQRR63U
+              id: 88345152
+              paging_token: '88345152'
+              seller: GACTQP5TAWIXF2LV4GWGJWIUNHKDWZ2ITCFDP37FIGOFPR3ORMQRR63U
+              selling:
+                asset_type: credit_alphanum4
+                asset_code: USD
+                asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              buying:
+                asset_type: credit_alphanum4
+                asset_code: USD
+                asset_issuer: GBUYUAI75XXWDZEKLY66CFYKQPET5JR4EENXZBUZ3YXZ7DS56Z4OKOFU
+              amount: '10.0000000'
+              price_r:
+                'n': 11
+                d: 10
+              price: '1.1000000'
+              last_modified_ledger: 23887778
+              last_modified_time: '2019-05-17T02:19:19Z'
+    GetOfferByOfferId:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/offers/165563085
+          offer_maker:
+            href: https://horizon-testnet.stellar.org/accounts/GCM4PT6XDZBWOOENDS6FOU22GJQLJPV2GC7VRVII4TFGZBA3ZXNM55SV
+        id: 165563085
+        paging_token: '165563085'
+        seller: GCM4PT6XDZBWOOENDS6FOU22GJQLJPV2GC7VRVII4TFGZBA3ZXNM55SV
+        selling:
+          asset_type: credit_alphanum4
+          asset_code: USD
+          asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+        buying:
+          asset_type: native
+        amount: '26.1075388'
+        price_r:
+          'n': 1449156725
+          d: 84642346
+        price: '17.1209423'
+        last_modified_ledger: 28412042
+        last_modified_time: null
+    GetTradesByOfferId:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/offers/104078276/trades?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/offers/104078276/trades?cursor=107449584845914113-0&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/offers/104078276/trades?cursor=107449468881756161-0&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GCO7OW5P2PP7WDN6YUDXUUOPAR4ZHJSDDCZTIAQRTRZHKQWV45WUPBWX
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/107449468881756161
+              id: 107449468881756161-0
+              paging_token: 107449468881756161-0
+              ledger_close_time: '2019-07-26T09:17:02Z'
+              offer_id: '104078276'
+              base_offer_id: '104078276'
+              base_account: GCO7OW5P2PP7WDN6YUDXUUOPAR4ZHJSDDCZTIAQRTRZHKQWV45WUPBWX
+              base_amount: '4433.2000000'
+              base_asset_type: native
+              counter_offer_id: '4719135487309144065'
+              counter_account: GD3CJYUTZAY6JQF4CEI6Z7VW5O6VNGKZTBYUECTOJPEDTB7I2HZSPI2K
+              counter_amount: '443.3200000'
+              counter_asset_type: credit_alphanum4
+              counter_asset_code: BB1
+              counter_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              base_is_seller: true
+              price:
+                'n': 1
+                d: 10
+    RetrieveAnOperation:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/operations/121692259040116737
+          transaction:
+            href: https://horizon-testnet.stellar.org/transactions/f92a9648c1084d1de0fd786faac5d5e1637d4127c60841d2366c70d2e7f77b85
+          effects:
+            href: https://horizon-testnet.stellar.org/operations/121692259040116737/effects
+          succeeds:
+            href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=121692259040116737
+          precedes:
+            href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=121692259040116737
+        id: '121692259040116737'
+        paging_token: '121692259040116737'
+        transaction_successful: true
+        source_account: GBDVKE33GVVMBXX73OHIBRP6RAHKHHW2P4PQVV6UNOKQCOXU7GNUM4QI
+        type: manage_offer
+        type_i: 3
+        created_at: '2020-02-21T20:10:21Z'
+        transaction_hash: f92a9648c1084d1de0fd786faac5d5e1637d4127c60841d2366c70d2e7f77b85
+        amount: '10000.0000000'
+        price: '0.0704336'
+        price_r:
+          'n': 44021
+          d: 625000
+        buying_asset_type: credit_alphanum4
+        buying_asset_code: USD
+        buying_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+        selling_asset_type: native
+        offer_id: 161536436
+    RetrieveAnOperationsEffects:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/operations/121693057904021505/effects?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/operations/121693057904021505/effects?cursor=121693057904021505-2&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/operations/121693057904021505/effects?cursor=121693057904021505-1&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/121693057904021505
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=121693057904021505-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=121693057904021505-1
+              id: 0121693057904021505-0000000001
+              paging_token: 121693057904021505-1
+              account: GALSPNVKGNRJ3VIOQ26QKPZBDCTVJK7XPLSPF3UVZV3JJXCKVCHNSPCK
+              type: account_credited
+              type_i: 2
+              created_at: '2020-02-21T20:27:30Z'
+              asset_type: credit_alphanum4
+              asset_code: NODL
+              asset_issuer: GB2Y3AWXVROM2BHFQKQPTWKIOI3TZEBBD3LTKTVQTKEPXGOBE742NODL
+              amount: '0.0000027'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/121693057904021505
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=121693057904021505-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=121693057904021505-2
+              id: 0121693057904021505-0000000002
+              paging_token: 121693057904021505-2
+              account: GDQWI6FKB72DPOJE4CGYCFQZKRPQQIOYXRMZ5KEVGXMG6UUTGJMBCASH
+              type: account_debited
+              type_i: 3
+              created_at: '2020-02-21T20:27:30Z'
+              asset_type: credit_alphanum4
+              asset_code: NODL
+              asset_issuer: GB2Y3AWXVROM2BHFQKQPTWKIOI3TZEBBD3LTKTVQTKEPXGOBE742NODL
+              amount: '0.0000027'
+    ListAllOperations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/operations?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/operations?cursor=12884905987&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/operations?cursor=12884905985&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985
+              id: '12884905985'
+              paging_token: '12884905985'
+              transaction_successful: true
+              source_account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: create_account
+              type_i: 0
+              created_at: '2015-09-30T17:15:54Z'
+              transaction_hash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              starting_balance: '20.0000000'
+              funder: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/12884905986
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/12884905986/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905986
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905986
+              id: '12884905986'
+              paging_token: '12884905986'
+              transaction_successful: true
+              source_account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: payment
+              type_i: 1
+              created_at: '2015-09-30T17:15:54Z'
+              transaction_hash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              asset_type: native
+              from: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              to: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              amount: '99999999959.9999700'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/12884905987
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/12884905987/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905987
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905987
+              id: '12884905987'
+              paging_token: '12884905987'
+              transaction_successful: true
+              source_account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: set_options
+              type_i: 5
+              created_at: '2015-09-30T17:15:54Z'
+              transaction_hash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              master_key_weight: 0
+    RetrieveAnOrderBook:
+      value:
+        bids:
+          - price_r:
+              'n': 10000000
+              d: 139999999
+            price: '0.0714286'
+            amount: '24.9999990'
+          - price_r:
+              'n': 1
+              d: 14
+            price: '0.0714286'
+            amount: '188.0000000'
+          - price_r:
+              'n': 1
+              d: 15
+            price: '0.0666667'
+            amount: '230.3200000'
+          - price_r:
+              'n': 1
+              d: 16
+            price: '0.0625000'
+            amount: '50.0000000'
+        asks:
+          - price_r:
+              'n': 5000000
+              d: 62500001
+            price: '0.0800000'
+            amount: '4.9400001'
+          - price_r:
+              'n': 10000000
+              d: 125000001
+            price: '0.0800000'
+            amount: '2516.5154327'
+          - price_r:
+              'n': 2
+              d: 25
+            price: '0.0800000'
+            amount: '3125.0000000'
+          - price_r:
+              'n': 4
+              d: 49
+            price: '0.0816327'
+            amount: '4593.7500000'
+        base:
+          asset_type: native
+        counter:
+          asset_type: credit_alphanum4
+          asset_code: BB1
+          asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+    ListStrictReceivePaymentPaths:
+      value:
+        _embedded:
+          records:
+            - source_asset_type: credit_alphanum4
+              source_asset_code: CNY
+              source_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              source_amount: '28.9871131'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '5.0000000'
+              path:
+                - asset_type: credit_alphanum4
+                  asset_code: XCN
+                  asset_issuer: GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: CNY
+              source_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              source_amount: '29.0722784'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '5.0000000'
+              path:
+                - asset_type: credit_alphanum4
+                  asset_code: ULT
+                  asset_issuer: GC76RMFNNXBFDSJRBXCABWLHXDK4ITVQSMI56DC2ZJVC3YOLLPCKKULT
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: CNY
+              source_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              source_amount: '29.4000002'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '5.0000000'
+              path:
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: CNY
+              source_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              source_amount: '31.8955888'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '5.0000000'
+              path:
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GBUYUAI75XXWDZEKLY66CFYKQPET5JR4EENXZBUZ3YXZ7DS56Z4OKOFU
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: CNY
+              source_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              source_amount: '34.7086084'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '5.0000000'
+              path:
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+                - asset_type: native
+    ListStrictSendPaymentPaths:
+      value:
+        _embedded:
+          records:
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '87.6373649'
+              path:
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '36.0841597'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: EURT
+                  asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '16.2264000'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: BTC
+                  asset_issuer: GBVOL67TMUQBGL4TZYNMY3ZQ5WGQYFPFD5VJRWXR72VA33VFNL225PL5
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: BB1
+              destination_asset_issuer: GD5J6HLF5666X4AZLTFTXLY46J5SW7EXRKBLEYPJP33S33MXZGV6CWFN
+              destination_amount: '13.9424750'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: CNY
+              destination_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              destination_amount: '499.8384123'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: ULT
+                  asset_issuer: GC76RMFNNXBFDSJRBXCABWLHXDK4ITVQSMI56DC2ZJVC3YOLLPCKKULT
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: CNY
+              destination_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              destination_amount: '498.1069097'
+              path:
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: CNY
+              destination_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              destination_amount: '494.5886542'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: XCN
+                  asset_issuer: GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: CNY
+              destination_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              destination_amount: '490.0780598'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: CNY
+              destination_asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+              destination_amount: '280.2909824'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GBUYUAI75XXWDZEKLY66CFYKQPET5JR4EENXZBUZ3YXZ7DS56Z4OKOFU
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: EURT
+              destination_asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              destination_amount: '63.1883029'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: EURT
+              destination_asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              destination_amount: '63.1472796'
+              path:
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: EURT
+              destination_asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              destination_amount: '62.9386895'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: NGNT
+                  asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: EURT
+              destination_asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              destination_amount: '6.7649849'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: WSD
+                  asset_issuer: GDSVWEA7XV6M5XNLODVTPCGMAJTNBLZBXOFNQD3BNPNYALEYBNT6CE2V
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: EURT
+              destination_asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+              destination_amount: '0.0498106'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: CNY
+                  asset_issuer: GAREELUB43IRHWEASCFBLKHURCGMHE5IF6XSE7EXDLACYHGRHM43RFOX
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: NGNT
+              destination_asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              destination_amount: '25155.3452034'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: NGNT
+              destination_asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              destination_amount: '25146.7108397'
+              path:
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: NGNT
+              destination_asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              destination_amount: '24986.8616583'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: BTC
+                  asset_issuer: GAUTUYY2THLF7SGITDFMXJVYH3LHDSMGEAKSBU267M2K7A3W543CKUEF
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: NGNT
+              destination_asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              destination_amount: '24948.9784843'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: XCN
+                  asset_issuer: GCNY5OXYSY4FKHOPT2SPOQZAOEIGXB5LBYW3HVU3OWSTQITS65M5RCNY
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: NGNT
+              destination_asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+              destination_amount: '24930.7854717'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: EURT
+                  asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: USD
+              destination_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              destination_amount: '69.7123752'
+              path:
+                - asset_type: native
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: USD
+              destination_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              destination_amount: '68.9785993'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: EURT
+                  asset_issuer: GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: USD
+              destination_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              destination_amount: '68.6731854'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: NGNT
+                  asset_issuer: GAWODAROMJ33V5YDFY3NPYTHVYQG7MJXVJ2ND3AOGIHYRWINES6ACCPD
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: USD
+              destination_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              destination_amount: '63.5394120'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: USD
+                  asset_issuer: GBUYUAI75XXWDZEKLY66CFYKQPET5JR4EENXZBUZ3YXZ7DS56Z4OKOFU
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: credit_alphanum4
+              destination_asset_code: USD
+              destination_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              destination_amount: '39.6691360'
+              path:
+                - asset_type: native
+                - asset_type: credit_alphanum4
+                  asset_code: HEX
+                  asset_issuer: GCGBSZ3DSSH6PRHCOD4JXFNNZXCTKBDFRT4JR2HIAC6FQZU4YK7GPHEX
+            - source_asset_type: credit_alphanum4
+              source_asset_code: BRL
+              source_asset_issuer: GDVKY2GU2DRXWTBEYJJWSFXIGBZV6AZNBVVSUHEPZI54LIS6BA7DVVSP
+              source_amount: '400.0000000'
+              destination_asset_type: native
+              destination_amount: '1226.9231099'
+              path: []
+    ListAllPayments:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/payments?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/payments?cursor=33676838572033&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/payments?cursor=12884905985&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/12884905985/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905985
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905985
+              id: '12884905985'
+              paging_token: '12884905985'
+              transaction_successful: true
+              source_account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: create_account
+              type_i: 0
+              created_at: '2015-09-30T17:15:54Z'
+              transaction_hash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              starting_balance: '20.0000000'
+              funder: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/12884905986
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/12884905986/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=12884905986
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=12884905986
+              id: '12884905986'
+              paging_token: '12884905986'
+              transaction_successful: true
+              source_account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              type: payment
+              type_i: 1
+              created_at: '2015-09-30T17:15:54Z'
+              transaction_hash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              asset_type: native
+              from: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              to: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              amount: '99999999959.9999700'
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/33676838572033
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/33676838572033/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=33676838572033
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=33676838572033
+              id: '33676838572033'
+              paging_token: '33676838572033'
+              transaction_successful: true
+              source_account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              type: create_account
+              type_i: 0
+              created_at: '2015-10-01T04:15:01Z'
+              transaction_hash: 2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a
+              starting_balance: '20.0000000'
+              funder: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              account: GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4
+    ListTradeAggregations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type=native&counter_asset_code=EURT&counter_asset_issuer=GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S&counter_asset_type=credit_alphanum4&resolution=3600000&start_time=1582156800000&end_time=1582178400001
+          next:
+            href: https://horizon-testnet.stellar.org/trade_aggregations?base_asset_type=native&counter_asset_code=EURT&counter_asset_issuer=GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S&counter_asset_type=credit_alphanum4&end_time=1582178400001&resolution=3600000&start_time=1582171200000
+          prev:
+            href: ''
+        _embedded:
+          records:
+            - timestamp: 1582164000000
+              trade_count: 3
+              base_volume: '399.3873200'
+              counter_volume: '25.5368082'
+              avg: '0.0639400'
+              high: '0.0652169'
+              high_r:
+                'N': 652169
+                D: 10000000
+              low: '0.0638338'
+              low_r:
+                'N': 8107550
+                D: 127010393
+              open: '0.0652169'
+              open_r:
+                'N': 652169
+                D: 10000000
+              close: '0.0638338'
+              close_r:
+                'N': 8107550
+                D: 127010393
+            - timestamp: 1582167600000
+              trade_count: 1
+              base_volume: '149.8415320'
+              counter_volume: '9.7149804'
+              avg: '0.0648350'
+              high: '0.0648350'
+              high_r:
+                'N': 5000000
+                D: 77118803
+              low: '0.0648350'
+              low_r:
+                'N': 5000000
+                D: 77118803
+              open: '0.0648350'
+              open_r:
+                'N': 5000000
+                D: 77118803
+              close: '0.0648350'
+              close_r:
+                'N': 5000000
+                D: 77118803
+    GetAllTrades:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/trades?base_asset_code=USD&base_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&base_asset_type=credit_alphanum4&counter_asset_type=native&cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/trades?base_asset_code=USD&base_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&base_asset_type=credit_alphanum4&counter_asset_type=native&cursor=83056000260648961-0&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/trades?base_asset_code=USD&base_asset_issuer=GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX&base_asset_type=credit_alphanum4&counter_asset_type=native&cursor=82854686553571330-0&limit=3&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GD47M25MLSCSYP4SIVNQXVQ4KWNLVGXS4S2AXPTYEJK6OY4VALJWK4BS
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GBCHK52UXADCQCO7FBA5VBYPGCJFXHCNAVJTMUEKOCCNKJH5F35UZU5T
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/82854686553571330
+              id: 82854686553571330-0
+              paging_token: 82854686553571330-0
+              ledger_close_time: '2018-08-05T00:55:34Z'
+              offer_id: '23074703'
+              base_offer_id: '23074703'
+              base_account: GD47M25MLSCSYP4SIVNQXVQ4KWNLVGXS4S2AXPTYEJK6OY4VALJWK4BS
+              base_amount: '22.9174941'
+              base_asset_type: credit_alphanum4
+              base_asset_code: USD
+              base_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              counter_offer_id: '4694540704980959234'
+              counter_account: GBCHK52UXADCQCO7FBA5VBYPGCJFXHCNAVJTMUEKOCCNKJH5F35UZU5T
+              counter_amount: '97.9999800'
+              counter_asset_type: native
+              base_is_seller: true
+              price:
+                'n': '106905209'
+                d: '25000000'
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GD47M25MLSCSYP4SIVNQXVQ4KWNLVGXS4S2AXPTYEJK6OY4VALJWK4BS
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GDURV3I6U5OTUV75WWAG2HWZTQHNMCR3NR2P5GPKDCIS2AEWCFSOLVFU
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/83005225157287937
+              id: 83005225157287937-0
+              paging_token: 83005225157287937-0
+              ledger_close_time: '2018-08-07T02:01:53Z'
+              offer_id: '23400441'
+              base_offer_id: '23400441'
+              base_account: GD47M25MLSCSYP4SIVNQXVQ4KWNLVGXS4S2AXPTYEJK6OY4VALJWK4BS
+              base_amount: '1.0000000'
+              base_asset_type: credit_alphanum4
+              base_asset_code: USD
+              base_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              counter_offer_id: '4694691243584675841'
+              counter_account: GDURV3I6U5OTUV75WWAG2HWZTQHNMCR3NR2P5GPKDCIS2AEWCFSOLVFU
+              counter_amount: '4.3080953'
+              counter_asset_type: native
+              base_is_seller: true
+              price:
+                'n': '430809521'
+                d: '100000000'
+            - _links:
+                self:
+                  href: ''
+                base:
+                  href: https://horizon-testnet.stellar.org/accounts/GD47M25MLSCSYP4SIVNQXVQ4KWNLVGXS4S2AXPTYEJK6OY4VALJWK4BS
+                counter:
+                  href: https://horizon-testnet.stellar.org/accounts/GBNDB4UHLDRBLR35JNU4ADYG3J5WA4LJZOPBXMNHZKTKSL37BDX4UBQY
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/83056000260648961
+              id: 83056000260648961-0
+              paging_token: 83056000260648961-0
+              ledger_close_time: '2018-08-07T18:27:33Z'
+              offer_id: '23400441'
+              base_offer_id: '23400441'
+              base_account: GD47M25MLSCSYP4SIVNQXVQ4KWNLVGXS4S2AXPTYEJK6OY4VALJWK4BS
+              base_amount: '1.0000000'
+              base_asset_type: credit_alphanum4
+              base_asset_code: USD
+              base_asset_issuer: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+              counter_offer_id: '4694742018688036865'
+              counter_account: GBNDB4UHLDRBLR35JNU4ADYG3J5WA4LJZOPBXMNHZKTKSL37BDX4UBQY
+              counter_amount: '4.3080953'
+              counter_asset_type: native
+              base_is_seller: true
+              price:
+                'n': '430809521'
+                d: '100000000'
+    RetrieveATransaction:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/transactions/5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc
+          account:
+            href: https://horizon-testnet.stellar.org/accounts/GDI5EK4HNMBHJJQGP3GUXQJIIOHU2CJO3LABPWD6WYSPJZP5NP67TMNN
+          ledger:
+            href: https://horizon-testnet.stellar.org/ledgers/27963785
+          operations:
+            href: https://horizon-testnet.stellar.org/transactions/5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc/operations{?cursor,limit,order}
+            templated: true
+          effects:
+            href: https://horizon-testnet.stellar.org/transactions/5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc/effects{?cursor,limit,order}
+            templated: true
+          precedes:
+            href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=120103542047408128
+          succeeds:
+            href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=120103542047408128
+        id: 5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc
+        paging_token: '120103542047408128'
+        successful: true
+        hash: 5ebd5c0af4385500b53dd63b0ef5f6e8feef1a7e1c86989be3cdcce825f3c0cc
+        ledger: 27963785
+        created_at: '2020-01-28T10:03:33Z'
+        source_account: GDI5EK4HNMBHJJQGP3GUXQJIIOHU2CJO3LABPWD6WYSPJZP5NP67TMNN
+        source_account_sequence: '65046128646685383'
+        fee_charged: 100
+        max_fee: 100
+        operation_count: 1
+        envelope_xdr: AAAAANHSK4drAnSmBn7NS8EoQ49NCS7awBfYfrYk9OX9a/35AAAAZADnFxwAAALHAAAAAAAAAAAAAAABAAAAAQAAAADR0iuHawJ0pgZ+zUvBKEOPTQku2sAX2H62JPTl/Wv9+QAAAAEAAAAA+qpaPAsU/CGcSeS4KnvqE9y+Bcjhyr1l6jiwixRsvu8AAAABTkdOVAAAAAAs4YIuYne69wMuNtfiZ64gb7E3qnTR7A4yD4jZDSS8AQAAAdGpSiAAAAAAAAAAAAH9a/35AAAAQM5LSBiFRQKtFYRPpNabwVuvIhZSVRDaajf0KzYaqJmgaXAlFaTOYyYc11YuxUM1Fzl1VT4UEbI22BvO/8HzUgQ=
+        result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+        result_meta_xdr: AAAAAQAAAAIAAAADAaqxiQAAAAAAAAAA0dIrh2sCdKYGfs1LwShDj00JLtrAF9h+tiT05f1r/fkAAAAAAhWQlADnFxwAAALGAAAAAQAAAAEAAAAAhD8BLsZFQEF33rKS6YopQUT3b6iLBG4nspe68/DBNBYAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBqrGJAAAAAAAAAADR0iuHawJ0pgZ+zUvBKEOPTQku2sAX2H62JPTl/Wv9+QAAAAACFZCUAOcXHAAAAscAAAABAAAAAQAAAACEPwEuxkVAQXfespLpiilBRPdvqIsEbieyl7rz8ME0FgAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAQAAAADAan62gAAAAEAAAAA+qpaPAsU/CGcSeS4KnvqE9y+Bcjhyr1l6jiwixRsvu8AAAABTkdOVAAAAAAs4YIuYne69wMuNtfiZ64gb7E3qnTR7A4yD4jZDSS8AQAAAAAAAAALf/////////8AAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEBqrGJAAAAAQAAAAD6qlo8CxT8IZxJ5Lgqe+oT3L4FyOHKvWXqOLCLFGy+7wAAAAFOR05UAAAAACzhgi5id7r3Ay421+JnriBvsTeqdNHsDjIPiNkNJLwBAAAB0alKIAt//////////wAAAAEAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwGp+6EAAAABAAAAANHSK4drAnSmBn7NS8EoQ49NCS7awBfYfrYk9OX9a/35AAAAAU5HTlQAAAAALOGCLmJ3uvcDLjbX4meuIG+xN6p00ewOMg+I2Q0kvAEAAAkQQwRXzX//////////AAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAaqxiQAAAAEAAAAA0dIrh2sCdKYGfs1LwShDj00JLtrAF9h+tiT05f1r/fkAAAABTkdOVAAAAAAs4YIuYne69wMuNtfiZ64gb7E3qnTR7A4yD4jZDSS8AQAABz6ZujfNf/////////8AAAABAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        fee_meta_xdr: AAAAAgAAAAMBqfuhAAAAAAAAAADR0iuHawJ0pgZ+zUvBKEOPTQku2sAX2H62JPTl/Wv9+QAAAAACFZD4AOcXHAAAAsYAAAABAAAAAQAAAACEPwEuxkVAQXfespLpiilBRPdvqIsEbieyl7rz8ME0FgAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQGqsYkAAAAAAAAAANHSK4drAnSmBn7NS8EoQ49NCS7awBfYfrYk9OX9a/35AAAAAAIVkJQA5xccAAACxgAAAAEAAAABAAAAAIQ/AS7GRUBBd96ykumKKUFE92+oiwRuJ7KXuvPwwTQWAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+        memo_type: none
+        signatures:
+          - zktIGIVFAq0VhE+k1pvBW68iFlJVENpqN/QrNhqomaBpcCUVpM5jJhzXVi7FQzUXOXVVPhQRsjbYG87/wfNSBA==
+    RetrieveATransactionsOperations:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a/operations?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a/operations?cursor=120133379185221636&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a/operations?cursor=120133379185221633&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221633
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221633/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120133379185221633
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120133379185221633
+              id: '120133379185221633'
+              paging_token: '120133379185221633'
+              transaction_successful: true
+              source_account: GDJX67SFY2N73H72TWMKKBQP5UPBNKBNUMNE2IGFKNES43S4327X6DHG
+              type: manage_buy_offer
+              type_i: 12
+              created_at: '2020-01-28T21:14:59Z'
+              transaction_hash: 6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+              amount: '0.0000000'
+              price: '0.0001000'
+              price_r:
+                'n': 1
+                d: 10000
+              buying_asset_type: native
+              selling_asset_type: credit_alphanum4
+              selling_asset_code: ETH
+              selling_asset_issuer: GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR
+              offer_id: 149983118
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221634
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221634/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120133379185221634
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120133379185221634
+              id: '120133379185221634'
+              paging_token: '120133379185221634'
+              transaction_successful: true
+              source_account: GDJX67SFY2N73H72TWMKKBQP5UPBNKBNUMNE2IGFKNES43S4327X6DHG
+              type: manage_buy_offer
+              type_i: 12
+              created_at: '2020-01-28T21:14:59Z'
+              transaction_hash: 6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+              amount: '0.0000000'
+              price: '0.0001000'
+              price_r:
+                'n': 1
+                d: 10000
+              buying_asset_type: native
+              selling_asset_type: credit_alphanum4
+              selling_asset_code: ETH
+              selling_asset_issuer: GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR
+              offer_id: 149983119
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221635
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221635/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120133379185221635
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120133379185221635
+              id: '120133379185221635'
+              paging_token: '120133379185221635'
+              transaction_successful: true
+              source_account: GDJX67SFY2N73H72TWMKKBQP5UPBNKBNUMNE2IGFKNES43S4327X6DHG
+              type: manage_offer
+              type_i: 3
+              created_at: '2020-01-28T21:14:59Z'
+              transaction_hash: 6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+              amount: '98.5005752'
+              price: '0.0003494'
+              price_r:
+                'n': 17471
+                d: 50000000
+              buying_asset_type: credit_alphanum4
+              buying_asset_code: ETH
+              buying_asset_issuer: GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR
+              selling_asset_type: native
+              offer_id: 0
+            - _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221636
+                transaction:
+                  href: https://horizon-testnet.stellar.org/transactions/6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+                effects:
+                  href: https://horizon-testnet.stellar.org/operations/120133379185221636/effects
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=120133379185221636
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=120133379185221636
+              id: '120133379185221636'
+              paging_token: '120133379185221636'
+              transaction_successful: true
+              source_account: GDJX67SFY2N73H72TWMKKBQP5UPBNKBNUMNE2IGFKNES43S4327X6DHG
+              type: manage_buy_offer
+              type_i: 12
+              created_at: '2020-01-28T21:14:59Z'
+              transaction_hash: 6b983a4e0dc3c04f4bd6b9037c55f70a09c434dfd01492be1077cf7ea68c2e4a
+              amount: '291.8057980'
+              price: '0.0002565'
+              price_r:
+                'n': 250039
+                d: 975000000
+              buying_asset_type: native
+              selling_asset_type: credit_alphanum4
+              selling_asset_code: ETH
+              selling_asset_issuer: GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR
+              offer_id: 0
+    RetrieveATransactionsEffects:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/transactions/512a9946bc7ff4a363299f14f79e0beb9b9cdbd0103e3a69a44446a0aa6471a8/effects?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/transactions/512a9946bc7ff4a363299f14f79e0beb9b9cdbd0103e3a69a44446a0aa6471a8/effects?cursor=121628667754319873-2&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/transactions/512a9946bc7ff4a363299f14f79e0beb9b9cdbd0103e3a69a44446a0aa6471a8/effects?cursor=121628667754319873-1&limit=10&order=desc
+        _embedded:
+          records:
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/121628667754319873
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=121628667754319873-1
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=121628667754319873-1
+              id: 0121628667754319873-0000000001
+              paging_token: 121628667754319873-1
+              account: GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A
+              type: account_credited
+              type_i: 2
+              created_at: '2020-02-20T21:18:33Z'
+              asset_type: native
+              amount: '1573.5112616'
+            - _links:
+                operation:
+                  href: https://horizon-testnet.stellar.org/operations/121628667754319873
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=121628667754319873-2
+                precedes:
+                  href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=121628667754319873-2
+              id: 0121628667754319873-0000000002
+              paging_token: 121628667754319873-2
+              account: GA2XP4KMY4KWNPW4KUCUKYUF2J7Y6HO5HLPUEA3VPVSMYCM3TGNEZP5S
+              type: account_debited
+              type_i: 3
+              created_at: '2020-02-20T21:18:33Z'
+              asset_type: native
+              amount: '1573.5112616'
+    RetrieveATransactionsPayments:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/transactions/f8929884dfc56ff9d8bc220c7bfba9e58208943eba96f33e8a0787a5bb8a4629/payments?cursor=&limit=10&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/transactions/f8929884dfc56ff9d8bc220c7bfba9e58208943eba96f33e8a0787a5bb8a4629/payments?cursor=3382840796385281&limit=10&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/transactions/f8929884dfc56ff9d8bc220c7bfba9e58208943eba96f33e8a0787a5bb8a4629/payments?cursor=3382840796385281&limit=10&order=desc
+        _embedded:
+          records:
+            _links:
+              self:
+                href: https://horizon-testnet.stellar.org/operations/3382840796385281
+              transaction:
+                href: https://horizon-testnet.stellar.org/transactions/f8929884dfc56ff9d8bc220c7bfba9e58208943eba96f33e8a0787a5bb8a4629
+              effects:
+                href: https://horizon-testnet.stellar.org/operations/3382840796385281/effects
+              succeeds:
+                href: https://horizon-testnet.stellar.org/effects?order=desc&cursor=3382840796385281
+              precedes:
+                href: https://horizon-testnet.stellar.org/effects?order=asc&cursor=3382840796385281
+            id: '3382840796385281'
+            paging_token: '3382840796385281'
+            transaction_successful: true
+            source_account: GCNEGL4IYJ4XH2GV62QK4PQ5D4YWSYZPBC3NVF6VMNSFUMBFW3V3DKKY
+            type: account_merge
+            type_i: 8
+            created_at: '2024-07-29T19:33:23Z'
+            transaction_hash: f8929884dfc56ff9d8bc220c7bfba9e58208943eba96f33e8a0787a5bb8a4629
+            account: GCNEGL4IYJ4XH2GV62QK4PQ5D4YWSYZPBC3NVF6VMNSFUMBFW3V3DKKY
+            into: GBFAIH5WKAJQ77NG6BZG7TGVGXHPX4SQLIJ7BENJMCVCZSUZPSISCLU5
+    ListAllTransactions:
+      value:
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/transactions?cursor=&limit=3&order=asc
+          next:
+            href: https://horizon-testnet.stellar.org/transactions?cursor=33736968114176&limit=3&order=asc
+          prev:
+            href: https://horizon-testnet.stellar.org/transactions?cursor=12884905984&limit=3&order=desc
+        _embedded:
+          records:
+            - memo: hello world
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/3
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=12884905984
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=12884905984
+              id: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              paging_token: '12884905984'
+              successful: true
+              hash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889
+              ledger: 3
+              created_at: '2015-09-30T17:15:54Z'
+              source_account: GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7
+              source_account_sequence: '1'
+              fee_charged: 300
+              max_fee: 300
+              operation_count: 3
+              envelope_xdr: AAAAAAGUcmKO5465JxTSLQOQljwk2SfqAJmZSG6JH6wtqpwhAAABLAAAAAAAAAABAAAAAAAAAAEAAAALaGVsbG8gd29ybGQAAAAAAwAAAAAAAAAAAAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAAAvrwgAAAAAAAAAAAQAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNgAAAAAN4Lazj4x61AAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABLaqcIQAAAEBKwqWy3TaOxoGnfm9eUjfTRBvPf34dvDA0Nf+B8z4zBob90UXtuCqmQqwMCyH+okOI3c05br3khkH0yP4kCwcE
+              result_xdr: AAAAAAAAASwAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAFAAAAAAAAAAA=
+              result_meta_xdr: AAAAAAAAAAMAAAACAAAAAAAAAAMAAAAAAAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAAAvrwgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAMAAAAAAAAAAAGUcmKO5465JxTSLQOQljwk2SfqAJmZSG6JH6wtqpwhDeC2s5t4PNQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAEAAAADAAAAAAAAAAABlHJijueOuScU0i0DkJY8JNkn6gCZmUhuiR+sLaqcIQAAAAAL68IAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAMAAAADAAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNgAAAAAL68IAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNg3gtrObeDzUAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAwAAAAAAAAAAAZRyYo7njrknFNItA5CWPCTZJ+oAmZlIbokfrC2qnCEAAAAAC+vCAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMAAAABAAAAAAAAAAABlHJijueOuScU0i0DkJY8JNkn6gCZmUhuiR+sLaqcIQ3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAAABlHJijueOuScU0i0DkJY8JNkn6gCZmUhuiR+sLaqcIQ3gtrOnY/7UAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - SsKlst02jsaBp35vXlI300Qbz39+HbwwNDX/gfM+MwaG/dFF7bgqpkKsDAsh/qJDiN3NOW695IZB9Mj+JAsHBA==
+            - memo: testpool,faucet,sdf
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/7841
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=33676838572032
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=33676838572032
+              id: 2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a
+              paging_token: '33676838572032'
+              successful: true
+              hash: 2db4b22ca018119c5027a80578813ffcf582cda4aa9e31cd92b43cf1bda4fc5a
+              ledger: 7841
+              created_at: '2015-10-01T04:15:01Z'
+              source_account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              source_account_sequence: '12884901890'
+              fee_charged: 300
+              max_fee: 300
+              operation_count: 3
+              envelope_xdr: AAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAABLAAAAAMAAAACAAAAAAAAAAEAAAATdGVzdHBvb2wsZmF1Y2V0LHNkZgAAAAADAAAAAAAAAAAAAAAAH6Ue1GOPj6Hb/ROPyIFCJpQPMujihEIvJSfK0UfMDIgAAAAAC+vCAAAAAAAAAAAAAAAAALMw4P7yJTyqj6ptNh7BPyXEoT+zVwTcU4JVbGyonvgbAAAAAAvrwgAAAAAAAAAAAAAAAABJlwu05Op/5x1uyrweYsyR6pTTos33hRNZe5IF6blnzwAAAAAL68IAAAAAAAAAAAHwXhY2AAAAQDSBB5eNEKkWIoQbZ1YQabJuE5mW/AKhrHTxw9H3m/sai90YcaZlsAe3ueO9jExjSZF289ZcR4vc0wFw1p/WyAc=
+              result_xdr: AAAAAAAAASwAAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+              result_meta_xdr: AAAAAAAAAAMAAAACAAAAAAAAHqEAAAAAAAAAAB+lHtRjj4+h2/0Tj8iBQiaUDzLo4oRCLyUnytFHzAyIAAAAAAvrwgAAAB6hAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAQAAHqEAAAAAAAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2DeC2s4+MeHwAAAADAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAB6hAAAAAAAAAACzMOD+8iU8qo+qbTYewT8lxKE/s1cE3FOCVWxsqJ74GwAAAAAL68IAAAAeoQAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAB6hAAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNg3gtrODoLZ8AAAAAwAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAeoQAAAAAAAAAASZcLtOTqf+cdbsq8HmLMkeqU06LN94UTWXuSBem5Z88AAAAAC+vCAAAAHqEAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAeoQAAAAAAAAAAFvELLeYuDeGJOpfhVQQSnrSkU6sk3FgzUm3FdPBeFjYN4Lazd7T0fAAAAAMAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAA=
+              fee_meta_xdr: AAAAAgAAAAMAAB55AAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNg3gtrObeDuoAAAAAwAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAB6hAAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNg3gtrObeDp8AAAAAwAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - NIEHl40QqRYihBtnVhBpsm4TmZb8AqGsdPHD0feb+xqL3RhxpmWwB7e5472MTGNJkXbz1lxHi9zTAXDWn9bIBw==
+            - memo: ''
+              _links:
+                self:
+                  href: https://horizon-testnet.stellar.org/transactions/3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a
+                account:
+                  href: https://horizon-testnet.stellar.org/accounts/GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+                ledger:
+                  href: https://horizon-testnet.stellar.org/ledgers/7855
+                operations:
+                  href: https://horizon-testnet.stellar.org/transactions/3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a/operations{?cursor,limit,order}
+                  templated: true
+                effects:
+                  href: https://horizon-testnet.stellar.org/transactions/3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a/effects{?cursor,limit,order}
+                  templated: true
+                precedes:
+                  href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=33736968114176
+                succeeds:
+                  href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=33736968114176
+              id: 3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a
+              paging_token: '33736968114176'
+              successful: true
+              hash: 3ce2aca2fed36da2faea31352c76c5e412348887a4c119b1e90de8d1b937396a
+              ledger: 7855
+              created_at: '2015-10-01T04:16:11Z'
+              source_account: GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB
+              source_account_sequence: '12884901891'
+              fee_charged: 100
+              max_fee: 100
+              operation_count: 1
+              envelope_xdr: AAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAZAAAAAMAAAADAAAAAAAAAAEAAAAAAAAAAQAAAAAAAAAFAAAAAQAAAAAfpR7UY4+Podv9E4/IgUImlA8y6OKEQi8lJ8rRR8wMiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwXhY2AAAAQNbDcWsR3s3z8Qzqatcdc/k2L4LXWJMA6eXac8dbXkAdc4ppH25isGC5OwvG06Vwvc3Ce3/r2rYcBP3vxhx18A8=
+              result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAFAAAAAAAAAAA=
+              result_meta_xdr: AAAAAAAAAAEAAAABAAAAAQAAHq8AAAAAAAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2DeC2s3e09BgAAAADAAAAAwAAAAAAAAABAAAAAB+lHtRjj4+h2/0Tj8iBQiaUDzLo4oRCLyUnytFHzAyIAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAA
+              fee_meta_xdr: AAAAAgAAAAMAAB6hAAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNg3gtrN3tPR8AAAAAwAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAB6vAAAAAAAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNg3gtrN3tPQYAAAAAwAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+              memo_type: text
+              signatures:
+                - 1sNxaxHezfPxDOpq1x1z+TYvgtdYkwDp5dpzx1teQB1zimkfbmKwYLk7C8bTpXC9zcJ7f+vathwE/e/GHHXwDw==
+    SubmitaTransaction:
+      value:
+        memo: Test Transaction
+        memo_bytes: VGVzdCBUcmFuc2FjdGlvbg==
+        _links:
+          self:
+            href: https://horizon-testnet.stellar.org/transactions/8ef0c6d60357bf91b0b0d7800b747ff02bf73117d3e017690cbff641ca67f124
+          account:
+            href: https://horizon-testnet.stellar.org/accounts/GCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72MJN
+          ledger:
+            href: https://horizon-testnet.stellar.org/ledgers/139575
+          operations:
+            href: https://horizon-testnet.stellar.org/transactions/8ef0c6d60357bf91b0b0d7800b747ff02bf73117d3e017690cbff641ca67f124/operations{?cursor,limit,order}
+            templated: true
+          effects:
+            href: https://horizon-testnet.stellar.org/transactions/8ef0c6d60357bf91b0b0d7800b747ff02bf73117d3e017690cbff641ca67f124/effects{?cursor,limit,order}
+            templated: true
+          precedes:
+            href: https://horizon-testnet.stellar.org/transactions?order=asc&cursor=599470060347392
+          succeeds:
+            href: https://horizon-testnet.stellar.org/transactions?order=desc&cursor=599470060347392
+          transaction:
+            href: https://horizon-testnet.stellar.org/transactions/8ef0c6d60357bf91b0b0d7800b747ff02bf73117d3e017690cbff641ca67f124
+        id: 8ef0c6d60357bf91b0b0d7800b747ff02bf73117d3e017690cbff641ca67f124
+        paging_token: '599470060347392'
+        successful: true
+        hash: 8ef0c6d60357bf91b0b0d7800b747ff02bf73117d3e017690cbff641ca67f124
+        ledger: 139575
+        created_at: '2021-03-25T21:14:11Z'
+        source_account: GCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72MJN
+        source_account_sequence: '599336916353025'
+        fee_account: GCIHAQVWZH2AB5BB5NP63FBSIREG77LQZZNUVKD2LN2IOCLOT6N72MJN
+        fee_charged: '100'
+        max_fee: '100'
+        operation_count: 1
+        envelope_xdr: AAAAAgAAAACQcEK2yfQA9CHrX+2UMkRIb/1wzltKqHpbdIcJbp+b/QAAAGQAAiEYAAAAAQAAAAEAAAAAAAAAAAAAAABgXP3QAAAAAQAAABBUZXN0IFRyYW5zYWN0aW9uAAAAAQAAAAAAAAABAAAAAJBwQrbJ9AD0Ietf7ZQyREhv/XDOW0qoelt0hwlun5v9AAAAAAAAAAAF9eEAAAAAAAAAAAFun5v9AAAAQKdJnG8QRiv9xGp1Oq7ACv/xR2BnNqjfUHrGNua7m4tWbrun3+GmAj6ca3xz+4ZppWRTbvTUcCxvpbHERZ85QgY=
+        result_xdr: AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAA=
+        result_meta_xdr: AAAAAgAAAAIAAAADAAIhNwAAAAAAAAAAkHBCtsn0APQh61/tlDJESG/9cM5bSqh6W3SHCW6fm/0AAAAXSHbnnAACIRgAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAIhNwAAAAAAAAAAkHBCtsn0APQh61/tlDJESG/9cM5bSqh6W3SHCW6fm/0AAAAXSHbnnAACIRgAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAA=
+        fee_meta_xdr: AAAAAgAAAAMAAiEYAAAAAAAAAACQcEK2yfQA9CHrX+2UMkRIb/1wzltKqHpbdIcJbp+b/QAAABdIdugAAAIhGAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAiE3AAAAAAAAAACQcEK2yfQA9CHrX+2UMkRIb/1wzltKqHpbdIcJbp+b/QAAABdIduecAAIhGAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==
+        memo_type: text
+        signatures:
+          - p0mcbxBGK/3EanU6rsAK//FHYGc2qN9QesY25rubi1Zuu6ff4aYCPpxrfHP7hmmlZFNu9NRwLG+lscRFnzlCBg==
+x-tagGroups:
+  - name: Resources
+    tags:
+      - Accounts
+      - Assets
+      - Claimable Balances
+      - Effects
+      - Ledgers
+      - Liquidity Pools
+      - Offers
+      - Operations
+      - Payments
+      - Trades
+      - Transactions
+  - name: Aggregations
+    tags:
+      - Order Books
+      - Paths
+      - Trade Aggregations
+      - Fee Stats

--- a/static/openapi/stellar-disbursement-platform.yaml
+++ b/static/openapi/stellar-disbursement-platform.yaml
@@ -1,0 +1,6499 @@
+openapi: 3.1.0
+info:
+  title: Stellar Disbursement Platform API
+  version: 2.1.0
+  summary: The Stellar Disbursement Platform (SDP) is a tool built for organizations to make bulk payments to a group of recipients over the Stellar network.
+  description: |
+    The Stellar Disbursement Platform (SDP) is a tool built for organizations to make bulk payments to a group of recipients over the Stellar network.
+
+    This is an open-source project that is built on top of the Stellar network, and the code can be found on the following repositories:
+
+    - [stellar/stellar-disbursement-platform-backend](https://github.com/stellar/stellar-disbursement-platform-backend): This repository contains the backend and infrastructure code for the Stellar Disbursement Platform.
+    - [stellar/stellar-disbursement-platform-frontend](https://github.com/stellar/stellar-disbursement-platform-frontend): This repository contains the web frontend code for the Stellar Disbursement Platform.
+    - [stellar/helm-charts](https://github.com/stellar/helm-charts/tree/main/charts/stellar-disbursement-platform): This repository contains the Helm chart for deploying the Stellar Disbursement Platform using kubernetes.
+  termsOfService: https://stellar.org/terms-of-service
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: ''
+tags:
+  - name: Admin
+    x-displayName: Admin (Tenant Management)
+    description: The Admin API oversees the management of tenants within the system, facilitating tasks such as provisioning new tenants, updating their information, and retrieving tenant data.
+  - name: Authentication
+    description: Authentication controls the log in/log out process for all SDP users, as well as the token refresh process. Authentication uses a JWT approach signed with an ES256 private key.
+  - name: API Keys
+    description: API Keys functionality allows to create access key with granular permissions and resource management.
+  - name: Balances
+    description: Endpoints related to balances. A balance is an amount of a particular asset held by an organization, tenant, or account.
+  - name: Bridge Integration
+    description: |
+      Bridge integration endpoints for connecting organizations with Bridge services.
+
+      **Integration Flow:**
+      1. Organization opts into Bridge (OPTED_IN status)
+      2. Complete KYC verification process via Bridge
+      3. Create virtual account for USD deposits (READY_FOR_DEPOSIT status)
+      4. Receive USD deposits that are automatically converted to USDC on Stellar
+
+      **Status Description:**
+      - NOT_ENABLED → Bridge service not configured
+      - NOT_OPTED_IN → Organization hasn't opted in
+      - OPTED_IN → Organization opted in, KYC link created
+      - READY_FOR_DEPOSIT → Virtual account created, ready for deposits
+      - ERROR → Integration error occurred
+  - name: Disbursements
+    description: Endpoints related to disbursements. A disbursement is a group of payments sent to multiple individuals at once. An SDP user with the appropriate role triggers a new disbursement through the SDP dashboard by uploading a list of receivers and amounts. When the receiver has linked their wallet to the SDP, the payment automatically begins. SDP users can track their disbursements in real-time through the SDP dashboard. Each disbursement must have a unique name defined by the organization.
+  - name: Organization
+    description: Organization endpoints manage the process of getting and updating organizational profile information. The organization's profile has basic information set at the time of SDP deployment. It can be modified by the Owner. Organizations can also manage their preferences, like which assets to use, through these endpoints.
+  - name: Payments
+    description: Endpoints related to payments. An SDP payment is an individual payment from an organization to a receiver. Each payment is part of a disbursement and occurs on the Stellar network. Granular payment status is stored in the SDP database and can be viewed in real-time on the SDP dashboard.
+  - name: Profile
+    description: 'Profiles endpoints manage the process of getting and updating individual profile information. Profile information is set when the account is created and can be updated by the user on the SDP dashboard Profile page. Note: profiles never refer to receivers of funds.'
+  - name: Receivers
+    description: |
+      Endpoints related to receivers. A receiver is an individual receiving a payment in a disbursement. The receiver is tracked by phone number to reduce the need for personally identifiable information. Each receiver must be unique within the disbursement.
+
+      Each receiver will have at least one wallet associated with them. The wallet public key will remain null until the receiver registers with a wallet provider and links the wallet to the SDP through SEP-24. Receivers must verify their identity through that process, which requires the SDP to store verification information on receivers like date of birth, national ID number, or personal PIN. This information can be updated by the organization through the receiver endpoints.
+  - name: Registration
+    description: |
+      The registration endpoints guide the process for a receiver to verify their identity and link their wallet address to an SDP. The registration process only needs to happen once per receiver to link their wallet. Only SDP-compatible wallet providers can facilitate the registration process. These endpoints must be supported and hit by the wallet providers after the receiver gets the initial invite. After the wallet address is successfully linked, the payment automatically begins.
+
+      There are two parts to the registration flow. First, the wallet must authenticate and initiate a registration flow using the Anchor Platform Endpoints defined below. Note that these endpoints are hosted on a different host than the Stellar Disursement Platform.
+
+      The second part of the registration flow is handled by the webview that is opened within the wallet application. This webview uses the endpoints defined in the Stellar Disbursement Platfrom Endpoints section to complete the registration process. The wallet application can chose not to use the webview and intstead integrate directly with the API.
+  - name: Statistics
+    description: Statistics endpoints return general aggregated data per organization, as well as disbursement-specific metrics. SDP users can use this data to monitor their disbursements over time.
+  - name: Users
+    description: The users endpoints facilitate the creation of new SDP users - including setting the appropriate role, sending an email invitation, and activating a user - and managing roles.
+paths:
+  /login:
+    post:
+      tags:
+        - Authentication
+      summary: Log In
+      description: 'Allows credentialed SDP users to log in to the SDP dashboard with a password. Note: all passwords must be at least 8 characters long and a combination of uppercase letters, lowercase letters, numbers, and symbols.'
+      operationId: LogIn
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              required:
+                - email
+                - password
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+                recaptcha_token:
+                  type: string
+                  description: Token for reCAPTCHA validation. ReCAPTCHA token is required unless the `DISABLE_RECAPTCHA` configuration is set to true.
+              example:
+                email: johndoe@mail.com
+                password: mysecret
+        required: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                example:
+                  token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoidXNlci1pZCIsImVtYWlsIjoiZW1haWxAZW1haWwuY29tIiwicm9sZXMiOlt7Im5hbWUiOiJTdXBlcnZpc29yIn1dfSwiZXhwIjoxNjc1OTYyOTQ3fQ.4Zj9yBXch-iuFYF-kc_EhHPxjpwp_egMOLbOv4bZKO1MFvcmEgZ5MlXH1_1fZfgUxaNBcMCdRM6MGSqKocwGnA
+              example:
+                token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoidXNlci1pZCIsImVtYWlsIjoiZW1haWxAZW1haWwuY29tIiwicm9sZXMiOlt7Im5hbWUiOiJTdXBlcnZpc29yIn1dfSwiZXhwIjoxNjc1OTYyOTQ3fQ.4Zj9yBXch-iuFYF-kc_EhHPxjpwp_egMOLbOv4bZKO1MFvcmEgZ5MlXH1_1fZfgUxaNBcMCdRM6MGSqKocwGnA
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Invalid credentials
+                  extras:
+                    status: 400
+                    message: Invalid username or password
+              example:
+                error: Invalid credentials
+                extras:
+                  status: 400
+                  message: Invalid username or password
+      x-codegen-request-body-name: body
+  /refresh-token:
+    post:
+      tags:
+        - Authentication
+      summary: Refresh Token
+      description: A user’s token expires after 15 minutes. This endpoint handles refreshing the user’s token without disrupting their experience. It is triggered within the 30-second window before the token expires.
+      operationId: RefreshToken
+      responses:
+        '200':
+          description: Returns a new access token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                example:
+                  token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoidXNlci1pZCIsImVtYWlsIjoiZW1haWxAZW1haWwuY29tIiwicm9sZXMiOlt7Im5hbWUiOiJTdXBlcnZpc29yIn1dfSwiZXhwIjoxNjc1OTYyOTQ3fQ.4Zj9yBXch-iuFYF-kc_EhHPxjpwp_egMOLbOv4bZKO1MFvcmEgZ5MlXH1_1fZfgUxaNBcMCdRM6MGSqKocwGnA
+              example:
+                token: eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoidXNlci1pZCIsImVtYWlsIjoiZW1haWxAZW1haWwuY29tIiwicm9sZXMiOlt7Im5hbWUiOiJTdXBlcnZpc29yIn1dfSwiZXhwIjoxNjc1OTYyOTQ3fQ.4Zj9yBXch-iuFYF-kc_EhHPxjpwp_egMOLbOv4bZKO1MFvcmEgZ5MlXH1_1fZfgUxaNBcMCdRM6MGSqKocwGnA
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - BearerAuth: []
+  /mfa:
+    post:
+      tags:
+        - Authentication
+      summary: Provide Multi-Factor Authentication
+      description: Governs the multi-factor authentication process for SDP user login, including the ability to remember the device so MFA is not always required.
+      operationId: authenticateMFA
+      parameters:
+        - name: Device-ID
+          in: header
+          description: Identifier of the device
+          required: false
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        description: MFA request data
+        content:
+          '*/*':
+            schema:
+              required:
+                - mfa_code
+              type: object
+              properties:
+                mfa_code:
+                  type: string
+                  description: Multi-factor authentication code
+                remember_me:
+                  type: boolean
+                  description: Boolean flag to remember the user
+                recaptcha_token:
+                  type: string
+                  description: Token for reCAPTCHA validation. ReCAPTCHA token is required unless the `DISABLE_RECAPTCHA` configuration is set to true.
+        required: true
+      responses:
+        '200':
+          description: Successful authentication
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: Authentication token
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      x-codegen-request-body-name: body
+  /forgot-password:
+    post:
+      tags:
+        - Authentication
+      summary: Forgot Password
+      description: Sends an email with a token to an SDP user who has gone through the Forgot Password process.
+      operationId: forgotPassword
+      requestBody:
+        description: Forgot password request data
+        content:
+          '*/*':
+            schema:
+              required:
+                - email
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: Email of the user
+                  format: email
+                recaptcha_token:
+                  type: string
+                  description: Token for reCAPTCHA validation
+        required: true
+      responses:
+        '200':
+          description: Forgot password email sent successfully
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '400':
+          description: Bad Request
+          content:
+            '*/*':
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+      x-codegen-request-body-name: body
+  /reset-password:
+    post:
+      tags:
+        - Authentication
+      summary: Reset Rassword
+      description: Allows an SDP user who has gone through the Forgot Password process to set their new password with a token sent via email.
+      operationId: resetPassword
+      requestBody:
+        description: Reset password request data
+        content:
+          '*/*':
+            schema:
+              required:
+                - password
+                - reset_token
+              type: object
+              properties:
+                password:
+                  type: string
+                  description: New password for the user
+                reset_token:
+                  type: string
+                  description: Token used to identify a valid password reset request
+        required: true
+      responses:
+        '200':
+          description: Password reset successfully
+          content: {}
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+      x-codegen-request-body-name: body
+  /disbursements:
+    get:
+      tags:
+        - Disbursements
+      summary: List All Disbursements
+      description: Fetches all disbursements the organization has created. This endpoint supports pagination. The response includes basic aggregations on payments within the disbursement.
+      operationId: ListAllDisbursements
+      parameters:
+        - name: page
+          in: query
+          description: The page requested.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 1
+        - name: page_limit
+          in: query
+          description: Define how many results will be returned in the response.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 20
+        - name: q
+          in: query
+          description: A search term used to query through the disbursement names.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Comma-separated list of disbursement statuses to filter by.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - DRAFT
+              - READY
+              - STARTED
+              - PAUSED
+              - COMPLETED
+          example: DRAFT
+        - name: created_at_after
+          in: query
+          description: 'Only return disbursements that are created after this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: created_at_before
+          in: query
+          description: 'Only return disbursements that are created before this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: sort
+          in: query
+          description: Field used to sort disbursements
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: created_at
+            enum:
+              - name
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting disbursements.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: A list of Disbursement details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DisbursementPagination'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Disbursements
+      summary: Create Disbursement
+      description: 'Creates a new disbursement in  `draft ` state with basic details. Important: a disbursement is not triggered until the organization adds receivers through the Upload Disbursement Instructions endpoint and the status changes from  `draft ` to  `ready `.'
+      operationId: CreateDisbursement
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                wallet_id:
+                  type: string
+                asset_id:
+                  type: string
+                verification_field:
+                  $ref: '#/components/schemas/VerificationField'
+                registration_contact_type:
+                  $ref: '#/components/schemas/RegistrationContactType'
+                receiver_registration_message_template:
+                  type: string
+              example:
+                name: My New Disbursement name
+                wallet_id: e2de8544-b7e2-40a9-ad40-411f70d5c4bf
+                asset_id: d227a68c-2f40-11ee-be56-0242ac120002
+                verification_field: DATE_OF_BIRTH
+                registration_contact_type: PHONE_NUMBER
+                receiver_registration_message_template: You have a payment waiting for you from {{.OrganizationName}}. Click {{.RegistrationLink}} to register.
+        required: false
+      responses:
+        '201':
+          description: A new disbursement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Disbursement'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Bad request
+                  extras:
+                    status: 400
+                    message: Invalid wallet provided
+              example:
+                error: Bad request
+                extras:
+                  status: 400
+                  message: Invalid wallet provided
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /disbursements/{id}:
+    get:
+      tags:
+        - Disbursements
+      summary: Retrieve a Disbursement
+      description: Fetches information on a specific disbursement by  `id `.
+      operationId: RetrieveADisbursement
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Disbursement`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Disbursement details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Disbursement'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not found
+                  extras:
+                    status: 404
+                    message: Disbursement not found
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Disbursement not found
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Disbursements
+      summary: Deletes a Draft Disbursement
+      description: Deletes a Disbursement in Draft or Ready Status by `id`.
+      operationId: DeleteADisbursement
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Disbursement`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Deleted Disbursement details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Disbursement'
+        '400':
+          description: Bad Request, Cannot delete a disbursement that has started
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /disbursements/{id}/receivers:
+    get:
+      tags:
+        - Disbursements
+      summary: List All Disbursement Receivers
+      description: Fetches a list of receivers within a specific disbursement using the disbursement  `id `. This endpoint supports pagination and sorting.
+      operationId: ListAllDisbursementReceivers
+      parameters:
+        - name: id
+          in: path
+          description: ID of the Disbursement
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: The page number to fetch.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 1
+        - name: page_limit
+          in: query
+          description: The number of records to return per page.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 20
+        - name: sort
+          in: query
+          description: Field used to sort receivers
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: updated_at
+            enum:
+              - updated_at
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting receivers.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: A list of Disbursement Receivers
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DisbursementReceiverPagination'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /disbursements/{id}/instructions:
+    get:
+      tags:
+        - Disbursements
+      summary: Download Disbursement Instructions
+      description: Allows an SDP user to download the raw CSV file that was uploaded when creating the disbursement. This will only return results after instructions have been attached to a draft disbursement.
+      operationId: DownloadDisbursementInstructions
+      parameters:
+        - name: id
+          in: path
+          description: ID of the Disbursement
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Disbursement CSV file
+          headers:
+            Content-Disposition:
+              description: The filename of the returned CSV file.
+              style: simple
+              explode: false
+              schema:
+                type: string
+            Content-Type:
+              description: text/csv
+              style: simple
+              explode: false
+              schema:
+                type: string
+          content:
+            text/csv:
+              example: ''
+        '400':
+          description: Bad request, invalid request parameters
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Disbursement Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Disbursements
+      summary: Upload Disbursement Instructions
+      description: Adds a file containing a list of receivers to a  `DRAFT` disbursement. This step is required before a disbursement can begin. The file must be a CSV and has a different possible formats according with the disbursement configuration, and they can be found at [public/resources/disbursementTemplates](https://github.com/stellar/stellar-disbursement-platform-frontend/tree/58873bbf36cff4614e603daf449079b1d9fad24a/public/resources/disbursementTemplates). The operation is idempotent, guaranteed by deleting and recreating the disbursement attributes when this endpoint is called.
+      operationId: UploadDisbursementInstructions
+      parameters:
+        - name: id
+          in: path
+          description: ID of the Disbursement
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              type: object
+              properties:
+                file:
+                  type: string
+                  description: 'Disbursement instructions file to upload. The CSV file columns can vary depending om the way the disbursement was configured, and the fields are a subset of the following: [`phone`, `email`, `id`, `amount`, `verification`, `paymentID`, `walletAddress`]'
+                  format: binary
+        required: true
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                example:
+                  message: File uploaded succesfully
+              example:
+                message: File uploaded succesfully
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      foo:
+                        type: string
+                      message:
+                        type: string
+                example:
+                  error: Invalid file format *.xyz
+                  extras:
+                    foo: bar
+                    message: Not authorized
+              example:
+                error: Invalid file format *.xyz
+                extras:
+                  foo: bar
+                  message: Not authorized
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not found
+                  extras:
+                    status: 404
+                    message: Disbursement not found
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Disbursement not found
+      security:
+        - BearerAuth: []
+  /disbursements/{id}/status:
+    patch:
+      tags:
+        - Disbursements
+      summary: Update a Disbursement Status
+      description: Updates the status of a disbursement according to the state machine. The disbursement must move from  `draft ` to  `ready ` in order to start the disbursement and trigger payments. Payments will start as soon as this endpoint is hit. A disbursement can also be moved into  `paused ` state by an SDP user to prevent further payments from going out and restarted when they are ready.
+      operationId: UpdateADisbursementStatus
+      parameters:
+        - name: id
+          in: path
+          description: ID of the disbursement
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Message Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+              example:
+                message: Disbursement started
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Bad request
+                  extras:
+                    status: 400
+                    message: Disbursement is not ready to be started
+              example:
+                error: Bad request
+                extras:
+                  status: 400
+                  message: Disbursement is not ready to be started
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not found
+                  extras:
+                    status: 404
+                    message: Disbursement not found
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Disbursement not found
+      security:
+        - BearerAuth: []
+  /exports/disbursements:
+    get:
+      tags:
+        - Exports
+      summary: Export Disbursements
+      description: Exports a CSV file of disbursements.
+      operationId: exportDisbursements
+      parameters:
+        - name: q
+          in: query
+          description: A search term used to query through the disbursement names.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Comma-separated list of disbursement statuses to filter by.
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/DisbursementStatus'
+          example: DRAFT
+        - name: created_at_after
+          in: query
+          description: 'Only return disbursements that are created after this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: created_at_before
+          in: query
+          description: 'Only return disbursements that are created before this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: sort
+          in: query
+          description: Field used to sort disbursements
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: created_at
+            enum:
+              - name
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting disbursements.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: CSV file of disbursements
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /exports/payments:
+    get:
+      tags:
+        - Exports
+      summary: Export Payments
+      description: Exports a CSV file of payments.
+      operationId: exportPaymentsCSV
+      parameters:
+        - name: q
+          in: query
+          description: Search payments by ID, external_payment_id, receiver wallet address, or disbursement name.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: Type of payments
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - DIRECT
+              - DISBURSEMENT
+        - name: status
+          in: query
+          description: Exact match on the status of the payment.
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/PaymentStatus'
+          example: DRAFT
+        - name: receiver_id
+          in: query
+          description: UUID that represents a receiver in the database
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: b6b667ad-6cc2-46cf-9be7-561daace7d48
+        - name: created_at_after
+          in: query
+          description: 'Only return payments that are created after this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: created_at_before
+          in: query
+          description: 'Only return payments that are created before this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: sort
+          in: query
+          description: Field used to sort payments.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: updated_at
+            enum:
+              - updated_at
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting payments.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: CSV file of payments
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /exports/receivers:
+    get:
+      tags:
+        - Exports
+      summary: Export Receivers
+      description: Exports a CSV file of receivers.
+      operationId: exportReceiversCSV
+      parameters:
+        - name: q
+          in: query
+          description: A search term used to query through the receiver phone_number, email, and ID.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Exact match on the status of the receiver wallet.
+          required: false
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/ReceiversWalletStatus'
+          example: DRAFT
+        - name: created_at_after
+          in: query
+          description: 'Only return receivers that are created after this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: created_at_before
+          in: query
+          description: 'Only return receivers that are created before this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: sort
+          in: query
+          description: Field used to sort receivers
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: updated_at
+            enum:
+              - updated_at
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting receivers.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: CSV file of receivers
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /payments:
+    get:
+      tags:
+        - Payments
+      summary: List All Payments
+      description: Returns all individual payments matching the request criteria. This endpoint supports pagination, and filtering on payment status, type, receiver ID, and timestamp. Each payment has details on the transaction itself, receiver, disbursement, asset, status history, and blockchain information.
+      operationId: ListAllPayments
+      parameters:
+        - name: page
+          in: query
+          description: The page requested.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 1
+        - name: q
+          in: query
+          description: Search payments by ID, external_payment_id, receiver wallet address, or disbursement name.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: Type of payments
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - DIRECT
+              - DISBURSEMENT
+        - name: page_limit
+          in: query
+          description: Define how many results will be returned in the response.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 20
+        - name: status
+          in: query
+          description: Exact match on the status of the payment.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - DRAFT
+              - READY
+              - PENDING
+              - PAUSED
+              - SUCCESS
+              - FAILED
+              - CANCELED
+          example: DRAFT
+        - name: receiver_id
+          in: query
+          description: UUID that represents a receiver in the database
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: b6b667ad-6cc2-46cf-9be7-561daace7d48
+        - name: created_at_after
+          in: query
+          description: 'Only return payments that are created after this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: created_at_before
+          in: query
+          description: 'Only return payments that are created before this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: sort
+          in: query
+          description: Field used to sort payments
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: updated_at
+            enum:
+              - updated_at
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting payments.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: A paginated list of payments
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentPagination'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Payments
+      summary: Create Direct Payment
+      description: Creates a new direct payment that is immediately sent to the specified receiver if they have a valid registered wallet. Direct payments bypass the disbursement workflow and are processed instantly.
+      operationId: CreateDirectPayment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDirectPaymentRequest'
+        required: true
+      responses:
+        '201':
+          description: Direct payment created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /payments/{id}:
+    get:
+      tags:
+        - Payments
+      summary: Retrieve a Payment
+      description: Fetches detailed information on a specific payment by  `id `.
+      operationId: RetrieveAPayment
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Payment`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Payment details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not found
+                  extras:
+                    status: 404
+                    message: Payment not found
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Payment not found
+      security:
+        - BearerAuth: []
+  /payments/retry:
+    patch:
+      tags:
+        - Payments
+      summary: Retry Payments
+      description: Retries failed payments by ID.
+      operationId: RetryPayments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - payment_ids
+              properties:
+                payment_ids:
+                  type: array
+                  items:
+                    type: string
+            example:
+              payment_ids:
+                - 9f687f8f-1f8f-4c8a-8e0f-1e67ed7c1330
+                - 6c2b9f20-53fd-4f1b-b7e2-9a2b1eb1d7c0
+        required: true
+      responses:
+        '200':
+          description: Payments retried successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+              example:
+                message: Payments retried successfully
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /payments/{id}/status:
+    patch:
+      tags:
+        - Payments
+      summary: Update Payment Status
+      description: Cancels a payment by setting its status to `CANCELED`.
+      operationId: UpdatePaymentStatus
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Payment`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - status
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - CANCELED
+            example:
+              status: CANCELED
+        required: true
+      responses:
+        '200':
+          description: Payment updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+              example:
+                message: Payment canceled
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /receivers/verification-types:
+    get:
+      tags:
+        - Receivers
+      summary: List Verification Types
+      description: Returns the supported receiver verification types.
+      operationId: ListReceiverVerificationTypes
+      responses:
+        '200':
+          description: A list of verification types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VerificationField'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /receivers:
+    get:
+      tags:
+        - Receivers
+      summary: List All Receivers
+      description: Returns all receivers matching the request criteria. This endpoint supports pagination and filtering on receiver status, receiver attributes, and timestamp. Each payment has details on the receiver, high-level payments metrics, and wallets associated with the receiver.
+      operationId: ListAllReceivers
+      parameters:
+        - name: page
+          in: query
+          description: The page requested.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 1
+        - name: page_limit
+          in: query
+          description: Define how many results will be returned in the response.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: number
+            default: 20
+        - name: q
+          in: query
+          description: A search term used to query through the receiver phone_number, email, and ID.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Exact match on the status of the receiver wallet.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            enum:
+              - DRAFT
+              - READY
+              - REGISTERED
+              - FLAGGED
+          example: DRAFT
+        - name: created_at_after
+          in: query
+          description: 'Only return receivers that are created after this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: created_at_before
+          in: query
+          description: 'Only return receivers that are created before this date. Format: YYYY-MM-DD'
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+          example: '2006-01-02'
+        - name: sort
+          in: query
+          description: Field used to sort receivers
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: updated_at
+            enum:
+              - updated_at
+              - created_at
+        - name: direction
+          in: query
+          description: Direction for sorting receivers.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+            default: desc
+            enum:
+              - asc
+              - desc
+      responses:
+        '200':
+          description: A paginated list of Receiver details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiverPagination'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Receivers
+      summary: Create Receiver
+      description: Creates a new Receiver. Allows clients to create a single receiver record, which can later be referenced in payments or disbursements.
+      operationId: CreateReceiver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReceiverRequest'
+        required: true
+      responses:
+        '201':
+          description: Receiver created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Receiver'
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '409':
+          description: Conflict - receiver already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+      security:
+        - BearerAuth: []
+  /receivers/{id}:
+    get:
+      tags:
+        - Receivers
+      summary: Retrieve a Receiver
+      description: Fetches detailed information on a specific receiver by  `id `, including all associated wallets.
+      operationId: RetrieveAReceiver
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Receiver`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Receiver Details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Receiver'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Resource not found
+      security:
+        - BearerAuth: []
+    patch:
+      tags:
+        - Receivers
+      summary: Update a Receiver
+      description: This endpoint allows an organization to add and update information on the receiver, including email address, external ID, date of birth, personal PIN, and national ID number. The response includes all information on the receiver.
+      operationId: UpdateReceiver
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Receiver`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        description: List of fields to patch for the receiver
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/PatchReceiverRequest'
+        required: true
+      responses:
+        '200':
+          description: Updated Receiver Details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Receiver'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Resource not found
+        '409':
+          description: Conflicting phone number or email
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+              example:
+                error: The provided email is already associated with another user.
+                extras:
+                  email: email must be unique
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /receivers/{receiver_id}/wallets/{receiver_wallet_id}:
+    patch:
+      tags:
+        - Receivers
+      summary: Update Receiver Wallet
+      description: Updates a receiver wallet's Stellar address and memo for user-managed wallets.
+      operationId: UpdateReceiverWallet
+      parameters:
+        - name: receiver_id
+          in: path
+          description: ID of the `Receiver`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: receiver_wallet_id
+          in: path
+          description: ID of the receiver wallet.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - stellar_address
+              properties:
+                stellar_address:
+                  type: string
+                  description: Stellar account or contract address for the receiver wallet.
+                stellar_memo:
+                  type: string
+                  description: Optional memo for the Stellar address.
+            example:
+              stellar_address: GCXAJ3XJ3VK3JFH3QMDFOSKM2NMMZBSO3VIT6EUPQWSDW2J74M23RRSL
+              stellar_memo: '12345'
+        required: true
+      responses:
+        '200':
+          description: Receiver wallet updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReceiverWallet'
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /receivers/wallets/{receiver_wallet_id}/status:
+    patch:
+      tags:
+        - Receivers
+      summary: Update Receiver Wallet Status
+      description: Updates a receiver wallet's status. Only `READY` is supported.
+      operationId: UpdateReceiverWalletStatus
+      parameters:
+        - name: receiver_wallet_id
+          in: path
+          description: ID of the receiver wallet.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - status
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - READY
+            example:
+              status: READY
+        required: true
+      responses:
+        '200':
+          description: Receiver wallet status updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /registration-contact-types:
+    get:
+      tags:
+        - Disbursements
+      summary: List Registration Contact Types
+      description: Returns the supported registration contact types for disbursement instructions.
+      operationId: ListRegistrationContactTypes
+      responses:
+        '200':
+          description: A list of registration contact types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RegistrationContactType'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /statistics:
+    get:
+      tags:
+        - Statistics
+      summary: Retrieve All Statistics
+      description: Fetches all metrics on all disbursements the organization has created. The response includes basic aggregations on payments, receivers, receiver wallets, and assets.
+      operationId: RetrieveAllStatistics
+      responses:
+        '200':
+          description: General Statistics response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralStatistics'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - BearerAuth: []
+  /statistics/{id}:
+    get:
+      tags:
+        - Statistics
+      summary: Retrieve Disbursement Statistics
+      description: Fetches metrics on a specific disbursement by  `id `.
+      operationId: RetrieveDisbursementStatistics
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Disbursement`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Returns statistics for disbursement
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DisbursementsStatistics'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+  /sep24-interactive-deposit/info:
+    get:
+      tags:
+        - Registration
+      summary: Get Receiver Registration Info
+      description: Returns the registration context for the receiver, including organization details and reCAPTCHA configuration.
+      operationId: GetReceiverRegistrationInfo
+      responses:
+        '200':
+          description: Registration context
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  privacy_policy_link:
+                    type: string
+                  organization_name:
+                    type: string
+                  organization_logo:
+                    type: string
+                  truncated_contact_info:
+                    type: string
+                  is_registered:
+                    type: boolean
+                  is_recaptcha_disabled:
+                    type: boolean
+                  recaptcha_site_key:
+                    type: string
+              example:
+                privacy_policy_link: https://example.com/privacy
+                organization_name: Stellar Aid
+                organization_logo: https://example.com/logo.png
+                truncated_contact_info: '******1234'
+                is_registered: false
+                is_recaptcha_disabled: false
+                recaptcha_site_key: 6Lc...site_key
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+      security:
+        - SEP24Auth: []
+  /sep24-interactive-deposit/otp:
+    post:
+      tags:
+        - Registration
+      summary: Send One-Time Passcode
+      description: This endpoint generates a 6-digit OTP and sends it to the user contact (email or phone number SMS) provided in the request body, as long as it matches the receiver contact info stored in the SDP. A valid SEP-24 token should be included in this request's Authorization header.
+      operationId: SendOneTimePasscode
+      requestBody:
+        description: Object containing phone number
+        content:
+          application/json:
+            schema:
+              required:
+                - recaptcha_token
+              type: object
+              properties:
+                phone_number:
+                  type: string
+                  description: Phone number to which the OTP will be sent. Either `phone_number` or `email` is required.
+                email:
+                  type: string
+                  description: Email to which the OTP will be sent. Either `phone_number` or `email` is required.
+                recaptcha_token:
+                  type: string
+                  description: Token for reCAPTCHA validation (required unless reCAPTCHA is disabled).
+        required: true
+      responses:
+        '200':
+          description: OTP sent successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  verification_field:
+                    $ref: '#/components/schemas/VerificationField'
+              example:
+                message: if your phone number is registered, you'll receive an OTP
+                verification_field: DATE_OF_BIRTH
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - SEP24Auth: []
+      x-codegen-request-body-name: body
+  /sep24-interactive-deposit/verification:
+    post:
+      tags:
+        - Registration
+      summary: Verify Receiver Registration
+      description: This endpoint verifies the receiver's registration by validating the OTP and other verification values provided in the request body. A valid SEP-24 token should be included in the Authorization header of the request.
+      operationId: VerifyReceiverRegistration
+      requestBody:
+        description: Verification data including phone_number/email, OTP, verification value, and reCAPTCHA token
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReceiverRegistrationRequest'
+        required: true
+      responses:
+        '200':
+          description: Verification successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: ok
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - SEP24Auth: []
+      x-codegen-request-body-name: body
+  /wallet-registration/start:
+    get:
+      tags:
+        - Registration
+      summary: Start Wallet Registration
+      description: Serves the SEP-24 interactive registration UI.
+      operationId: StartWalletRegistration
+      parameters:
+        - name: token
+          in: query
+          description: SEP-24 token for authorization.
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: transaction_id
+          in: query
+          description: SEP-24 transaction ID.
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: lang
+          in: query
+          description: Optional language override for the webview.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: HTML webview for receiver registration.
+          content:
+            text/html:
+              schema:
+                type: string
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+      security:
+        - SEP24QueryAuth: []
+  /.well-known/stellar.toml:
+    get:
+      tags:
+        - Registration
+      summary: Retrieve Stellar Info File
+      description: Allows the wallet to fetch the SEP-10 server url, SEP-10 signing public key and SEP-24 server url.
+      operationId: RetrieveStellarInfoFile
+      responses:
+        '200':
+          description: Token is valid and the webpage will be loaded normally.
+          content:
+            text/toml:
+              example: |
+                ACCOUNTS=["GBC2HVWFIFN7WJHFORVBCDKJORXXXXXXXXXXXXXXXXXXXXXXXX", "GDA34JZ26FZY64XCSY46CUNSHLX762LHJXQXXXXXXXXXXXXXXXXXXXXXXXX"] SIGNING_KEY="GDA34JZ26FZY64XCSY46XXXXXXXXXXXXXXXXXXXXXXXX" NETWORK_PASSPHRASE="Test SDF Network ; September 2015" HORIZON_URL="https://horizon-testnet.stellar.org" WEB_AUTH_ENDPOINT="https://ap-stellar-disbursement-platform-backend-dev.stellar.org/sep10/auth" TRANSFER_SERVER_SEP0024="https://ap-stellar-disbursement-platform-backend-dev.stellar.org/sep24"
+                [[DOCUMENTATION]] ORG_NAME="Stellar Aid"
+                [[CURRENCIES]] code = "EUROC" issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" is_asset_anchored = true anchor_asset_type = "fiat" status = "live" desc = "EUROC"
+                [[CURRENCIES]] code = "USDC" issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5" is_asset_anchored = true anchor_asset_type = "fiat" status = "live" desc = "USDC"
+  /sep10/auth:
+    get:
+      tags:
+        - Registration
+      summary: Request Challenge Transaction
+      description: Allows the wallet to get the SEP-10 challenge transaction to be signed. More information [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#challenge). The endpoint url can change but is provided in the Get Stellar toml endpoint response under the `WEB_AUTH_ENDPOINT` variable.
+      operationId: RequestChallengeTransaction
+      parameters:
+        - name: account
+          in: query
+          description: The client account (G...) that the client wishes to authenticate with the server.
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: memo
+          in: query
+          description: The memo to attach to the challenge transaction. Only permitted if a Stellar account (G...) is used. The memo must be of type id. Other memo types are not supported.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: home_domain
+          in: query
+          description: Home domain for SEP-10. Defaults to the server base domain if omitted.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: client_domain
+          in: query
+          description: Client domain for wallet attribution. Required when SEP-10 client attribution is enabled (default).
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transaction:
+                    type: string
+                  network_passphrase:
+                    type: string
+                example:
+                  transaction: AAAAAgAAAADIiRu2BrqqeOcP28PWCkD4D5Rjjsqh71HwvqFX+F4VXAAAAGQAAAAAAAAAAAAAAAEAAAAAXzrUcQAAAABfOtf1AAAAAAAAAAEAAAABAAAAAEEB8rhqNa70RYjaNnF1ARE2CbL50iR9HPXST/fImJN1AAAACgAAADB0aGlzaXNhdGVzdC5zYW5kYm94LmFuY2hvci5hbmNob3Jkb21haW4uY29tIGF1dGgAAAABAAAAQGdGOFlIQm1zaGpEWEY0L0VJUFZucGVlRkxVTDY2V0tKMVBPYXZuUVVBNjBoL09XaC91M2Vvdk54WFJtSTAvQ2UAAAAAAAAAAfheFVwAAABAheKE1HjGnUCNwPbX8mz7CqotShKbA+xM2Hbjl6X0TBpEprVOUVjA6lqMJ1j62vrxn1mF3eJzsLa9s9hRofG3Ag==
+                  network_passphrase: Test SDF Network ; September 2015
+              example:
+                transaction: AAAAAgAAAADIiRu2BrqqeOcP28PWCkD4D5Rjjsqh71HwvqFX+F4VXAAAAGQAAAAAAAAAAAAAAAEAAAAAXzrUcQAAAABfOtf1AAAAAAAAAAEAAAABAAAAAEEB8rhqNa70RYjaNnF1ARE2CbL50iR9HPXST/fImJN1AAAACgAAADB0aGlzaXNhdGVzdC5zYW5kYm94LmFuY2hvci5hbmNob3Jkb21haW4uY29tIGF1dGgAAAABAAAAQGdGOFlIQm1zaGpEWEY0L0VJUFZucGVlRkxVTDY2V0tKMVBPYXZuUVVBNjBoL09XaC91M2Vvdk54WFJtSTAvQ2UAAAAAAAAAAfheFVwAAABAheKE1HjGnUCNwPbX8mz7CqotShKbA+xM2Hbjl6X0TBpEprVOUVjA6lqMJ1j62vrxn1mF3eJzsLa9s9hRofG3Ag==
+                network_passphrase: Test SDF Network ; September 2015
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+    post:
+      tags:
+        - Registration
+      summary: Provide Signed Challenge Transaction
+      description: Allows the wallet to post the signed SEP-10 challenge transaction. More information     [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#challenge). The endpoint url can change but is provided in the toml file under the  `WEB_AUTH_ENDPOINT ` variable.
+      operationId: ProvideSignedChallengeTransaction
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                transaction:
+                  type: string
+            example:
+              transaction: AAAAAgAAAADIiRu2BrqqeOcP28PWCkD4D5Rjjsqh71HwvqFX+F4VXAAAAGQAAAAAAAAAAAAAAAEAAAAAXzrUcQAAAABfOtf1AAAAAAAAAAEAAAABAAAAAEEB8rhqNa70RYjaNnF1ARE2CbL50iR9HPXST/fImJN1AAAACgAAADB0aGlzaXNhdGVzdC5zYW5kYm94LmFuY2hvci5hbmNob3Jkb21haW4uY29tIGF1dGgAAAABAAAAQGdGOFlIQm1zaGpEWEY0L0VJUFZucGVlRkxVTDY2V0tKMVBPYXZuUVVBNjBoL09XaC91M2Vvdk54WFJtSTAvQ2UAAAAAAAAAAvheFVwAAABAheKE1HjGnUCNwPbX8mz7CqotShKbA+xM2Hbjl6X0TBpEprVOUVjA6lqMJ1j62vrxn1mF3eJzsLa9s9hRofG3AsiYk3UAAABArIrkvqmA0V9lIZcVyCUdja6CiwkPwsV8BfI4CZOyR1Oq7ysvNJWwY0G42dpxN9OP1qz4dum8apG2hqvxVWjkDQ==
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                transaction:
+                  type: string
+              example:
+                transaction: AAAAAgAAAADIiRu2BrqqeOcP28PWCkD4D5Rjjsqh71HwvqFX+F4VXAAAAGQAAAAAAAAAAAAAAAEAAAAAXzrUcQAAAABfOtf1AAAAAAAAAAEAAAABAAAAAEEB8rhqNa70RYjaNnF1ARE2CbL50iR9HPXST/fImJN1AAAACgAAADB0aGlzaXNhdGVzdC5zYW5kYm94LmFuY2hvci5hbmNob3Jkb21haW4uY29tIGF1dGgAAAABAAAAQGdGOFlIQm1zaGpEWEY0L0VJUFZucGVlRkxVTDY2V0tKMVBPYXZuUVVBNjBoL09XaC91M2Vvdk54WFJtSTAvQ2UAAAAAAAAAAvheFVwAAABAheKE1HjGnUCNwPbX8mz7CqotShKbA+xM2Hbjl6X0TBpEprVOUVjA6lqMJ1j62vrxn1mF3eJzsLa9s9hRofG3AsiYk3UAAABArIrkvqmA0V9lIZcVyCUdja6CiwkPwsV8BfI4CZOyR1Oq7ysvNJWwY0G42dpxN9OP1qz4dum8apG2hqvxVWjkDQ==
+        required: true
+      responses:
+        '200':
+          description: SEP-10 handshake was successful.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                example:
+                  token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQTZVSVhYUEVXWUZJTE5VSVdBQzM3WTRRUEVaTVFWREpIREtWV0ZaSjJLQ1dVQklVNUlYWk5EQSIsImp0aSI6IjE0NGQzNjdiY2IwZTcyY2FiZmRiZGU2MGVhZTBhZDczM2NjNjVkMmE2NTg3MDgzZGFiM2Q2MTZmODg1MTkwMjQiLCJpc3MiOiJodHRwczovL2ZsYXBweS1iaXJkLWRhcHAuZmlyZWJhc2VhcHAuY29tLyIsImlhdCI6MTUzNDI1Nzk5NCwiZXhwIjoxNTM0MzQ0Mzk0fQ.8nbB83Z6vGBgC1X9r3N6oQCFTBzDiITAfCJasRft0z0
+              example:
+                token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJHQTZVSVhYUEVXWUZJTE5VSVdBQzM3WTRRUEVaTVFWREpIREtWV0ZaSjJLQ1dVQklVNUlYWk5EQSIsImp0aSI6IjE0NGQzNjdiY2IwZTcyY2FiZmRiZGU2MGVhZTBhZDczM2NjNjVkMmE2NTg3MDgzZGFiM2Q2MTZmODg1MTkwMjQiLCJpc3MiOiJodHRwczovL2ZsYXBweS1iaXJkLWRhcHAuZmlyZWJhc2VhcHAuY29tLyIsImlhdCI6MTUzNDI1Nzk5NCwiZXhwIjoxNTM0MzQ0Mzk0fQ.8nbB83Z6vGBgC1X9r3N6oQCFTBzDiITAfCJasRft0z0
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+      x-codegen-request-body-name: body
+  /sep24/info:
+    get:
+      tags:
+        - Registration
+      summary: SEP-24 Info
+      description: Returns supported assets and feature flags for SEP-24 registration deposits.
+      operationId: GetSEP24Info
+      responses:
+        '200':
+          description: SEP-24 info response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deposit:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                        min_amount:
+                          type: number
+                        max_amount:
+                          type: number
+                  withdraw:
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                        min_amount:
+                          type: number
+                        max_amount:
+                          type: number
+                  fee:
+                    type: object
+                    properties:
+                      enabled:
+                        type: boolean
+                  features:
+                    type: object
+                    properties:
+                      account_creation:
+                        type: boolean
+                      claimable_balances:
+                        type: boolean
+  /sep24/transactions/deposit/interactive:
+    post:
+      tags:
+        - Registration
+      summary: Request Registration URL
+      description: |
+        The deposit endpoint allows a wallet to get deposit information from an anchor,  so a user has all the information needed to initiate a deposit.
+
+        It also lets the anchor specify additional information that the user must submit interactively via a popup or embedded browser window to be able to deposit. Please check the detailed documentation [here](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#deposit-2).
+      operationId: RequestRegistrationURL
+      externalDocs:
+        description: Find more info here
+        url: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#deposit-2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - asset_code
+              properties:
+                asset_code:
+                  type: string
+                  description: Stellar asset code for the deposit.
+                account:
+                  type: string
+                  description: Stellar account for the deposit; defaults to the SEP-10 subject.
+                lang:
+                  type: string
+                  description: Language for the interactive flow.
+                claimable_balance_supported:
+                  type: string
+                  description: Indicates if claimable balances are supported.
+            example:
+              asset_code: USDC
+              account: GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
+              lang: en
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - asset_code
+              properties:
+                asset_code:
+                  type: string
+                  description: Stellar asset code for the deposit.
+                account:
+                  type: string
+                  description: Stellar account for the deposit; defaults to the SEP-10 subject.
+                lang:
+                  type: string
+                  description: Language for the interactive flow.
+                claimable_balance_supported:
+                  type: string
+                  description: Indicates if claimable balances are supported.
+            example:
+              asset_code: USDC
+              account: GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
+              lang: en
+        required: false
+      responses:
+        '200':
+          description: An anchor requires the user to fill out information on a webpage hosted by the anchor.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    description: Always set to interactive_customer_info_needed.
+                    example: interactive_customer_info_needed
+                  url:
+                    type: string
+                    description: URL hosted by the anchor. The wallet should show this URL to the user as a popup.
+                    example: https://api.example.com/kycflow?account=GACW7NONV43MZIFHCOKCQJAKSJSISSICFVUJ2C6EZIW5773OU3HD64VI
+                  id:
+                    type: string
+                    description: The anchor's internal ID for this deposit / withdrawal request. The wallet will use this ID to query the /transaction endpoint to check status of the request.
+                    example: 82fhs729f63dh0v4
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+      security:
+        - SEP10Auth: []
+  /profile:
+    get:
+      tags:
+        - Profile
+      summary: Get Profile
+      description: Fetches the individual information of the logged in user to populate the Profile page.
+      operationId: GetProfile
+      responses:
+        '200':
+          description: Returns user profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+      security:
+        - BearerAuth: []
+    patch:
+      tags:
+        - Profile
+      summary: Update User Profile
+      description: 'Updates the profile details of the logged in user. Note: all fields are optional but at least one should be sent in the request.'
+      operationId: UpdateUserProfile
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                email:
+                  type: string
+              example:
+                first_name: FirstName
+                last_name: LastName
+                email: email@email.com
+        required: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+              example:
+                message: user profile updated successfully
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+  /profile/reset-password:
+    patch:
+      tags:
+        - Profile
+      summary: Reset Password
+      description: Updates the password for the logged in user.
+      operationId: ResetUserPassword
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - current_password
+                - new_password
+              properties:
+                current_password:
+                  type: string
+                new_password:
+                  type: string
+            example:
+              current_password: currentPassword123!
+              new_password: newPassword123!
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+              example:
+                message: user password updated successfully
+        '400':
+          description: Bad Request
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /organization:
+    get:
+      tags:
+        - Organization
+      summary: Get Organization Info
+      description: This endpoint returns the organization's info. It is used in many places across the UI. It returns the name in the navbar and the public key of the organization’s distribution account.
+      operationId: GetOrganizationInfo
+      responses:
+        '200':
+          description: Returns organization details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Organization'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - BearerAuth: []
+    patch:
+      tags:
+        - Organization
+      summary: Update Organization Profile
+      description: 'Updates the organization profile details. Only account owners have permission to do this. Note: both fields are optional but at least one should be sent in the request. It is not necessary to set the header Content-Type for this request. It is set automatically by the HTTP client.'
+      operationId: UpdateOrganizationProfile
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                logo:
+                  type: string
+                  description: The logo of the organization, file type must be png or jpeg.
+                  format: binary
+                data:
+                  type: string
+                  description: |
+                    A JSON string that contains the details to update. Contains the following keys:  `organization_name` (string): the new name of the organization, `timezone_utc_offset` (string): the new timezone offset of the organization, `is_approval_required` (boolean): whether the approval workflow is enabled or not. `receiver_registration_message_template` (string): the message template sent to the receivers inviting them to registration. Sending this field empty sets the `default` value for it. `otp_message_template` (string): the message template sent to the receivers sending the OTP to complete the registration flow. Sending this field empty sets the `default` value for it. For example: '{"organization_name": "NewOrgName", "timezone_utc_offset": "+02:00", "is_approval_required": true, "receiver_registration_message_template": "You have a payment waiting for you from {{.OrganizationName}}. Click {{.RegistrationLink}} to register.", "otp_message_template": "{{.OTP}} is your {{.OrganizationName}} phone verification code."}'
+                  format: json
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+              example:
+                message: organization profile updated successfully
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+  /organization/logo:
+    get:
+      tags:
+        - Organization
+      summary: Retrieve Organization Logo
+      description: Retrieves the logo of the organization for display in the UI navbar.
+      operationId: GetOrganizationLogo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  /organization/circle-config:
+    patch:
+      tags:
+        - Organization
+      summary: Circle Account Setup
+      description: 'Updates the Circle configuration for the organization. Only account owners have permission to do this. Note: in the first time configuration, all fields are mandatory, but after it is been configured at least once, you can replace a single field at a time.'
+      operationId: PatchOrganizationCircle
+      requestBody:
+        description: Circle configuration to be updated
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                api_key:
+                  type: string
+                  description: The Circle API key with permissions to POST & GET transfers
+                wallet_id:
+                  type: string
+                  description: The ID of the Circle walet from where the funds will be sent
+        required: true
+      responses:
+        '200':
+          description: Circle configuration updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Circle configuration updated
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /balances:
+    get:
+      tags:
+        - Balances
+      summary: Get Organization (Circle) Balances
+      description: ATTENTION, this endpoint is only enabled when the tenant distribution account type is `CIRCLE`.
+      operationId: GetOrganization(Circle)Balances
+      responses:
+        '200':
+          description: Returns the organization's Circle balances
+          content:
+            application/json:
+              schema:
+                required:
+                  - account
+                  - balances
+                type: object
+                properties:
+                  account:
+                    $ref: '#/components/schemas/DistributionAccount'
+                  balances:
+                    type: array
+                    description: The organization's Circle balances
+                    items:
+                      $ref: '#/components/schemas/Balance'
+        '400':
+          description: Bad request, not supported when the distribution account is not of the CIRCLE type.
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - BearerAuth: []
+  /assets:
+    get:
+      tags:
+        - Organization
+      summary: Get All Assets
+      description: 'Fetches the list of available assets to populate the dropdown box in the New Disbursement flow. Note: the organization must hold a balance in a particular asset to use it in a disbursement.'
+      operationId: GetAllAssets
+      responses:
+        '200':
+          description: A list of assets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Asset'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Organization
+      summary: Create Asset
+      description: 'This endpoint is used to create a new asset that can be used in a Disbursement. Note: the organization must hold a balance in a particular asset to use it in a disbursement.'
+      operationId: CreateAsset
+      requestBody:
+        description: Asset to be created
+        content:
+          application/json:
+            schema:
+              required:
+                - code
+                - issuer
+              type: object
+              properties:
+                code:
+                  type: string
+                  description: The asset code
+                  example: USDC
+                issuer:
+                  type: string
+                  description: The issuer
+                  example: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+        required: true
+      responses:
+        '201':
+          description: Asset created successfully
+          content: {}
+        '400':
+          description: Bad request, invalid request body or the provided code/issuer is invalid.
+          content: {}
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /assets/{id}:
+    delete:
+      tags:
+        - Organization
+      summary: Delete Asset
+      description: This endpoint is used to soft delete an asset.
+      operationId: DeleteAsset
+      parameters:
+        - name: id
+          in: path
+          description: ID of the asset to delete
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Asset deleted successfully
+          content: {}
+        '204':
+          description: Asset already deleted
+          content: {}
+        '404':
+          description: Asset not found
+          content: {}
+      security:
+        - BearerAuth: []
+  /wallets:
+    get:
+      tags:
+        - Wallets
+      summary: Get All Wallets
+      description: Fetches the list of available wallet providers to populate the dropdown box in the New Disbursement flow. The organization should coordinate with the wallet provider before selecting a particular wallet provider for a disbursement. By default, soft-deleted wallets are excluded from the response. Use the `include_deleted` parameter to include them.
+      operationId: GetAllWallets
+      parameters:
+        - name: include_deleted
+          in: query
+          description: When set to `true`, includes soft-deleted wallets in the response. When `false` or omitted, only non-deleted wallets are returned.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: boolean
+            default: false
+        - name: enabled
+          in: query
+          description: Filter wallets by enabled/disabled status.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: boolean
+        - name: user_managed
+          in: query
+          description: Filter by user-managed wallets.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: boolean
+        - name: supported_assets
+          in: query
+          description: Comma-separated list of asset codes or IDs to filter wallets by supported assets (max 20).
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A list of wallets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Wallet'
+        '400':
+          description: Bad request - validation errors
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Wallets
+      summary: Create Wallet
+      description: Creates a new wallet provider that can be used for disbursements. The wallet must be configured with supported assets and proper authentication domains.
+      operationId: CreateWallet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWalletRequest'
+        required: true
+      responses:
+        '201':
+          description: Wallet created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Wallet'
+        '400':
+          description: Bad request - validation errors
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '409':
+          description: Conflict - wallet name, homepage, or deep link schema already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+      security:
+        - BearerAuth: []
+  /wallets/{id}:
+    patch:
+      tags:
+        - Wallets
+      summary: Update Wallet
+      description: 'This endpoint is used to enable or disable a wallet provider. Note: the organization should coordinate with the wallet provider before selecting a particular wallet provider for a disbursement.'
+      operationId: UpdateWallet
+      parameters:
+        - name: id
+          in: path
+          description: ID of the wallet to update
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        description: Wallet to be updated
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateWalletRequest'
+        required: true
+      responses:
+        '200':
+          description: Wallet updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Wallet'
+        '400':
+          description: Bad request, usually caused by the `enabled` field missing from the request body.
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Wallet not found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Wallets
+      summary: Delete Wallet
+      description: Soft deletes a wallet provider.
+      operationId: DeleteWallet
+      parameters:
+        - name: id
+          in: path
+          description: ID of the wallet to delete
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Wallet deleted successfully
+          content: {}
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Wallet not found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+  /users:
+    get:
+      tags:
+        - Users
+      summary: Get All Users
+      description: Fetches all SDP users within the organization, whether they are active yet or not.
+      operationId: GetAllUsers
+      responses:
+        '200':
+          description: Returns a paginated list of User Details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Users'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Users
+      summary: Create User
+      description: This endpoint creates a new SDP user as the result of an SDP owner adding their information in the UI. It also handles sending the invite email.
+      operationId: CreateUser
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                first_name:
+                  type: string
+                last_name:
+                  type: string
+                roles:
+                  type: array
+                  items:
+                    type: string
+                email:
+                  type: string
+              example:
+                first_name: John
+                last_name: Doe
+                roles:
+                  - business
+                email: email@email.com
+        required: false
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /users/activation:
+    patch:
+      tags:
+        - Users
+      summary: Update User Activation Status
+      description: Updates the SDP user’s activation status. This endpoint is primarily used to move a user into active status when they accept the invite to join an SDP organization account and create a password.
+      operationId: UpdateUserActivationStatus
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                is_active:
+                  type: boolean
+              example:
+                user_id: 5ca230c9-da95-4bd1-b2a2-aa5d0df65efd
+                is_active: false
+        required: false
+      responses:
+        '200':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              example:
+                message: user activation was updated successfully
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /users/roles:
+    get:
+      tags:
+        - Users
+      summary: Get All Roles
+      description: Fetches available SDP roles, such as owner, financial controller, business user, and developer.
+      operationId: GetAllRoles
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      type: string
+                example:
+                  roles:
+                    - developer
+                    - financial_controller
+                    - business
+                    - owner
+              example:
+                roles:
+                  - developer
+                  - financial_controller
+                  - business
+                  - owner
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+    patch:
+      tags:
+        - Users
+      summary: Update User Role
+      description: Updates an SDP user’s role by  `user_ID `.
+      operationId: UpdateUserRole
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                roles:
+                  type: array
+                  items:
+                    type: string
+              example:
+                user_id: 5ca230c9-da95-4bd1-b2a2-aa5d0df65efd
+                roles:
+                  - developer
+        required: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                example:
+                  message: user roles were updated successfully
+              example:
+                message: user roles were updated successfully
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BearerAuth: []
+      x-codegen-request-body-name: body
+  /tenants:
+    get:
+      tags:
+        - Admin
+      summary: Get All Tenants
+      operationId: GetAllTenants
+      responses:
+        '200':
+          description: A list of provisioned tenants with their configurations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenants'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - BasicAuth: []
+    post:
+      tags:
+        - Admin
+      summary: Create Tenant
+      operationId: CreateTenant
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              required:
+                - distribution_account_type
+                - name
+                - organization_name
+                - owner_email
+                - owner_first_name
+                - owner_last_name
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The tenant name. It should match the pattern `^[a-z-]+$`
+                distribution_account_type:
+                  type: string
+                  description: The distribution account type of the tenant.
+                  enum:
+                    - DISTRIBUTION_ACCOUNT.STELLAR.ENV
+                    - DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT
+                    - DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT
+                owner_email:
+                  type: string
+                  description: The owner user e-mail address
+                owner_first_name:
+                  type: string
+                  description: The owner user first name
+                owner_last_name:
+                  type: string
+                  description: The owner user last name
+                organization_name:
+                  type: string
+                  description: The organization name
+                base_url:
+                  type: string
+                  description: The SDP backend server's base URL. If this field is not provided, the SDP will generate one based on the host `BASE_URL` configuration, and the tenant name.
+                sdp_ui_base_url:
+                  type: string
+                  description: The SDP UI/dashboard Base URL. If this field is not provided, the SDP will generate one based on the host `SDP_UI_BASE_URL` configuration, and the tenant name.
+              example:
+                name: redcorp
+                distribution_account_type: DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT
+                owner_email: owner@redcorp.org
+                owner_first_name: Owner
+                owner_last_name: Last
+                organization_name: Red Corp
+                base_url: https://redcorp-backend.sdp.org
+                sdp_ui_base_url: https://redcorp.sdp.org
+        required: false
+      responses:
+        '201':
+          description: Provision a new tenant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+      security:
+        - BasicAuth: []
+      x-codegen-request-body-name: body
+  /tenants/{id}:
+    get:
+      tags:
+        - Admin
+      summary: Retrieve a Tenant
+      operationId: RetrieveATenant
+      parameters:
+        - name: id
+          in: path
+          description: ID or Name of the `Tenant`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Tenant details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Resource not found
+      security:
+        - BasicAuth: []
+    delete:
+      tags:
+        - Admin
+      summary: Soft delete a Tenant
+      operationId: SoftDeleteATenant
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Tenant`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Deleted Tenant details, with a non-empty `deleted_at` field
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
+        '304':
+          description: The tenant was already deleted before this request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Bad request, when the tenant is not elligible to be deleted. For example, when the tenant is the default tenant or when it has not been patched with the deactivated status.
+          $ref: '#/components/responses/BadRequestResponse'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Resource not found
+      security:
+        - BasicAuth: []
+    patch:
+      tags:
+        - Admin
+      summary: Update a Tenant
+      description: This endpoint updates the Tenant data.
+      operationId: UpdateATenant
+      parameters:
+        - name: id
+          in: path
+          description: ID of the `Tenant`.
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        description: List of fields to update for the tenant
+        content:
+          '*/*':
+            schema:
+              type: object
+              properties:
+                base_url:
+                  type: string
+                  description: The SDP backend server's base URL.
+                sdp_ui_base_url:
+                  type: string
+                  description: The SDP UI/dashboard Base URL.
+                status:
+                  type: string
+                  enum:
+                    - TENANT_CREATED
+                    - TENANT_PROVISIONED
+                    - TENANT_ACTIVATED
+                    - TENANT_DEACTIVATED
+        required: true
+      responses:
+        '200':
+          description: Updated Tenant details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Details about the error
+                  extras:
+                    type: object
+                    properties: {}
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+              example:
+                error: Not found
+                extras:
+                  status: 404
+                  message: Resource not found
+      security:
+        - BasicAuth: []
+      x-codegen-request-body-name: body
+  /tenants/default-tenant:
+    post:
+      tags:
+        - Admin
+      summary: Default Tenant
+      description: |
+        Sets the tenant specified in the request body as the default one, resolving all the incoming API request to that tenant when the env `SINGLE_TENANT_MODE` is set to true. Once set, the default tenant can be overwritten but never unset, although it is only effective when `SINGLE_TENANT_MODE` is set to true.
+
+        Default tenant is useful for development purposes or when the SDP is used by a single organization. This allows the organization to skip specifying the tenant in every request and simplifies the SDP setup operationally by removing the need of providing wildcard TLS certificates for multi-tenant configurations.
+      operationId: DefaultTenant
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              required:
+                - id
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: The tenant id.
+              example:
+                id: 1736bed3-7b92-4760-8ff2-51fb08ee079f
+        required: false
+      responses:
+        '201':
+          description: Default tenant details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tenant'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  extras:
+                    type: object
+                    properties:
+                      status:
+                        type: number
+                      message:
+                        type: string
+                example:
+                  error: Not authorized
+                  extras:
+                    status: 401
+                    message: Not authorized
+              example:
+                error: Not authorized
+                extras:
+                  status: 401
+                  message: Not authorized
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                example:
+                  error: Forbidden
+              example:
+                error: Forbidden
+      security:
+        - BasicAuth: []
+      x-codegen-request-body-name: body
+  /bridge-integration:
+    get:
+      summary: Get Bridge Integration Status
+      description: |
+        Retrieves the current Bridge integration status and information for the organization.
+        Returns live data from the Bridge API including KYC status and virtual account details.
+      operationId: getBridgeIntegration
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Bridge integration status retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BridgeIntegrationInfo'
+              examples:
+                not_enabled:
+                  summary: Bridge service not enabled
+                  value:
+                    status: NOT_ENABLED
+                not_opted_in:
+                  summary: Organization not opted in
+                  value:
+                    status: NOT_OPTED_IN
+                opted_in:
+                  summary: Organization opted in, KYC pending
+                  value:
+                    status: OPTED_IN
+                    customer_id: cust_123abc
+                    kyc_status:
+                      id: kyc_456def
+                      full_name: John Doe
+                      email: john@example.com
+                      type: business
+                      kyc_link: https://bridge.stellar.org/kyc/456def
+                      tos_link: https://bridge.stellar.org/tos/456def
+                      kyc_status: under_review
+                      tos_status: approved
+                      created_at: '2025-01-01T00:00:00Z'
+                      customer_id: cust_123abc
+                    opted_in_by: user_789
+                    opted_in_at: '2025-01-01T00:00:00Z'
+                ready_for_deposit:
+                  summary: Virtual account created and ready
+                  value:
+                    status: READY_FOR_DEPOSIT
+                    customer_id: cust_123abc
+                    virtual_account:
+                      id: va_789xyz
+                      status: activated
+                      developer_fee_percent: '0.5'
+                      customer_id: cust_123abc
+                      source_deposit_instructions:
+                        bank_beneficiary_name: Stellar Bridge
+                        currency: usd
+                        bank_name: Wells Fargo
+                        bank_address: 123 Main St, San Francisco, CA
+                        bank_account_number: '1234567890'
+                        bank_routing_number: '121000248'
+                        payment_rails:
+                          - ach
+                          - wire
+                      destination:
+                        payment_rail: stellar
+                        currency: usdc
+                        address: GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37
+                        blockchain_memo: '12345'
+                    virtual_account_created_by: user_789
+                    virtual_account_created_at: '2025-01-01T00:00:00Z'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      tags:
+        - Bridge Integration
+    patch:
+      summary: Update Bridge Integration Status
+      description: |
+        Updates the Bridge integration status. Supports two main operations:
+        1. Opt-in to Bridge (status: "OPTED_IN") - Creates KYC link for organization onboarding
+        2. Create Virtual Account (status: "READY_FOR_DEPOSIT") - Creates virtual account after KYC approval
+      operationId: updateBridgeIntegration
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BridgeIntegrationPatchRequest'
+            examples:
+              opt_in:
+                summary: Opt into Bridge integration
+                value:
+                  status: OPTED_IN
+                  email: john@example.com
+                  full_name: John Doe
+                  kyc_type: business
+              create_virtual_account:
+                summary: Create virtual account
+                value:
+                  status: READY_FOR_DEPOSIT
+      responses:
+        '200':
+          description: Bridge integration updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BridgeIntegrationInfo'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: Not Found
+          $ref: '#/components/responses/NotFoundResponse'
+      tags:
+        - Bridge Integration
+  /api-keys:
+    get:
+      tags:
+        - API Keys
+      summary: List API Keys
+      description: Retrieves all API keys created by the current user. The results are ordered by creation date in descending order (most recent first). API key values are not included in the response for security reasons.
+      operationId: ListAPIKeys
+      responses:
+        '200':
+          description: API keys retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/APIKey'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - API Keys
+      summary: Create API Key
+      description: Creates a new API Key to access SDP endpoints. API Key can be configured to have a granular read/write access, also API key can be restricted to the specific IP or range of the IPs.
+      operationId: CreateAPIKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAPIKeyRequest'
+        required: true
+      responses:
+        '201':
+          description: API key created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAPIKeyResponse'
+        '400':
+          description: Bad request - validation errors
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+      security:
+        - BearerAuth: []
+  /api-keys/{id}:
+    get:
+      tags:
+        - API Keys
+      summary: Get API Key Details
+      description: Retrieves a specific API key by its ID. Returns the API key details including permissions and restrictions, but does not include the actual key value for security reasons.
+      operationId: GetAPIKey
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier of the API key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: API key retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKey'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: API key not found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+    patch:
+      tags:
+        - API Keys
+      summary: Update API Key
+      description: Updates an existing API key's permissions and IP restrictions. The API key name and expiration date cannot be modified after creation.
+      operationId: UpdateAPIKey
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier of the API key to update
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAPIKeyRequest'
+        required: true
+      responses:
+        '200':
+          description: API key updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKey'
+        '400':
+          description: Bad request - validation errors
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: API key not found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - API Keys
+      summary: Delete API Key
+      description: Permanently deletes an API key. This action cannot be undone. Once deleted, the API key will no longer be able to authenticate API requests.
+      operationId: DeleteAPIKey
+      parameters:
+        - name: id
+          in: path
+          description: The unique identifier of the API key to delete
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: API key deleted successfully
+        '401':
+          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        '403':
+          description: Forbidden
+          $ref: '#/components/responses/ForbiddenResponse'
+        '404':
+          description: API key not found
+          $ref: '#/components/responses/NotFoundResponse'
+      security:
+        - BearerAuth: []
+components:
+  schemas:
+    Amount:
+      type: object
+      properties:
+        asset_code:
+          type: string
+          example: USDC
+        asset_issuer:
+          type: string
+          example: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+        received_amount:
+          type: string
+          example: '100.00'
+    Asset:
+      type: object
+      properties:
+        id:
+          type: string
+          example: ffaec4b3-46b0-4db4-a4c4-6c3508057705
+        code:
+          type: string
+          description: Asset code
+          example: USDC
+        issuer:
+          type: string
+          description: Asset issuer address
+          example: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        deleted_at:
+          type: string
+          format: date-time
+          example: '2023-06-03T10:55:51Z'
+      description: The Stellar asset object
+    Disbursement:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the disbursement
+          example: 619da857-8725-4c58-933d-c120a458e0f5
+        name:
+          type: string
+          description: The name of the disbursement
+          example: Disbursement Name
+        receiver_registration_message_template:
+          type: string
+          description: 'The custom template used to send invitations to receivers. The `default` message isn''t returned. In the message''s content it''s possible to add the following template variables: {{.OrganizationName}} which is the Organization Name configured and {{.RegistrationLink}} which is the link generated by SDP to send to the receiver (in case this is not present in the message, it''s automatically appended at the end).'
+          example: You have a payment waiting for you from {{.OrganizationName}}. Click {{.RegistrationLink}} to register.
+        registration_contact_type:
+          $ref: '#/components/schemas/RegistrationContactType'
+        wallet:
+          $ref: '#/components/schemas/Wallet'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        status:
+          $ref: '#/components/schemas/DisbursementStatus'
+        verification_field:
+          $ref: '#/components/schemas/VerificationField'
+        status_history:
+          $ref: '#/components/schemas/DisbursementStatusHistory'
+        file_name:
+          type: string
+          example: disbursement-feb-03-2023.csv
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        total_payments:
+          type: integer
+          description: Total number of payments
+          example: 10
+        total_payments_sent:
+          type: integer
+          description: Total number of successful payments
+          example: 8
+        total_payments_failed:
+          type: integer
+          description: Total number of failed payments
+          example: 1
+        total_payments_remaining:
+          type: integer
+          description: Total number of remaining payments
+          example: 1
+        amount_disbursed:
+          type: string
+          description: The total amount disbursed so far
+          example: '800.00'
+        total_amount:
+          type: string
+          description: The total amount to be disbursed
+          example: '1000.00'
+        average_amount:
+          type: string
+          description: The average amount per payment
+          example: '100.00'
+    DisbursementLite:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the disbursement
+          format: uuid
+          example: c51ba1d5-52d3-412f-a59c-6ef32d59ab43
+        name:
+          type: string
+          description: The name of the disbursement
+          example: disbursement-june-29
+        receiver_registration_message_template:
+          type: string
+          description: 'The custom template used to send invitations to receivers. The `default` message isn''t returned. In the message''s content it''s possible to add the following template variables: `{{.OrganizationName}}` which is the Organization Name configured and `{{.RegistrationLink}}` which is the link generated by SDP to send to the receiver (in case this is not present in the message, it''s automatically appended at the end).'
+          example: You have a payment waiting for you from {{.OrganizationName}}. Click {{.RegistrationLink}} to register.
+        registration_contact_type:
+          $ref: '#/components/schemas/RegistrationContactType'
+        status:
+          $ref: '#/components/schemas/DisbursementStatus'
+        verification_field:
+          $ref: '#/components/schemas/VerificationField'
+        status_history:
+          $ref: '#/components/schemas/DisbursementStatusHistory'
+        file_name:
+          type: string
+          example: disbursement-feb-03-2023.csv
+        created_at:
+          type: string
+          description: The creation timestamp of the disbursement
+          format: date-time
+          example: '2023-06-30T01:22:57.831975Z'
+        updated_at:
+          type: string
+          description: The last update timestamp of the disbursement
+          format: date-time
+          example: '2023-06-30T01:22:58.316511Z'
+    DisbursementPagination:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Disbursement'
+    DisbursementReceiver:
+      type: object
+      properties:
+        id:
+          type: string
+          example: ec3a57c0-5660-4b5a-af76-acadc7b09b93
+        email:
+          type: string
+          example: receiver@mail.org
+        phone_number:
+          type: string
+          example: '+15552368475'
+        external_id:
+          type: string
+          example: usr129001
+        receiver_wallet:
+          $ref: '#/components/schemas/ReceiverWallet'
+        payment:
+          $ref: '#/components/schemas/Payment'
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+    DisbursementReceiverPagination:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/DisbursementReceiver'
+    DisbursementsStatistics:
+      type: object
+      properties:
+        payment_counters:
+          $ref: '#/components/schemas/PaymentCounters'
+        payment_amounts_by_asset:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentAmountsByAsset'
+        receiver_wallets_counters:
+          $ref: '#/components/schemas/ReceiverWalletsCounters'
+        total_receivers:
+          type: integer
+          description: Total number of receivers
+          format: int64
+          example: 100
+    DisbursementStatus:
+      type: string
+      enum:
+        - DRAFT
+        - READY
+        - STARTED
+        - PAUSED
+        - COMPLETED
+    DisbursementStatusHistory:
+      type: array
+      items:
+        $ref: '#/components/schemas/DisbursementStatusHistoryEntry'
+    DisbursementStatusHistoryEntry:
+      type: object
+      properties:
+        user_id:
+          type: string
+          example: 3f351b9e-ed0f-40fa-a314-14757b42dab1
+        status:
+          $ref: '#/components/schemas/DisbursementStatus'
+        timestamp:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+    GeneralStatistics:
+      type: object
+      properties:
+        total_disbursements:
+          type: integer
+          description: Total number of disbursements
+          format: int64
+          example: 20
+        payment_counters:
+          $ref: '#/components/schemas/PaymentCounters'
+        payment_amounts_by_asset:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentAmountsByAsset'
+        receiver_wallets_counters:
+          $ref: '#/components/schemas/ReceiverWalletsCounters'
+        total_receivers:
+          type: integer
+          description: Total number of receivers
+          format: int64
+          example: 1000
+    MessageResponse:
+      required:
+        - message
+      type: object
+      properties:
+        message:
+          type: string
+    Organization:
+      required:
+        - distribution_account
+        - is_approval_required
+        - logo_url
+        - name
+        - payment_cancellation_period_days
+        - privacy_policy_link
+        - receiver_invitation_resend_interval_days
+        - timezone_utc_offset
+      type: object
+      properties:
+        name:
+          type: string
+          example: Stellar Aid
+        logo_url:
+          type: string
+          example: https://stellar-disbursement-platform-backend-dev.stellar.org/organization/logo
+        distribution_account:
+          $ref: '#/components/schemas/DistributionAccount'
+        distribution_account_public_key:
+          type: string
+          description: DEPRECATED! Please refer to distribution_account.address instead.
+          example: GCXAJ3XJ3VK3JFH3QMDFOSKM2NMMZBSO3VIT6EUPQWSDW2J74M23RRSL
+        timezone_utc_offset:
+          type: string
+          example: '+00:00'
+        is_approval_required:
+          type: boolean
+          description: Enables multi-user approval workflow for disbursements
+          example: true
+        receiver_invitation_resend_interval_days:
+          type: integer
+          description: The amount of days that the SDP will wait to resend the invitation to the receivers that have not registered. If `0`, that means the resending invitation feature is disabled.
+          example: 5
+        payment_cancellation_period_days:
+          type: integer
+          description: The amount of days that the SDP will wait to cancel a payment that is waiting for the receiver to register. If `0`, that means the payment cancellation feature is disabled.
+          example: 5
+        privacy_policy_link:
+          type: string
+          description: The link to the organization privacy policy
+          example: https://stellar.org/privacy-policy
+        receiver_registration_message_template:
+          type: string
+          description: 'The custom template used to send invitations to receivers. The `default` message isn''t returned. In the message''s content it''s possible to add the following template variables: {{.OrganizationName}} which is the Organization Name configured and {{.RegistrationLink}} which is the link generated by SDP to send to the receiver (in case this is not present in the message, it''s automatically appended at the end).'
+          example: You have a payment waiting for you from {{.OrganizationName}}. Click {{.RegistrationLink}} to register.
+        otp_message_template:
+          type: string
+          description: 'The custom OTP message template set to send OTP code to the receiver complete the registration flow. The `default` message isn''t returned. In the message''s content it''s possible to add the following template variables: {{.OrganizationName}} which is the Organization Name configured and {{.OTP}} which is the OTP code to send to the receiver complete the registration flow (in case this is not present in the message, it''s automatically appended at the end).'
+          example: '{{.OTP}} is your {{.OrganizationName}} phone verification code.'
+    DistributionAccount:
+      required:
+        - status
+        - type
+      type: object
+      properties:
+        address:
+          type: string
+          description: The address of the distribution account, present when the account type is `STELLAR`.
+          example: GCXAJ3XJ3VK3JFH3QMDFOSKM2NMMZBSO3VIT6EUPQWSDW2J74M23RRSL
+        circle_wallet_id:
+          type: string
+          description: The ID of the Circle wallet, present when the account type is `CIRCLE`.
+          example: '1000646072'
+        type:
+          type: string
+          description: The type of the distribution account.
+          example: DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT
+          enum:
+            - DISTRIBUTION_ACCOUNT.STELLAR.ENV
+            - DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT
+            - DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT
+        status:
+          type: string
+          example: ACTIVE
+          enum:
+            - ACTIVE
+            - PENDING_USER_ACTIVATION
+    Balance:
+      type: object
+      properties:
+        asset_code:
+          type: string
+          description: The asset code of the balance in the Stellar network.
+          example: USDC
+        asset_issuer:
+          type: string
+          description: The asset issuer of the balance in the Stellar network.
+          example: GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+        amount:
+          type: string
+          description: The amount of the balance.
+          example: '100.00'
+      description: The balances of the organization's distribution account. Currently, this is only used for the Circle distribution accounts.
+    Pagination:
+      type: object
+      properties:
+        next:
+          type: string
+          example: '?page=3&page_limit=2'
+        prev:
+          type: string
+          example: '?page=1&page_limit=2'
+        pages:
+          type: integer
+          example: 8
+        total:
+          type: integer
+          example: 16
+    Payment:
+      type: object
+      properties:
+        id:
+          type: string
+          example: ddf22f55-3259-4822-a4e2-ce01334997f4
+        amount:
+          type: string
+          description: The amount of the payment
+          example: '100.00'
+        stellar_transaction_id:
+          type: string
+          description: The ID of the transaction in the Stellar network. It can be used tio track the payment in the Stellar network using [Stellar Laboratory](https://laboratory.stellar.org/), or [StellarExpert](https://stellar.expert/).
+          example: 0b339d1c89d314186b8147c2af4c9a9ed5bbdbcd7ada8d138633907649b
+        circle_transfer_request_id:
+          type: string
+          description: The Circle transfer request ID. It is only present when the payment was made using Circle.
+          example: 74a68b6a-3f67-424b-b8b0-e593a19d7463
+        stellar_operation_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        status_history:
+          $ref: '#/components/schemas/PaymentStatusHistory'
+        type:
+          type: string
+          description: The type of the payment.
+          enum:
+            - DISBURSEMENT
+            - DIRECT
+        disbursement:
+          $ref: '#/components/schemas/DisbursementLite'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        receiver_wallet:
+          $ref: '#/components/schemas/ReceiverWalletLite'
+        external_payment_id:
+          type: string
+          description: Optional external payment identifier provided by the client.
+          example: payment-001
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+    PaymentPagination:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Payment'
+    PaymentStatus:
+      type: string
+      description: The status of the payment
+      enum:
+        - DRAFT
+        - READY
+        - PENDING
+        - PAUSED
+        - SUCCESS
+        - FAILED
+        - CANCELED
+    PaymentStatusHistory:
+      type: array
+      description: An aggregated list of metadata objects containing the statuses and the timestamp of when these status changes occurred.
+      items:
+        $ref: '#/components/schemas/PaymentStatusHistoryEntry'
+    PaymentStatusHistoryEntry:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        status_message:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+    PaymentCounters:
+      type: object
+      properties:
+        draft:
+          type: integer
+          format: int64
+          example: 1
+        ready:
+          type: integer
+          format: int64
+          example: 2
+        pending:
+          type: integer
+          format: int64
+          example: 3
+        paused:
+          type: integer
+          format: int64
+          example: 1
+        success:
+          type: integer
+          format: int64
+          example: 5
+        failed:
+          type: integer
+          format: int64
+          example: 1
+        total:
+          type: integer
+          format: int64
+          example: 14
+    PaymentAmountsByAsset:
+      type: object
+      properties:
+        asset_code:
+          type: string
+          example: USDC
+        payment_amounts:
+          $ref: '#/components/schemas/PaymentAmounts'
+    PaymentAmounts:
+      type: object
+      properties:
+        draft:
+          type: string
+          example: '100.00'
+        ready:
+          type: string
+          example: '200.00'
+        pending:
+          type: string
+          example: '300.00'
+        paused:
+          type: string
+          example: '100.00'
+        success:
+          type: string
+          example: '500.00'
+        failed:
+          type: string
+          example: '100.00'
+        average:
+          type: string
+          example: '100.00'
+        total:
+          type: string
+          example: '1400.00'
+    Profile:
+      type: object
+      properties:
+        first_name:
+          type: string
+          example: Jane
+        last_name:
+          type: string
+          example: Doe
+        email:
+          type: string
+          example: jdoe@mail.org
+        roles:
+          type: array
+          items:
+            type: string
+        organization_name:
+          type: string
+      example:
+        first_name: Jane
+        last_name: Doe
+        email: jdoe@mail.org
+        roles:
+          - developer
+        organization_name: Stellar Aid
+    Receiver:
+      type: object
+      properties:
+        id:
+          type: string
+          example: f83bb638-dda4-41e6-80c9-d03e6eec2aef
+        phone_number:
+          type: string
+          example: '+15552368475'
+        external_id:
+          type: string
+          example: usr12334
+        email:
+          type: string
+          example: jdoe@mail.org
+        created_at:
+          type: string
+          example: '2023-02-03T10:45:51.000Z'
+        total_payments:
+          type: string
+          example: '2'
+        successful_payments:
+          type: string
+          example: '2'
+        failed_payments:
+          type: string
+          example: '0'
+        remaining_payments:
+          type: string
+          example: '0'
+        registered_wallets:
+          type: string
+          example: '1'
+        received_amounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Amount'
+        wallets:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReceiverWallet'
+    ReceiverLite:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 029e2ed0-feb6-4c40-8b47-0836a85741a2
+    ReceiverPagination:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Receiver'
+    ReceiverWallet:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 803031d4-1d04-4879-b6d9-dc5641f9988e
+        receiver:
+          $ref: '#/components/schemas/ReceiverLite'
+        wallet:
+          $ref: '#/components/schemas/WalletLite'
+        stellar_address:
+          type: string
+          example: GCXAJ3XJ3VK3JFH3QMDFOSKM2NMMZBSO3VIT6EUPQWSDW2J74M23RRSL
+        stellar_memo:
+          type: string
+        stellar_memo_type:
+          type: string
+        created_at:
+          type: string
+          example: '2023-02-03T10:45:51.000Z'
+        updated_at:
+          type: string
+          example: '2023-02-03T10:45:51.000Z'
+        invited_at:
+          type: string
+          example: '2023-02-09T10:45:51.000Z'
+        last_message_sent_at:
+          type: string
+          description: timestamp when the receiver last received an invitation about this wallet
+          example: '2023-02-10T10:45:51.000Z'
+        total_payments:
+          type: string
+          example: '2'
+        payments_received:
+          type: string
+          example: '2'
+        failed_payments:
+          type: string
+          example: '0'
+        remaining_payments:
+          type: string
+          example: '0'
+        received_amounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/Amount'
+        status:
+          $ref: '#/components/schemas/ReceiversWalletStatus'
+        status_history:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReceiversWalletStatusHistoryEntry'
+    ReceiverWalletLite:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 803031d4-1d04-4879-b6d9-dc5641f9988e
+        receiver:
+          $ref: '#/components/schemas/ReceiverLite'
+        wallet:
+          $ref: '#/components/schemas/WalletLite'
+        stellar_address:
+          type: string
+          example: GCXAJ3XJ3VK3JFH3QMDFOSKM2NMMZBSO3VIT6EUPQWSDW2J74M23RRSL
+        stellar_memo:
+          type: string
+        stellar_memo_type:
+          type: string
+        sep24_transaction_id:
+          type: string
+        created_at:
+          type: string
+          example: '2023-02-03T10:45:51.000Z'
+        updated_at:
+          type: string
+          example: '2023-02-03T10:45:51.000Z'
+        invitation_sent_at:
+          type: string
+          example: '2023-02-09T10:45:51.000Z'
+        status:
+          $ref: '#/components/schemas/ReceiversWalletStatus'
+        status_history:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReceiversWalletStatusHistoryEntry'
+        otp_confirmed_at:
+          type: string
+          format: date-time
+          example: '2023-02-10T10:45:51Z'
+        otp_confirmed_with:
+          type: string
+    ReceiverWalletsCounters:
+      type: object
+      properties:
+        draft:
+          type: integer
+          format: int64
+          example: 1
+        ready:
+          type: integer
+          format: int64
+          example: 1
+        registered:
+          type: integer
+          format: int64
+          example: 1
+        flagged:
+          type: integer
+          format: int64
+          example: 1
+        total:
+          type: integer
+          format: int64
+          example: 4
+    ReceiversWalletStatus:
+      type: string
+      enum:
+        - DRAFT
+        - READY
+        - REGISTERED
+        - FLAGGED
+    ReceiversWalletStatusHistoryEntry:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/ReceiversWalletStatus'
+        timestamp:
+          type: string
+          format: date-time
+          example: '2023-02-10T10:45:51Z'
+    Users:
+      type: array
+      items:
+        $ref: '#/components/schemas/User'
+    User:
+      required:
+        - email
+        - first_name
+        - id
+        - is_active
+        - last_name
+        - roles
+      type: object
+      properties:
+        id:
+          type: string
+          example: 1736bed3-7b92-4760-8ff2-51fb08ee079f
+        first_name:
+          type: string
+          example: John
+        last_name:
+          type: string
+          example: Doe
+        email:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        is_active:
+          type: boolean
+      example:
+        - id: 7a4c6555-1f73-49b3-a211-f95bd2b8ec90
+          first_name: John
+          last_name: Doe
+          email: email@email.com
+          roles:
+            - developer
+          is_active: true
+        - id: 5f4df1dd-c84f-482a-84ad-541ffd46e75a
+          first_name: Jane
+          last_name: Doe
+          email: email@email.com
+          roles:
+            - financial_controller
+          is_active: false
+    VerificationField:
+      type: string
+      enum:
+        - DATE_OF_BIRTH
+        - YEAR_MONTH
+        - PIN
+        - NATIONAL_ID_NUMBER
+    RegistrationContactType:
+      type: string
+      enum:
+        - EMAIL
+        - PHONE_NUMBER
+        - EMAIL_AND_WALLET_ADDRESS
+        - PHONE_NUMBER_AND_WALLET_ADDRESS
+    Wallet:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 5ada9ed5-455a-4782-a0ee-160767e0deb1
+        name:
+          type: string
+          example: Vibrant Assist
+        homepage:
+          type: string
+          example: https://vibrantapp.com
+        sep_10_client_domain:
+          type: string
+          example: api-dev.vibrantapp.com
+        deep_link_schema:
+          type: string
+          example: https://vibrantapp.com/sdp-dev
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-07-31T20:50:45.648Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2023-07-31T20:50:45.648Z'
+    WalletLite:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 5ada9ed5-455a-4782-a0ee-160767e0deb1
+        name:
+          type: string
+          example: Vibrant Assist
+        homepage:
+          type: string
+          example: https://vibrantapp.com
+        sep_10_client_domain:
+          type: string
+          example: api-dev.vibrantapp.com
+        deep_link_schema:
+          type: string
+          example: https://vibrantapp.com/sdp-dev
+        enabled:
+          type: boolean
+          example: true
+        user_managed:
+          type: boolean
+          example: false
+    ReceiverRegistrationRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Email associated with the receiver in the SDP database. Either `phone_number` or `email` is required.
+        phone_number:
+          type: string
+          description: Phone number associated with the receiver in the SDP database. Either `phone_number` or `email` is required.
+        otp:
+          type: string
+          description: One-Time Password received for verification
+        verification:
+          type: string
+          description: Verification value provided by the user
+        verification_field:
+          $ref: '#/components/schemas/VerificationField'
+        recaptcha_token:
+          type: string
+          description: Token received from Google reCAPTCHA
+    PatchReceiverRequest:
+      type: object
+      properties:
+        date_of_birth:
+          type: string
+          description: Date of birth of the receiver
+        pin:
+          type: string
+          description: Personal identification number of the receiver
+        national_id:
+          type: string
+          description: National ID of the receiver
+        email:
+          type: string
+          description: Email of the receiver
+        phone_number:
+          type: string
+          description: Phone number of the receiver
+        external_id:
+          type: string
+          description: External ID of the receiver
+      example:
+        date_of_birth: '1980-01-01'
+        pin: '1234'
+        national_id: '123456789'
+        email: john@example.com
+        external_id: external123
+    Tenant:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 1736bed3-7b92-4760-8ff2-51fb08ee079f
+        name:
+          type: string
+          description: The tenant name. It should match the pattern `^[a-z-]+$`.
+          example: bluecorp
+        base_url:
+          type: string
+          description: The SDP backend server's base URL.
+          example: https://bluecorp-backend.sdp.org
+        sdp_ui_base_url:
+          type: string
+          description: The SDP UI/dashboard Base URL.
+          example: https://bluecorp.sdp.org
+        status:
+          type: string
+          enum:
+            - TENANT_CREATED
+            - TENANT_PROVISIONED
+            - TENANT_ACTIVATED
+            - TENANT_DEACTIVATED
+        distribution_account_address:
+          type: string
+          description: The Stellar account address used for distributing funds.
+          example: GCXAJ3XJ3VK3JFH3QMDFOSKM2NMMZBSO3VIT6EUPQWSDW2J74M23RRSL
+        distribution_account_type:
+          type: string
+          description: The Stellar account type used for distributing funds.
+          enum:
+            - DISTRIBUTION_ACCOUNT.STELLAR.ENV
+            - DISTRIBUTION_ACCOUNT.STELLAR.DB_VAULT
+            - DISTRIBUTION_ACCOUNT.CIRCLE.DB_VAULT
+        distribution_account_status:
+          type: string
+          description: The status of the distribution account used for distributing funds.
+          enum:
+            - ACTIVE
+            - PENDING_USER_ACTIVATION
+        is_default:
+          type: boolean
+          description: Boolean flag that shows whether the tenant is the default or not.
+          default: false
+        created_at:
+          type: string
+          format: date-time
+          example: '2024-03-27T17:21:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2024-03-27T17:21:51Z'
+        deleted_at:
+          type: string
+          description: The timestamp when the tenant was (soft) deleted.
+          format: date-time
+          example: '2024-03-27T17:21:51Z'
+      required:
+        - base_url
+        - created_at
+        - distribution_account_address
+        - distribution_account_status
+        - distribution_account_type
+        - id
+        - is_default
+        - name
+        - sdp_ui_base_url
+        - status
+        - updated_at
+      example:
+        id: 840dca45-d1df-44cd-83c1-65c04235c25f
+        name: redcorp
+        base_url: https://redcorp-backend.sdp.org
+        sdp_ui_base_url: https://redcorp.sdp.org
+        status: TENANT_PROVISIONED
+        distribution_account: GCQVDMPOEN3HHJJ64V42KUTONOXN7C6V2PSVPALEVJ7PIYOB6M3DJV7N
+        is_default: true
+        created_at: '2024-03-27T17:21:51.000Z'
+        updated_at: '2024-03-27T17:21:51.000Z'
+    Tenants:
+      type: array
+      items:
+        $ref: '#/components/schemas/Tenant'
+    BridgeIntegrationInfo:
+      type: object
+      description: Complete Bridge integration information including status and related data
+      properties:
+        status:
+          $ref: '#/components/schemas/BridgeIntegrationStatus'
+        customer_id:
+          type: string
+          description: Bridge customer ID
+          example: cust_123abc
+        kyc_status:
+          $ref: '#/components/schemas/KYCLinkInfo'
+        virtual_account:
+          $ref: '#/components/schemas/VirtualAccountInfo'
+        opted_in_by:
+          type: string
+          description: User ID who opted the organization into Bridge
+          example: user_789
+        opted_in_at:
+          type: string
+          format: date-time
+          description: Timestamp when organization opted into Bridge
+          example: '2025-01-01T00:00:00Z'
+        virtual_account_created_by:
+          type: string
+          description: User ID who created the virtual account
+          example: user_789
+        virtual_account_created_at:
+          type: string
+          format: date-time
+          description: Timestamp when virtual account was created
+          example: '2025-01-01T00:00:00Z'
+      required:
+        - status
+    BridgeIntegrationStatus:
+      type: string
+      description: Current status of the Bridge integration
+      enum:
+        - NOT_ENABLED
+        - NOT_OPTED_IN
+        - OPTED_IN
+        - READY_FOR_DEPOSIT
+        - ERROR
+      example: OPTED_IN
+    BridgeIntegrationPatchRequest:
+      type: object
+      description: Request to update Bridge integration status
+      properties:
+        status:
+          type: string
+          description: Target status for the integration
+          enum:
+            - OPTED_IN
+            - READY_FOR_DEPOSIT
+          example: OPTED_IN
+        email:
+          type: string
+          format: email
+          description: Email address for KYC verification (optional, defaults to user email)
+          example: john@example.com
+        full_name:
+          type: string
+          description: Full name for KYC verification (optional, defaults to user name)
+          example: John Doe
+        kyc_type:
+          $ref: '#/components/schemas/KYCType'
+      required:
+        - status
+    KYCLinkInfo:
+      type: object
+      description: KYC verification link information
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the KYC link
+          example: kyc_456def
+        full_name:
+          type: string
+          description: Full name of the person undergoing KYC
+          example: John Doe
+        email:
+          type: string
+          format: email
+          description: Email address for KYC verification
+          example: john@example.com
+        type:
+          $ref: '#/components/schemas/KYCType'
+        kyc_link:
+          type: string
+          format: uri
+          description: URL for completing KYC verification
+          example: https://bridge.stellar.org/kyc/456def
+        tos_link:
+          type: string
+          format: uri
+          description: URL for accepting terms of service
+          example: https://bridge.stellar.org/tos/456def
+        kyc_status:
+          $ref: '#/components/schemas/KYCStatus'
+        tos_status:
+          $ref: '#/components/schemas/TOSStatus'
+        rejection_reasons:
+          type: array
+          items:
+            type: string
+          description: Reasons for KYC rejection (if applicable)
+          example:
+            - Incomplete documentation
+            - Address verification failed
+        created_at:
+          type: string
+          format: date-time
+          description: When the KYC link was created
+          example: '2025-01-01T00:00:00Z'
+        customer_id:
+          type: string
+          description: Bridge customer ID
+          example: cust_123abc
+      required:
+        - id
+        - full_name
+        - email
+        - type
+        - kyc_link
+        - tos_link
+        - kyc_status
+        - tos_status
+        - customer_id
+    KYCType:
+      type: string
+      description: Type of KYC verification
+      enum:
+        - individual
+        - business
+      example: business
+    KYCStatus:
+      type: string
+      description: |
+        KYC verification status:
+        - not_started: KYC process not yet started
+        - incomplete: KYC process started but not complete
+        - awaiting_ubo: Awaiting Ultimate Beneficial Owner verification
+        - under_review: KYC submission under review
+        - approved: KYC verification approved
+        - rejected: KYC verification rejected
+        - paused: KYC process paused
+        - offboarded: Customer offboarded
+      enum:
+        - not_started
+        - incomplete
+        - awaiting_ubo
+        - under_review
+        - approved
+        - rejected
+        - paused
+        - offboarded
+      example: under_review
+    TOSStatus:
+      type: string
+      description: |
+        Terms of Service acceptance status:
+        - pending: Terms of service not yet accepted
+        - approved: Terms of service accepted
+      enum:
+        - pending
+        - approved
+      example: approved
+    VirtualAccountInfo:
+      type: object
+      description: Virtual account information for USD deposits
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the virtual account
+          example: va_789xyz
+        status:
+          $ref: '#/components/schemas/VirtualAccountStatus'
+        developer_fee_percent:
+          type: string
+          description: Developer fee percentage as a string
+          example: '0.5'
+        customer_id:
+          type: string
+          description: Bridge customer ID
+          example: cust_123abc
+        source_deposit_instructions:
+          $ref: '#/components/schemas/VirtualAccountDepositInstructions'
+        destination:
+          $ref: '#/components/schemas/VirtualAccountDestination'
+      required:
+        - id
+        - status
+        - developer_fee_percent
+        - customer_id
+        - source_deposit_instructions
+        - destination
+    VirtualAccountStatus:
+      type: string
+      description: |
+        Virtual account status:
+        - activated: Account is active and ready for deposits
+        - deactivated: Account is deactivated
+      enum:
+        - activated
+        - deactivated
+      example: activated
+    VirtualAccountDepositInstructions:
+      type: object
+      description: Bank deposit instructions for sending USD to the virtual account
+      properties:
+        bank_beneficiary_name:
+          type: string
+          description: Name of the bank account beneficiary
+          example: Stellar Bridge
+        currency:
+          type: string
+          description: Currency for deposits
+          example: usd
+        bank_name:
+          type: string
+          description: Name of the receiving bank
+          example: Wells Fargo
+        bank_address:
+          type: string
+          description: Address of the receiving bank
+          example: 123 Main St, San Francisco, CA
+        bank_account_number:
+          type: string
+          description: Bank account number for deposits
+          example: '1234567890'
+        bank_routing_number:
+          type: string
+          description: Bank routing number
+          example: '121000248'
+        payment_rails:
+          type: array
+          items:
+            type: string
+          description: Supported payment rails for deposits
+          example:
+            - ach
+            - wire
+      required:
+        - bank_beneficiary_name
+        - currency
+        - bank_name
+        - bank_address
+        - bank_account_number
+        - bank_routing_number
+        - payment_rails
+    VirtualAccountDestination:
+      type: object
+      description: Destination configuration for converted funds
+      properties:
+        payment_rail:
+          type: string
+          description: Payment rail for destination
+          example: stellar
+        currency:
+          type: string
+          description: Destination currency
+          example: usdc
+        address:
+          type: string
+          description: Stellar address for receiving USDC
+          example: GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37
+        blockchain_memo:
+          type: string
+          description: Blockchain memo for the destination transaction
+          example: '12345'
+      required:
+        - payment_rail
+        - currency
+        - address
+    APIKey:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the API key
+        name:
+          type: string
+          description: Human-readable name for the API key
+        permissions:
+          type: array
+          items:
+            type: string
+          description: List of permissions granted to this API key
+        allowed_ips:
+          type: array
+          items:
+            type: string
+          description: List of allowed IP addresses or CIDR ranges
+        expiry_date:
+          type: string
+          format: date-time
+          description: Expiration date of the API key
+        created_at:
+          type: string
+          format: date-time
+          description: When the API key was created
+        created_by:
+          type: string
+          description: User who created the API key
+        updated_at:
+          type: string
+          format: date-time
+          description: When the API key was last updated
+        updated_by:
+          type: string
+          description: User who last updated the API key
+        last_used_at:
+          type: string
+          format: date-time
+          description: When the API key was last used
+    CreateAPIKeyRequest:
+      type: object
+      required:
+        - name
+        - permissions
+      properties:
+        name:
+          type: string
+          description: Human-readable name for the API key
+        permissions:
+          type: array
+          description: List of permissions granted to this API key
+          items:
+            type: string
+            enum:
+              - read:all
+              - write:all
+              - read:disbursements
+              - write:disbursements
+              - read:receivers
+              - write:receivers
+              - read:payments
+              - write:payments
+              - read:organization
+              - write:organization
+              - read:users
+              - write:users
+              - read:wallets
+              - write:wallets
+              - read:statistics
+              - read:exports
+          minItems: 1
+        expiry_date:
+          type: string
+          format: date-time
+          description: Optional expiration date for the API key (must be in the future)
+        allowed_ips:
+          oneOf:
+            - type: string
+              description: Single IP address or CIDR range
+            - type: array
+              items:
+                type: string
+              description: Array of IP addresses or CIDR ranges
+          description: IP restrictions for the API key. If not provided, the key can be used from any IP
+    CreateAPIKeyResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the API key
+        name:
+          type: string
+          description: Human-readable name for the API key
+        key:
+          type: string
+          description: The actual API key (only returned once at creation)
+        permissions:
+          type: array
+          items:
+            type: string
+          description: List of permissions granted to this API key
+        allowed_ips:
+          type: array
+          items:
+            type: string
+          description: List of allowed IP addresses or CIDR ranges
+        expiry_date:
+          type: string
+          format: date-time
+          description: Expiration date of the API key
+        created_at:
+          type: string
+          format: date-time
+          description: When the API key was created
+        created_by:
+          type: string
+          description: User who created the API key
+        updated_at:
+          type: string
+          format: date-time
+          description: When the API key was last updated
+        updated_by:
+          type: string
+          description: User who last updated the API key
+        last_used_at:
+          type: string
+          format: date-time
+          description: When the API key was last used
+    UpdateAPIKeyRequest:
+      type: object
+      required:
+        - permissions
+      properties:
+        permissions:
+          type: array
+          description: List of permissions granted to this API key
+          items:
+            type: string
+            enum:
+              - read:all
+              - write:all
+              - read:disbursements
+              - write:disbursements
+              - read:receivers
+              - write:receivers
+              - read:payments
+              - write:payments
+              - read:organization
+              - write:organization
+              - read:users
+              - write:users
+              - read:wallets
+              - write:wallets
+              - read:statistics
+              - read:exports
+          minItems: 1
+        allowed_ips:
+          oneOf:
+            - type: string
+              description: Single IP address or CIDR range
+            - type: array
+              items:
+                type: string
+              description: Array of IP addresses or CIDR ranges
+          description: IP restrictions for the API key. If not provided, existing restrictions remain unchanged
+    CreateDirectPaymentRequest:
+      type: object
+      required:
+        - amount
+        - asset
+        - receiver
+        - wallet
+      properties:
+        amount:
+          type: string
+          description: The payment amount
+        asset:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Asset ID (use either id or type)
+            type:
+              type: string
+              enum:
+                - native
+                - classic
+                - contract
+                - fiat
+              description: Asset type (use either id or type)
+            code:
+              type: string
+              description: Asset code (required for classic and fiat assets)
+            issuer:
+              type: string
+              description: Asset issuer address (required for classic assets)
+            contract_id:
+              type: string
+              description: Contract ID (required for contract assets)
+          description: Asset reference - specify either id or type with required fields
+        receiver:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Receiver ID
+            email:
+              type: string
+              description: Receiver email address
+            phone_number:
+              type: string
+              description: Receiver phone number
+            wallet_address:
+              type: string
+              description: Receiver wallet address (Stellar account or contract)
+          description: Receiver reference - specify exactly one identifier
+        wallet:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Wallet ID
+            address:
+              type: string
+              description: Wallet address (Stellar account or contract)
+          description: Wallet reference - specify either id or address
+        external_payment_id:
+          type: string
+          description: Optional external payment identifier
+    DirectPayment:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The unique identifier of the payment
+          example: 619da857-8725-4c58-933d-c120a458e0f5
+        amount:
+          type: string
+          description: The payment amount
+          example: '100.00'
+        asset:
+          $ref: '#/components/schemas/Asset'
+        receiver:
+          type: object
+          properties:
+            id:
+              type: string
+              example: 7a4c68dd-861c-4448-8813-ea3f6dda7b25
+            email:
+              type: string
+              example: horus@example.com
+            phone_number:
+              type: string
+              example: '+1234567890'
+            created_at:
+              type: string
+              format: date-time
+              example: '2023-02-03T10:45:51Z'
+            updated_at:
+              type: string
+              format: date-time
+              example: '2023-02-03T10:45:51Z'
+          description: The receiver object
+        wallet:
+          $ref: '#/components/schemas/Wallet'
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        external_payment_id:
+          type: string
+          description: External payment identifier
+          example: payment-001
+        created_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2023-02-03T10:45:51Z'
+    CreateReceiverRequest:
+      oneOf:
+        - type: object
+          required:
+            - external_id
+            - verifications
+          properties:
+            email:
+              type: string
+              description: Email address of the receiver
+              format: email
+            phone_number:
+              type: string
+              description: Phone number of the receiver
+            external_id:
+              type: string
+              description: External identifier for the receiver
+            verifications:
+              type: array
+              description: Verification requirements for the receiver
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - date_of_birth
+                      - pin
+                      - national_id
+                      - year_month
+                    description: Type of verification required
+                  value:
+                    type: string
+                    description: Expected verification value
+                required:
+                  - type
+                  - value
+        - type: object
+          required:
+            - external_id
+            - wallets
+          properties:
+            email:
+              type: string
+              description: Email address of the receiver
+              format: email
+            phone_number:
+              type: string
+              description: Phone number of the receiver
+            external_id:
+              type: string
+              description: External identifier for the receiver
+            wallets:
+              type: array
+              description: Wallet information for the receiver (max 1 wallet)
+              items:
+                type: object
+                properties:
+                  address:
+                    type: string
+                    description: Stellar address of the wallet
+                  memo:
+                    type: string
+                    description: Optional memo for the wallet address
+                required:
+                  - address
+              maxItems: 1
+    CreateWalletRequest:
+      type: object
+      required:
+        - name
+        - homepage
+        - deep_link_schema
+        - sep_10_client_domain
+      properties:
+        name:
+          type: string
+          description: Human-readable name of the wallet provider
+        homepage:
+          type: string
+          description: Homepage URL of the wallet provider
+        deep_link_schema:
+          type: string
+          description: Deep link schema for the wallet application
+        sep_10_client_domain:
+          type: string
+          description: SEP-10 client domain for authentication
+        enabled:
+          type: boolean
+          description: Whether the wallet is enabled for use
+          default: true
+        assets:
+          type: array
+          description: Array of asset references supported by this wallet
+          items:
+            oneOf:
+              - type: object
+                description: Asset reference by ID
+                properties:
+                  id:
+                    type: string
+                    description: Asset ID
+                required:
+                  - id
+              - type: object
+                description: Classic asset reference
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - classic
+                  code:
+                    type: string
+                    description: Asset code
+                  issuer:
+                    type: string
+                    description: Asset issuer address
+                required:
+                  - type
+                  - code
+                  - issuer
+              - type: object
+                description: Native XLM asset reference
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - native
+                required:
+                  - type
+        assets_ids:
+          type: array
+          description: |
+            Legacy: Array of asset IDs (cannot be used with assets field)
+          items:
+            type: string
+    UpdateWalletRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Human-readable name of the wallet provider
+        homepage:
+          type: string
+          description: Homepage URL of the wallet provider
+        deep_link_schema:
+          type: string
+          description: Deep link schema for the wallet application
+        sep_10_client_domain:
+          type: string
+          description: SEP-10 client domain for authentication
+        enabled:
+          type: boolean
+          description: Whether the wallet is enabled for use
+        assets:
+          type: array
+          description: Array of asset references supported by this wallet
+          items:
+            oneOf:
+              - type: object
+                description: Asset reference by ID
+                properties:
+                  id:
+                    type: string
+                    description: Asset ID
+                required:
+                  - id
+              - type: object
+                description: Classic asset reference
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - classic
+                  code:
+                    type: string
+                    description: Asset code
+                  issuer:
+                    type: string
+                    description: Asset issuer address
+                required:
+                  - type
+                  - code
+                  - issuer
+              - type: object
+                description: Native XLM asset reference
+                properties:
+                  type:
+                    type: string
+                    enum:
+                      - native
+                required:
+                  - type
+      minProperties: 1
+  responses:
+    UnauthorizedResponse:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              extras:
+                type: object
+                properties:
+                  status:
+                    type: number
+                  message:
+                    type: string
+          example:
+            error: Not authorized
+            extras:
+              status: 401
+              message: Not authorized
+    ForbiddenResponse:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+          example:
+            error: Forbidden
+    BadRequestResponse:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Details about the error
+              extras:
+                type: object
+                properties: {}
+    NotFoundResponse:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              extras:
+                type: object
+                properties:
+                  status:
+                    type: number
+                  message:
+                    type: string
+          example:
+            error: Not found
+            extras:
+              status: 404
+              message: Resource not found
+  securitySchemes:
+    BearerAuth:
+      type: apiKey
+      description: Authorization header containing an SDP JWT (ES256) or an SDP_ API key.
+      name: Authorization
+      in: header
+    SEP10Auth:
+      type: apiKey
+      description: Authorization header containing a SEP-10 JWT (Bearer {token}).
+      name: Authorization
+      in: header
+    SEP24Auth:
+      type: apiKey
+      description: Authorization header containing a SEP-24 JWT (Bearer {token}).
+      name: Authorization
+      in: header
+    SEP24QueryAuth:
+      type: apiKey
+      description: Query parameter containing a SEP-24 JWT.
+      name: token
+      in: query
+x-original-swagger-version: '2.0'


### PR DESCRIPTION
Closes #2441.

Makes `developers.stellar.org` discoverable to AI agents and other automated clients via standard HTTP link relations (RFC 8288) and an API catalog (RFC 9727).

**Changes**
- `nginx/nginx.conf`: emits 10 `Link` headers on `/`, covering all four Stellar APIs (Horizon, Stellar RPC, Anchor Platform, SDP) with `rel="service-desc"`, `rel="service-doc"`, `rel="api-catalog"`, and `rel="describedby"` for `/llms.txt`. Headers live inside `location /` because nginx `add_header` inheritance is shadowed by inner location blocks.
- `static/.well-known/api-catalog`: RFC 9264 linkset (served as `application/linkset+json`) listing all four APIs with their service descriptions and human docs in one machine-readable document.
- `static/openapi/{horizon.yml,anchor-platform.yaml,stellar-disbursement-platform.yaml}`: raw OpenAPI bundles published at stable URLs so each API has a `service-desc` target (previously only Stellar RPC's OpenRPC spec was served).