### PR TITLE
chore: update java-stellar-sdk dependency to 3.0.0

### DIFF
--- a/docs/build/guides/transactions/create-account.mdx
+++ b/docs/build/guides/transactions/create-account.mdx
@@ -481,7 +481,7 @@ func check(err error) {
 ```java
 // File: main.java
 // Dependencies (Maven coordinates):
-//   org.stellar:java-stellar-sdk:0.43.0-SNAPSHOT
+//   org.stellar:java-stellar-sdk:3.0.0
 //   com.fasterxml.jackson.core:jackson-databind:2.17.2
 
 import java.io.IOException;


### PR DESCRIPTION
## Summary

- Updates the Maven dependency comment in the Java create-account example from the stale pre-release `0.43.0-SNAPSHOT` to the current stable `3.0.0`

## Context

`java-stellar-sdk` 3.0.0 was released April 22, 2026. Notable changes in this release:

- Removed previously deprecated `StrKey` helper methods (use `StrKey.encodeEd25519PublicKey(byte[])` and `MuxedAccount` instead)
- Added SEP-0051 (XDR-JSON) support
- Fixed OkHttp SSE factory for Horizon streams
- Enhanced `ScMap` entry sorting to comply with Soroban runtime ordering requirements
- Expanded `GetLatestLedgerResponse` with `closeTime`, `headerXdr`, and `metadataXdr` fields
- Updated XDR definitions to `stellar-xdr v26.0`
- **Build from source now requires JDK 21 and Gradle 9.4.1**; published artifacts remain Java 8 compatible

No existing code examples used the removed `StrKey` methods, so only the version comment needs updating.

## Test plan

- [ ] Verify the Java code block in `docs/build/guides/transactions/create-account.mdx` shows `org.stellar:java-stellar-sdk:3.0.0`
- [ ] Confirm the example compiles against the 3.0.0 artifact

https://claude.ai/code/session_0153obE5b1Rb9p6MAFVydK9R

---
_Generated by [Claude Code](https://claude.ai/code/session_0153obE5b1Rb9p6MAFVydK9R)_