### PR TITLE
fix(meeting-notes/2026-04-23): correct MPP Router URL and mainnet status

### DIFF
--- a/meeting-notes/2026-04-23.mdx
+++ b/meeting-notes/2026-04-23.mdx
@@ -69,9 +69,9 @@ One note for anyone building in this space: distribution is everything for infra
 
 ### MPP Router (Rozo)
 
-[mpprouter.net.dev](https://mpprouter.net.dev) is a payment network router specifically designed for agent-to-agent micropayments. On Tempo, there are over 400 MPP endpoints. This router makes it possible for users and agents on Stellar to reach and use those endpoints by paying on Stellar.
+[mpprouter.dev](https://mpprouter.dev) is a payment network router specifically designed for agent-to-agent micropayments. On Tempo, there are over 400 MPP endpoints. This router makes it possible for users and agents on Stellar to reach and use those endpoints by paying on Stellar.
 
-Not yet on mainnet, but the problem it solves is real and concrete: 400 agents on another network, and this project makes them reachable from Stellar. The way to find good project ideas is to find the pain points of a network — this one found a clear one.
+It's on mainnet. The problem it solves is real and concrete: 400 agents on another network, and this project makes them reachable from Stellar. The way to find good project ideas is to find the pain points of a network — this one found a clear one.
 
 ### Stellar Security Audit Agent
 


### PR DESCRIPTION
Small fact corrections in the MPP Router (Rozo) blurb under `meeting-notes/2026-04-23.mdx`:

1. Domain typo: `mpprouter.net.dev` → `mpprouter.dev` (both the link text and the href).
2. "Not yet on mainnet" → "It's on mainnet." — the router has been live on Stellar mainnet at https://apiserver.mpprouter.dev for a while now.

Thanks for the writeup! 🙏

— Shawn (Rozo / MPP Router)