### PR TITLE
bump rpc disk size requirement to 350Gb

### DIFF
--- a/docs/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/docs/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -13,7 +13,7 @@ The RPC service can be installed on bare metal or a virtual machine. It is nativ
 
 _\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, +40GB per retention day_
 
-_\* RAM/CPU: Assuming RPC will serve a modest request volume (e.g. 100 requests per second across all endpoints). For deployments expecting heavier request volume to Stellar RPC, we recommend horizontal scaling and load balancing across at least 32GB of RAM and an appropriately scaled CPU._
+_\* RAM/CPU: Assuming RPC will serve a modest request volume (e.g. 100 requests per second across all endpoints). For deployments expecting heavier request volume to Stellar RPC (e.g. >500 requests per second), we recommend horizontal scaling and load balancing across at least 32GB of RAM and an appropriately scaled CPU._
 
 We highly recommend using a local SSD disk for storage. RPC is compatible with network-based filesystems like AWS EBS but it will negatively impact its performance.
 

--- a/docs/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/docs/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -11,7 +11,7 @@ The RPC service can be installed on bare metal or a virtual machine. It is nativ
 | --- | --- | --- | --- | --- | --- |
 | Stellar RPC | 4-8 vCPUs | 16GB | 350 GB persistent volume >= 3K IOPS | [c5.2xlarge] | [n4-highcpu-8] |
 
-_\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, +20GB per retention day_ _\* RAM/CPU: Assuming RPC will serve up to 100 requests per second. For deployments expecting 1000+ requests per second to Stellar RPC, we recommend horizontal scaling and load balancing across at least 32GB of RAM and a quad core CPU with a 2.4GHz clock speed._
+_\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, +40GB per retention day_ _\* RAM/CPU: Assuming RPC will serve a modest request volume (e.g. 100 requests per second across all endpoints). For deployments expecting heavier request volume to Stellar RPC, we recommend horizontal scaling and load balancing across at least 32GB of RAM and an appropriately scaled CPU._
 
 We highly recommend using a local SSD disk for storage. RPC is compatible with network-based filesystems like AWS EBS but it will negatively impact its performance.
 

--- a/docs/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/docs/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -11,7 +11,9 @@ The RPC service can be installed on bare metal or a virtual machine. It is nativ
 | --- | --- | --- | --- | --- | --- |
 | Stellar RPC | 4-8 vCPUs | 16GB | 350 GB persistent volume >= 3K IOPS | [c5.2xlarge] | [n4-highcpu-8] |
 
-_\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, +40GB per retention day_ _\* RAM/CPU: Assuming RPC will serve a modest request volume (e.g. 100 requests per second across all endpoints). For deployments expecting heavier request volume to Stellar RPC, we recommend horizontal scaling and load balancing across at least 32GB of RAM and an appropriately scaled CPU._
+_\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, +40GB per retention day_
+
+_\* RAM/CPU: Assuming RPC will serve a modest request volume (e.g. 100 requests per second across all endpoints). For deployments expecting heavier request volume to Stellar RPC, we recommend horizontal scaling and load balancing across at least 32GB of RAM and an appropriately scaled CPU._
 
 We highly recommend using a local SSD disk for storage. RPC is compatible with network-based filesystems like AWS EBS but it will negatively impact its performance.
 

--- a/docs/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/docs/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -9,7 +9,7 @@ The RPC service can be installed on bare metal or a virtual machine. It is nativ
 
 | Node Type | CPU | RAM | Disk | AWS SKU | Google Cloud SKU |
 | --- | --- | --- | --- | --- | --- |
-| Stellar RPC | 4-8 vCPUs | 16GB | 250 GB persistent volume >= 3K IOPS | [c5.2xlarge] | [n4-highcpu-8] |
+| Stellar RPC | 4-8 vCPUs | 16GB | 350 GB persistent volume >= 3K IOPS | [c5.2xlarge] | [n4-highcpu-8] |
 
 _\* Disk: Assuming the default 7-day retention window for data storage. Otherwise, +20GB per retention day_ _\* RAM/CPU: Assuming RPC will serve up to 100 requests per second. For deployments expecting 1000+ requests per second to Stellar RPC, we recommend horizontal scaling and load balancing across at least 32GB of RAM and a quad core CPU with a 2.4GHz clock speed._
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -11,7 +11,9 @@ El servicio RPC se puede instalar en hardware físico o en una máquina virtual.
 | -------------- | ----------- | ---- | ---------------------------------------- | ------------- | ------------------- |
 | RPC de Stellar | 4-8 vCPUs   | 16GB | Volumen persistente de 350 GB >= 3K IOPS | [c5.2xlarge]  | [n4-highcpu-8]      |
 
-_\* Disco: Suponiendo la ventana de retención predeterminada de 7 días para el almacenamiento de datos. De lo contrario, +40 GB por día de retención_ _\* RAM/CPU: Suponiendo que RPC atenderá un volumen de solicitudes modesto (por ejemplo, 100 solicitudes por segundo a través de todos los endpoints). Para implementaciones que esperan un mayor volumen de solicitudes al RPC de Stellar, recomendamos escalado horizontal y balanceo de carga con al menos 32 GB de RAM y una CPU dimensionada adecuadamente._
+_\* Disco: Suponiendo la ventana de retención predeterminada de 7 días para el almacenamiento de datos. De lo contrario, +40 GB por día de retención_
+
+_\* RAM/CPU: Suponiendo que RPC atenderá un volumen de solicitudes modesto (por ejemplo, 100 solicitudes por segundo a través de todos los endpoints). Para implementaciones que esperan un mayor volumen de solicitudes al RPC de Stellar, recomendamos escalado horizontal y balanceo de carga con al menos 32 GB de RAM y una CPU dimensionada adecuadamente._
 
 Te recomendamos encarecidamente utilizar un disco SSD local para almacenamiento. RPC es compatible con sistemas de archivos basados en la red como AWS EBS, pero impactará negativamente en su rendimiento.
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -7,13 +7,13 @@ El servicio RPC se puede instalar en hardware físico o en una máquina virtual.
 
 ### Requisitos de hardware
 
-| Tipo de nodo   | CPU    | RAM  | Disco                                    | SKU de AWS  | SKU de Google Cloud |
-| -------------- | ------ | ---- | ---------------------------------------- | ----------- | ------------------- |
-| RPC de Stellar | 2 vCPU | 16GB | Volumen persistente de 350 GB >= 3K IOPS | [c5.xlarge] | [n4-highcpu-4]      |
+| Tipo de nodo   | CPU         | RAM  | Disco                                    | SKU de AWS    | SKU de Google Cloud |
+| -------------- | ----------- | ---- | ---------------------------------------- | ------------- | ------------------- |
+| RPC de Stellar | 4-8 vCPUs   | 16GB | Volumen persistente de 350 GB >= 3K IOPS | [c5.2xlarge]  | [n4-highcpu-8]      |
 
-_\* Disco: Suponiendo la ventana de retención predeterminada de 7 días para el almacenamiento de datos. De lo contrario, 20 GB + 20 GB por día de retención_ _\* RAM/CPU: Suponiendo que RPC atenderá hasta 1000 solicitudes por segundo. Para implementaciones que esperan entre 1000 y más de 10000 solicitudes por segundo al RPC de Stellar, recomendamos al menos 16 GB de RAM y al menos una CPU de cuatro núcleos con una velocidad de reloj de 2,4 GHz._
+_\* Disco: Suponiendo la ventana de retención predeterminada de 7 días para el almacenamiento de datos. De lo contrario, +40 GB por día de retención_ _\* RAM/CPU: Suponiendo que RPC atenderá un volumen de solicitudes modesto (por ejemplo, 100 solicitudes por segundo a través de todos los endpoints). Para implementaciones que esperan un mayor volumen de solicitudes al RPC de Stellar, recomendamos escalado horizontal y balanceo de carga con al menos 32 GB de RAM y una CPU dimensionada adecuadamente._
 
 Te recomendamos encarecidamente utilizar un disco SSD local para almacenamiento. RPC es compatible con sistemas de archivos basados en la red como AWS EBS, pero impactará negativamente en su rendimiento.
 
-[c5.xlarge]: https://aws.amazon.com/ec2/instance-types/c5/
-[n4-highcpu-4]: https://cloud.google.com/compute/docs/general-purpose-machines#n4-highcpu
+[c5.2xlarge]: https://aws.amazon.com/ec2/instance-types/c5/
+[n4-highcpu-8]: https://cloud.google.com/compute/docs/general-purpose-machines#n4-highcpu

--- a/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -9,7 +9,7 @@ El servicio RPC se puede instalar en hardware físico o en una máquina virtual.
 
 | Tipo de nodo   | CPU    | RAM  | Disco                                    | SKU de AWS  | SKU de Google Cloud |
 | -------------- | ------ | ---- | ---------------------------------------- | ----------- | ------------------- |
-| RPC de Stellar | 2 vCPU | 16GB | Volumen persistente de 250 GB >= 3K IOPS | [c5.xlarge] | [n4-highcpu-4]      |
+| RPC de Stellar | 2 vCPU | 16GB | Volumen persistente de 350 GB >= 3K IOPS | [c5.xlarge] | [n4-highcpu-4]      |
 
 _\* Disco: Suponiendo la ventana de retención predeterminada de 7 días para el almacenamiento de datos. De lo contrario, 20 GB + 20 GB por día de retención_ _\* RAM/CPU: Suponiendo que RPC atenderá hasta 1000 solicitudes por segundo. Para implementaciones que esperan entre 1000 y más de 10000 solicitudes por segundo al RPC de Stellar, recomendamos al menos 16 GB de RAM y al menos una CPU de cuatro núcleos con una velocidad de reloj de 2,4 GHz._
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/data/apis/rpc/admin-guide/prerequisites.mdx
@@ -13,7 +13,7 @@ El servicio RPC se puede instalar en hardware físico o en una máquina virtual.
 
 _\* Disco: Suponiendo la ventana de retención predeterminada de 7 días para el almacenamiento de datos. De lo contrario, +40 GB por día de retención_
 
-_\* RAM/CPU: Suponiendo que RPC atenderá un volumen de solicitudes modesto (por ejemplo, 100 solicitudes por segundo a través de todos los endpoints). Para implementaciones que esperan un mayor volumen de solicitudes al RPC de Stellar, recomendamos escalado horizontal y balanceo de carga con al menos 32 GB de RAM y una CPU dimensionada adecuadamente._
+_\* RAM/CPU: Suponiendo que RPC atenderá un volumen de solicitudes modesto (por ejemplo, 100 solicitudes por segundo a través de todos los endpoints). Para implementaciones que esperan un mayor volumen de solicitudes al RPC de Stellar (por ejemplo, >500 solicitudes por segundo), recomendamos escalado horizontal y balanceo de carga con al menos 32 GB de RAM y una CPU dimensionada adecuadamente._
 
 Te recomendamos encarecidamente utilizar un disco SSD local para almacenamiento. RPC es compatible con sistemas de archivos basados en la red como AWS EBS, pero impactará negativamente en su rendimiento.
 


### PR DESCRIPTION
### What

Updated the RPC minimum hardware recommendations page:
- bumps RPC's disk size requirement to 350Gb instead of 250Gb
- drops recommendation to use a "quad core CPU" for intense load
- shys away from "100 RPS"/"1000 RPS"-based recommendations in favor of "modest load (e.g. 100 RPS on average"/"heavier request volume"
- updates the Spanish counterparts of these recommendations

### Why

Respective to the bullets above,
- when it holds on one week of ledgers/120,960 ledgers, RPC's disk can grow to exceed 300Gb. 350Gb seems to provide a safe buffer.
- we recommend 4-8 vCPUs minimum irrespective of load. recommending a "quad core CPU" for more intense load doesn't make any sense
- there's no grounding for absolutist claims around 100 RPS/1000 RPS, especially because depending on what the request looks like (e.g. is the request`getHealth` or is it `getLedgers` w/ `count=200`), we may easily clear 1000 RPS on the recommended `c5.2xlarge` or may not clear 1 RPS. 
- the Spanish counterpart not only needed the same changes as were made to the English recommendations, but also, it recommended an even more insufficient machine (`c5.xlarge`)