### PR TITLE
chore: document py-stellar-base v14.0.0 breaking changes

### DIFF
--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -38,7 +38,7 @@ It provides:
 
 **The Python SDK is maintained by dedicated community developers.**
 
-`py-stellar-base` is a Python library for communicating with a Stellar Horizon server. It is used for building Stellar apps on Python. It supports Python 3.7+ as well as PyPy 3.7+.
+`py-stellar-base` is a Python library for communicating with a Stellar Horizon server. It is used for building Stellar apps on Python. It supports Python 3.9+ as well as PyPy 3.9+.
 
 This SDK is maintained by a dedicated community developer.
 
@@ -46,6 +46,19 @@ It provides:
 
 - A networking layer API for Horizon endpoints.
 - Facilities for building and signing transactions, for communicating with a Stellar Horizon instance, and for submitting transactions or querying network history.
+
+:::caution v14.0.0 breaking changes
+
+`py-stellar-base` v14.0.0 (released May 2026) contains several breaking changes:
+
+- **Auth API redesign**: `authorize_entry()` now accepts `signers` as `Callable[[HashIDPreimage], SCVal]` instead of returning `(public_key, signature)` tuples. The `authorize_invocation()` parameter `public_key` was renamed to `address`. `AssembledTransaction.sign_auth_entries()` now requires an `address` parameter for non-`Keypair` signers.
+- **Removed**: `StrKey.encode_muxed_account` and `StrKey.decode_muxed_account` — use `MuxedAccount` instead.
+- **Removed**: `TransactionBuilder.append_create_stellar_asset_contract_from_address_op` — use `append_create_contract_op` instead.
+- **Dropped**: PyPy 3.10 support.
+
+See the [v14.0.0 release notes](https://github.com/StellarCN/py-stellar-base/releases/latest) for the full changelog.
+
+:::
 
 ## Rust
 


### PR DESCRIPTION
## Summary

- Adds a `:::caution` callout to the Python SDK section of `docs/tools/sdks/client-sdks.mdx` documenting the breaking changes introduced in `py-stellar-base` v14.0.0
- Updates the supported Python/PyPy version range (`3.7+` → `3.9+`)

## Context

`py-stellar-base` v14.0.0 was released May 3, 2026 with several breaking changes that developers need to be aware of before upgrading:

**Auth API redesign**
- `authorize_entry()` now accepts `signers` as `Callable[[HashIDPreimage], SCVal]` instead of `(public_key, signature)` tuples
- `authorize_invocation()` parameter `public_key` renamed to `address`
- `AssembledTransaction.sign_auth_entries()` now requires an `address` parameter for non-`Keypair` signers

**Removed APIs**
- `StrKey.encode_muxed_account` / `StrKey.decode_muxed_account` → use `MuxedAccount`
- `TransactionBuilder.append_create_stellar_asset_contract_from_address_op` → use `append_create_contract_op`

**Dropped support**
- PyPy 3.10

None of the existing code examples in the docs used the removed APIs, so no example code needed rewriting — only the informational callout was added.

## Test plan

- [ ] Verify the caution callout renders correctly on the Client SDKs page
- [ ] Confirm all links in the callout resolve

https://claude.ai/code/session_0153obE5b1Rb9p6MAFVydK9R

---
_Generated by [Claude Code](https://claude.ai/code/session_0153obE5b1Rb9p6MAFVydK9R)_