### PR TITLE
Add Stellar Developer Meeting notes for 2026-05-14

### DIFF
--- a/meeting-notes/2026-05-14.mdx
+++ b/meeting-notes/2026-05-14.mdx
@@ -74,7 +74,7 @@ The shape of this tool: best when the underlying work is _coding_ and you want a
 
 [Paperclip](https://paperclip.ing) takes the orchestrator framing one step further. Where Cline Kanban treats your project as a repo, Paperclip treats it as a _company_. You onboard with `npx paperclip-ai onboard --yes`, name the company, give it a mission, hire your first agent (the CEO by default), and from there you're the board.
 
-The demo company was "Paper Excel" — Dunder Mifflin in spirit — with the goal "to be the best paper company in the world with the best-looking UI." The CEO went to work hiring the first team: CTO, CMO, UX designer, research lead, intern. Each role has its own starter prompt, its own heartbeat interval, and its own assigned skill set. The dashboard tracks issues, an organizational chart, an inbox for the board (i.e., you) to receive agent emails, and routines for recurring work. The agent backends are pluggable: Claude Code, Codex, Open Router, Gemini CLI, Hermes Agent, Open Claw.
+The demo company was "Paper Excel" — Dunder Mifflin in spirit — with the goal "to be the best paper company in the world with the best-looking UI." The CEO went to work hiring the first team: CTO, CMO, UX designer, research lead, intern. Each role has its own starter prompt, its own heartbeat interval, and its own assigned skill set. The dashboard tracks issues, an organizational chart, an inbox for the board (i.e., you) to receive agent emails, and routines for recurring work. The agent backends are pluggable: Claude Code, Codex, OpenRouter, Gemini CLI, Hermes Agent, Open Claw.
 
 Two practical notes:
 

--- a/meeting-notes/2026-05-14.mdx
+++ b/meeting-notes/2026-05-14.mdx
@@ -14,7 +14,7 @@ tags: [developer]
 
 ## A Packed Two-Part Meeting
 
-This week's meeting splits cleanly in half. The first half belongs to Renat — a builder in our community working out of Estonia — presenting a draft SEP for zero-knowledge group membership state on Soroban. The second half is mine: a tour of three open-source, free, locally-runnable orchestration layers for AI-assisted development. If ZK isn't your thing, stick around for the second half. If running fleets of agents isn't your thing, the first half is the better one for you.
+This week's meeting splits cleanly in half. The first half belongs to Renat — a builder in our community working out of Estonia — presenting a draft SEP for zero-knowledge group membership state on Soroban. The second half is mine: an introduction to open-source, free, locally-runnable orchestration layers for AI-assisted development. If ZK isn't your thing, stick around for the second half. If running fleets of agents isn't your thing, the first half is the better one for you.
 
 Renat is upfront about the framing: he's a builder, not a mathematician. The work he's presenting isn't a new cryptographic result — it's the integration story of getting Stellar's ZK primitives (shipped in Protocol 22 and Protocol 25) to compose into something useful, and then sharing what works, what doesn't, and what's still unsolved.
 

--- a/meeting-notes/2026-05-14.mdx
+++ b/meeting-notes/2026-05-14.mdx
@@ -1,0 +1,98 @@
+---
+title: "2026-05-14"
+authors: kaankacar
+tags: [developer]
+---
+
+<iframe
+  src="https://www.youtube.com/embed/pZMpqTGGA_Y"
+  title="Stellar Developer Meeting 2026-05-14 recording"
+  width="640"
+  height="480"
+  allow="autoplay"
+></iframe>
+
+## A Packed Two-Part Meeting
+
+This week's meeting splits cleanly in half. The first half belongs to Renat — a builder in our community working out of Estonia — presenting a draft SEP for zero-knowledge group membership state on Soroban. The second half is mine: a tour of three open-source, free, locally-runnable orchestration layers for AI-assisted development. If ZK isn't your thing, stick around for the second half. If running fleets of agents isn't your thing, the first half is the better one for you.
+
+Renat is upfront about the framing: he's a builder, not a mathematician. The work he's presenting isn't a new cryptographic result — it's the integration story of getting Stellar's ZK primitives (shipped in Protocol 22 and Protocol 25) to compose into something useful, and then sharing what works, what doesn't, and what's still unsolved.
+
+## The Problem: Group State Without Metadata
+
+The naive way to put a group on-chain is to store a list of addresses. That works, and it's terrible for privacy — anyone who reads the contract storage knows who is in the group, who is an admin, and what the governance rules are.
+
+The use cases Renat is targeting all want the opposite shape: a messenger that hides which group a user belongs to, DAO credentials that prove "I'm a member" without revealing _who_ I am, governance contracts that enforce rules without leaking the rule structure (is this a democracy, a tyranny, a one-on-one?). The problem is "prove membership and authority without revealing identity," which is the classic zero-knowledge setting.
+
+## Three Iterations: Groth16 → PLONK → Post-Quantum
+
+Renat walked through the iteration history:
+
+**Groth16** was the starting point. It worked, but supporting governance rules over a hidden group required contributing randomness via a trusted-setup ceremony. The standard reassurance — "you only need one honest contributor out of fifty" — is mathematically fine, and the Ethereum KZG ceremony had ~141,000 contributors as proof-by-example, but the operational burden of running a credible ceremony at a small-project scale didn't fit.
+
+**PLONK** was the second iteration, chosen explicitly to dodge the trusted-setup ceremony. This is what's currently live on testnet, and it owes its existence to the Soroban primitives shipped in Protocols 22 and 25. The contract interface is small: update the Merkle tree, verify membership, create group — with the proof transported separately from identity. A postmortem about getting the proof from client to contract is part of the package; that turned out to be the part of the work that bit the hardest.
+
+**Post-Quantum (no ceremony at all)** is the direction Renat wants to take this next. It's currently blocked on memory consumption inside the Soroban environment — not CPU, which was his initial guess, but memory. The Stellar developers helped him diagnose this. Cost is also a factor at the post-quantum end — somewhere north of 16 cents per update versus less than a cent for the PLONK path.
+
+## Cost, Limits, and the Open Payer Problem
+
+The PLONK version is cheap. State updates cost less than a cent, and the actual messages in the messenger reference implementation are free. That's a usable cost envelope for a real product.
+
+The limits worth knowing:
+
+- **PLONK is bounded by K max 2** in the current configuration — meaning "democracy" in the governance taxonomy doesn't scale to large groups yet. Two voters max per vote at the current parameters.
+- **TTL and contract capacity** need to be designed into any SEP draft. They don't disqualify the approach, but they aren't free parameters either.
+- **The payer/anonymous-user interface** is the most interesting open problem: somewhere in the flow, gas needs to come from somewhere, and "the anonymous member pays" leaks information unless handled carefully. This is the surface point of contact between the fee-paying entity and the privacy-preserving member, and there's no good answer in the current draft.
+
+The code is MIT-licensed and reproducible — the runs are public, the reference messenger implementation is published, and Renat is explicit that what's shown is reference-quality, not production-ready.
+
+## What Renat Is Looking For
+
+This part is the actual call to action: Renat is looking for a SEP champion in the developer community. Someone who can read the draft, push it through the ecosystem-proposal process, and validate that the work is useful beyond his own messenger project.
+
+If that sounds like you, his Discord handle is pinned in the meeting comments, and his email and GitHub are reachable from the reference implementation's README. He's open to "this works" feedback, "this doesn't work" feedback, and — the most useful kind — "this works but here's the obstacle you missed." He's planning to attend [Meridian 2026](https://meridian.stellar.org) in Lisbon this October, so the champion conversation can also happen in person.
+
+## The Orchestrator Shift
+
+The pivot of the second half: if you've been building on Stellar for any length of time, you're using AI. Pretending otherwise is silly. The interesting question is what _kind_ of AI use you're doing.
+
+There are two roles to recognize. The earlier role — the **facilitator** — is what most of us got used to between November 2022 and roughly the end of 2024: you write what you think, you write what you want, you guide the model through the build, and you stay close to the work. Cursor Composer, Sonnet 4, GPT-o3 — all of these reward facilitation.
+
+The newer role — the **orchestrator** — is what Opus 4.7, Composer 2, the Claude Agents SDK, and the autonomous-agent stacks (Hermes, Open Claw, custom-built agents) are designed for. You're no longer the one writing prompts to a single model; you're managing a fleet, and your job is to keep that fleet aimed at a useful outcome. That's a different skill, and the tools for that role are still finding their shape.
+
+The three tools in the second half of this meeting are all attempts at giving the orchestrator a control plane.
+
+## Cline Kanban
+
+Cline Kanban — free, open-source, runs locally — is the lightest of the three. It's a Kanban board for agent work, built on top of Cline (the open-source coding agent that ships an SDK, a CLI, and a VS Code extension of its own). You drop into a project directory, run `kanban`, and a local web UI comes up. The board can attach to any of the major agents — Cline itself, Claude Code, Codex, Factory Droid, Kiro, Hermes — and you use it to define tasks, set dependencies between them, and drag work through To Do → In Progress → Review → Done.
+
+The demo: a fresh directory called `x402-contest-demo`, a one-line ask to "create an exploratory x402 demo on Stellar," and the Kanban agent decomposed it into five linked tasks. From that point on, the orchestrator's job is to review each completed task, decide whether to merge to main, and unblock the next one in the chain. The board offers auto-commit, open-PR, and "leave on branch" flows; while you're getting a feel for an agent's output quality, "ask for approval at each step" is the right default.
+
+The shape of this tool: best when the underlying work is _coding_ and you want a lightweight layer on top of one or more agents to keep tasks orderly and dependencies explicit.
+
+## Paperclip: A Control Plane for AI Labor
+
+[Paperclip](https://paperclip.ing) takes the orchestrator framing one step further. Where Cline Kanban treats your project as a repo, Paperclip treats it as a _company_. You onboard with `npx paperclip-ai onboard --yes`, name the company, give it a mission, hire your first agent (the CEO by default), and from there you're the board.
+
+The demo company was "Paper Excel" — Dunder Mifflin in spirit — with the goal "to be the best paper company in the world with the best-looking UI." The CEO went to work hiring the first team: CTO, CMO, UX designer, research lead, intern. Each role has its own starter prompt, its own heartbeat interval, and its own assigned skill set. The dashboard tracks issues, an organizational chart, an inbox for the board (i.e., you) to receive agent emails, and routines for recurring work. The agent backends are pluggable: Claude Code, Codex, Open Router, Gemini CLI, Hermes Agent, Open Claw.
+
+Two practical notes:
+
+- **It is not a magic productivity multiplier.** It's a coordination layer for running multiple agents — most of the agents in the demo were slacking on their first day, and roughly half the issues failed on first run with API errors. This is alpha-quality at the experience level, even where the underlying agent capabilities are strong.
+- **It will burn through tokens fast.** Bring-your-own-API-key with per-agent spending caps is the right way to experiment. The demo ran on a Claude Code subscription and was probably $50–100 of usage in 30 minutes. For exploratory work, point it at a free model on OpenRouter — output quality is worse, but cost is bounded.
+
+The shape of this tool: best when the work is broader than coding — a research-and-marketing-and-content-and-product company-shaped problem — and you want to see what "running a small AI org" actually feels like before staffing one in real life.
+
+## BMAD Method (Saved for Next Week)
+
+The third tool is the BMAD method — this week's favorite, and the one I most wanted to demo. The meeting ran long (the first half earned its time), and BMAD is worth a real walkthrough rather than five rushed minutes. Tune in next week for that one.
+
+The one-sentence pitch: BMAD is for builders who want an Agile development flow with their agents, and for builders who want a thoughtful brainstorming partner that's read more about the problem space than they have. If either of those describes your current bottleneck, the deferred demo will be the one to catch.
+
+## Where This Is Going
+
+Two takeaways:
+
+The move from facilitator to orchestrator isn't a tooling upgrade — it's a skill change. The tools shown today are the early shape of what that change looks like: local-first, agent-agnostic, opinionated about how you compose work. They're not finished. They will get better.
+
+And: if you have time before next week, read Renat's draft and the reference implementation. A SEP that lets Soroban hold private group state cheaply is exactly the kind of primitive that quietly unlocks an entire category of applications later. The champion role is open.

--- a/routes.txt
+++ b/routes.txt
@@ -902,6 +902,7 @@
 /meetings/2026/04/16
 /meetings/2026/04/23
 /meetings/2026/05/07
+/meetings/2026/05/14
 /meetings/archive
 /meetings/authors
 /meetings/authors/carstenjacobsen


### PR DESCRIPTION
The latest Stellar Developer Meeting recordings are missing from the docs. This issue tracks adding the corresponding .mdx files to the meetings/ directory.

Meetings to Add

2026-05-14 — https://www.youtube.com/embed/pZMpqTGGA_Y