### PR TITLE
⚓ Reference Anchor Fundamentals page

### DIFF
--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -7,7 +7,9 @@ description: "Learn about the on and off ramps on Stellar called anchors and the
 
 # Anchors
 
-## Overview
+import YouTube from "@site/src/components/YouTube";
+
+<YouTube ID="9iN9XT1rHHA" />
 
 An anchor is a Stellar-specific term for the on and off-ramps that connect the Stellar network to traditional financial rails, such as financial institutions or fintech companies. Anchors accept deposits of fiat currencies (such as the US dollar, Argentine peso, or Nigerian naira) via existing rails (such as bank deposits or cash-in points), then sends the user the equivalent digital tokens on the Stellar network. The equivalent digital tokens can either represent that same fiat currency or another digital token altogether. Alternatively, anchors allow token holders to redeem their tokens for the real-world assets they represent.
 
@@ -25,16 +27,7 @@ Stellar is an open-source network that is designed to interoperate with traditio
 
 Read more about SEPs in the [SEPs section](../fundamentals/stellar-ecosystem-proposals.mdx).
 
-For anchors, the most important SEPs are [SEP-6]: Programmatic Deposit and Withdrawal, [SEP-24]: Hosted Deposit and Withdrawal, and [SEP-31]: Cross Border Payments API. You’ll also work with [SEP-10]: Stellar Authentication, [SEP-12]: KYC API, and [SEP-38]: Anchor RFQ API.
-
-[sep-1]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
-[sep-6]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md
-[sep-9]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md
-[sep-10]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md
-[sep-12]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md
-[sep-24]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md
-[sep-31]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md
-[sep-38]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md
+For anchors, the most important SEPs are [SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md): Programmatic Deposit and Withdrawal, [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md): Hosted Deposit and Withdrawal, and [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md): Cross Border Payments API. You’ll also work with [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md): Stellar Authentication, [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md): KYC API, and [SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md): Anchor RFQ API.
 
 ### Using SEP-6: Programmatic Deposit and Withdrawal versus SEP-24: Hosted Deposit and Withdrawal
 

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -11,7 +11,7 @@ import YouTube from "@site/src/components/YouTube";
 
 <YouTube ID="9iN9XT1rHHA" />
 
-An anchor is a Stellar-specific term for the on and off-ramps that connect the Stellar network to traditional financial rails, such as financial institutions or fintech companies. Anchors accept deposits of fiat currencies (such as the US dollar, Argentine peso, or Nigerian naira) via existing rails (such as bank deposits or cash-in points), then sends the user the equivalent digital tokens on the Stellar network. The equivalent digital tokens can either represent that same fiat currency or another digital token altogether. Alternatively, anchors allow token holders to redeem their tokens for the real-world assets they represent.
+An anchor connects the Stellar network to traditional financial rails, such as financial institutions or fintech companies. Anchors accept deposits of fiat currencies (such as the US dollar, Argentine peso, or Nigerian naira) via existing rails (such as bank deposits or cash-in points), then send the user the equivalent digital tokens on the Stellar network. The equivalent digital tokens can either represent that same fiat currency or another digital token altogether. Alternatively, anchors allow token holders to redeem their tokens for the real-world assets they represent.
 
 Stellar has anchor services operating worldwide. View the [Anchor Directory](https://anchors.stellar.org) for more information on existing Stellar anchors.
 
@@ -19,11 +19,11 @@ Anchors can issue their own assets on the Stellar network, or they can honor ass
 
 You can set up an anchor by using the SDF-maintained [Anchor Platform](../../platforms/anchor-platform/README.mdx), which is the easiest way to deploy an anchor service compatible with Stellar Ecosystem Proposals (SEPs).
 
-Learn how to integrate anchor services into your blockchain-based application by viewing the [Build Apps section](../../build/apps/overview.mdx). If you’re looking for MoneyGram Ramps, see the Integrate with [MoneyGram Ramps tutorial](https://developer.moneygram.com/moneygram-developer/docs/integrate-moneygram-ramps).
+Learn how to integrate anchor services into your blockchain-based application by viewing the [Build Apps section](../../build/apps/overview.mdx). If you're looking for MoneyGram Ramps, see the [Integrate with MoneyGram Ramps tutorial](https://developer.moneygram.com/moneygram-developer/docs/integrate-moneygram-ramps).
 
 ## Stellar Ecosystem Proposals (SEPs)
 
-Stellar is an open-source network that is designed to interoperate with traditional financial institutions, various types of assets, and other networks. Network participants implement Stellar Ecosystem Proposals (SEPs) to ensure they can interoperate with other products and services on the network. SEPs are publicly created, open-source documents that live in a [GitHub repository](https://github.com/stellar/stellar-protocol/tree/master/ecosystem#stellar-ecosystem-proposals-seps.mdx) and they define how anchors, asset issuers, applications, exchanges, and other service providers should interact and interoperate.
+Stellar is an open-source network that is designed to interoperate with traditional financial institutions, various types of assets, and other networks. Network participants implement Stellar Ecosystem Proposals (SEPs) so they can interoperate with other products and services on the network. The Stellar community creates SEPs as open-source documents in a [GitHub repository](https://github.com/stellar/stellar-protocol/tree/master/ecosystem#stellar-ecosystem-proposals-seps.mdx); they define how anchors, asset issuers, applications, exchanges, and other service providers should interact and interoperate.
 
 Read more about SEPs in the [SEPs section](../fundamentals/stellar-ecosystem-proposals.mdx).
 
@@ -35,7 +35,7 @@ For anchors, the most important SEPs are:
 - [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md): Hosted Deposit and Withdrawal
 - [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md): Cross Border Payments API
 
-They also work with:
+Anchors also work with:
 
 - [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md): Stellar Authentication
 - [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md): KYC API
@@ -51,20 +51,20 @@ A user typically must decide whether they want to set up an anchor using [SEP-6:
 
 Defines the standard way for anchors and wallets to interact on behalf of users. With this SEP’s guidance, wallets and other clients can interact with anchors directly without the user needing to leave the wallet to go to the anchor’s site. With SEP-6, the client collects KYC information from the user.
 
-Wallets (clients) must take into consideration when using SEP-6:
+Wallets (clients) must consider these requirements when using SEP-6:
 
 - Clients must collect KYC information they may not need
 - Clients must know what information to collect per-anchor
 - Clients must send the information in a standardized format [(SEP-12: KYC API)](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md)
-- Anchors must receive the information via SEP-12’s API
+- Anchors must receive the information via SEP-12's API
 
 #### SEP-24: Hosted Deposit and Withdrawal
 
 Defines the standard way for anchors and wallets to interact on behalf of users interactively. This means that the user’s application must open a webview hosted by a third-party anchor for the user to provide the information necessary to complete the transaction. With SEP-24, the anchor collects KYC information from the user.
 
-Wallets (clients) must take into consideration when using SEP-24:
+Wallets (clients) must consider these requirements when using SEP-24:
 
-- Clients don’t have to collect the anchor’s required KYC information
-- Clients & anchors don’t have to implement [SEP-12: KYC API](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md)
-- Anchors must create a UI to be rendered by many clients
+- Clients don't have to collect the anchor's required KYC information
+- Clients and anchors don't have to implement [SEP-12: KYC API](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md)
+- Anchors must create a UI that many clients can render
 - Clients must allow anchors to temporarily control UX

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -5,9 +5,9 @@ sidebar_label: Anchors
 description: "Learn about the on and off ramps on Stellar called anchors and their role in bridging between the traditional financial system and blockchain networks."
 ---
 
-# Anchors
-
 import YouTube from "@site/src/components/YouTube";
+
+# Anchors
 
 <YouTube ID="9iN9XT1rHHA" />
 

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -27,9 +27,23 @@ Stellar is an open-source network that is designed to interoperate with traditio
 
 Read more about SEPs in the [SEPs section](../fundamentals/stellar-ecosystem-proposals.mdx).
 
-For anchors, the most important SEPs are [SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md): Programmatic Deposit and Withdrawal, [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md): Hosted Deposit and Withdrawal, and [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md): Cross Border Payments API. You’ll also work with [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md): Stellar Authentication, [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md): KYC API, and [SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md): Anchor RFQ API.
+:::note
 
-### Using SEP-6: Programmatic Deposit and Withdrawal versus SEP-24: Hosted Deposit and Withdrawal
+For anchors, the most important SEPs are:
+
+- [SEP-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md): Programmatic Deposit and Withdrawal
+- [SEP-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md): Hosted Deposit and Withdrawal
+- [SEP-31](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0031.md): Cross Border Payments API
+
+They also work with:
+
+- [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md): Stellar Authentication
+- [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md): KYC API
+- [SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md): Anchor RFQ API
+
+:::
+
+### Using SEP-6 vs. SEP-24
 
 A user typically must decide whether they want to set up an anchor using [SEP-6: Programmatic Deposit and Withdrawal](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) or [SEP-24: Hosted Deposit and Withdrawal](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md). Here are the differences and what to consider when choosing one or the other.
 

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -11,7 +11,7 @@ import YouTube from "@site/src/components/YouTube";
 
 <YouTube ID="9iN9XT1rHHA" />
 
-An anchor connects the Stellar network to traditional financial rails, such as financial institutions or fintech companies. Anchors accept deposits of fiat currencies (such as the US dollar, Argentine peso, or Nigerian naira) via existing rails (such as bank deposits or cash-in points), then send the user the equivalent digital tokens on the Stellar network. The equivalent digital tokens can either represent that same fiat currency or another digital token altogether. Alternatively, anchors allow token holders to redeem their tokens for the real-world assets they represent.
+Anchors are Stellar's on- and off-ramps to traditional financial rails, typically operated by financial institutions or fintech companies. Anchors accept deposits of fiat currencies (such as the US dollar, Argentine peso, or Nigerian naira) via existing rails (such as bank deposits or cash-in points), then send the user the equivalent digital tokens on the Stellar network. The equivalent digital tokens can either represent that same fiat currency or another digital token altogether. Alternatively, anchors allow token holders to redeem their tokens for the real-world assets they represent.
 
 Stellar has anchor services operating worldwide. View the [Anchor Directory](https://anchors.stellar.org) for more information on existing Stellar anchors.
 

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -27,7 +27,7 @@ Stellar is an open-source network that is designed to interoperate with traditio
 
 Read more about SEPs in the [SEPs section](../fundamentals/stellar-ecosystem-proposals.mdx).
 
-:::note
+:::info
 
 For anchors, the most important SEPs are:
 

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -45,7 +45,7 @@ Anchors also work with:
 
 :::
 
-### Using SEP-6 vs. SEP-24
+### SEP-6 vs. SEP-24: Programmatic vs. Hosted Transfers
 
 A user typically must decide whether they want to set up an anchor using [SEP-6: Programmatic Deposit and Withdrawal](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) or [SEP-24: Hosted Deposit and Withdrawal](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md). Here are the differences and what to consider when choosing one or the other.
 

--- a/docs/learn/fundamentals/anchors.mdx
+++ b/docs/learn/fundamentals/anchors.mdx
@@ -37,6 +37,8 @@ For anchors, the most important SEPs are:
 
 Anchors also work with:
 
+- [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md): Stellar Info File
+- [SEP-9](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md): Standard KYC Fields
 - [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md): Stellar Authentication
 - [SEP-12](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md): KYC API
 - [SEP-38](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md): Anchor RFQ API

--- a/routes.txt
+++ b/routes.txt
@@ -558,7 +558,6 @@
 /docs/platforms/anchor-platform/admin-guide/getting-started
 /docs/platforms/anchor-platform/api-reference
 /docs/platforms/anchor-platform/api-reference/callbacks
-/docs/platforms/anchor-platform/api-reference/callbacks/callbacks-server
 /docs/platforms/anchor-platform/api-reference/callbacks/del-customer
 /docs/platforms/anchor-platform/api-reference/callbacks/get-customer
 /docs/platforms/anchor-platform/api-reference/callbacks/get-rates
@@ -594,7 +593,6 @@
 /docs/platforms/anchor-platform/api-reference/platform/transactions
 /docs/platforms/anchor-platform/api-reference/platform/transactions/get-transaction
 /docs/platforms/anchor-platform/api-reference/platform/transactions/get-transactions
-/docs/platforms/anchor-platform/api-reference/platform/transactions/platform-server
 /docs/platforms/anchor-platform/sep-guide
 /docs/platforms/anchor-platform/sep-guide/sep1
 /docs/platforms/anchor-platform/sep-guide/sep10

--- a/routes.txt
+++ b/routes.txt
@@ -558,6 +558,7 @@
 /docs/platforms/anchor-platform/admin-guide/getting-started
 /docs/platforms/anchor-platform/api-reference
 /docs/platforms/anchor-platform/api-reference/callbacks
+/docs/platforms/anchor-platform/api-reference/callbacks/callbacks-server
 /docs/platforms/anchor-platform/api-reference/callbacks/del-customer
 /docs/platforms/anchor-platform/api-reference/callbacks/get-customer
 /docs/platforms/anchor-platform/api-reference/callbacks/get-rates
@@ -593,6 +594,7 @@
 /docs/platforms/anchor-platform/api-reference/platform/transactions
 /docs/platforms/anchor-platform/api-reference/platform/transactions/get-transaction
 /docs/platforms/anchor-platform/api-reference/platform/transactions/get-transactions
+/docs/platforms/anchor-platform/api-reference/platform/transactions/platform-server
 /docs/platforms/anchor-platform/sep-guide
 /docs/platforms/anchor-platform/sep-guide/sep1
 /docs/platforms/anchor-platform/sep-guide/sep10


### PR DESCRIPTION
This continues the work from #2446, inlining the protocol/SEP links, while adding a great vid introducing users to anchors and their role with assets such as those used in SEP6 and -2243 discussed later on in the page. It also rebuilds the routes to account for some structural changes modified in #2447. For some reason, the files around there were added previously but not pathfound, and the Actions check didn't catch it.