### PR TITLE
chore: note js-stellar-sdk v15.1.0 BalanceResponse.revocable deprecation

### DIFF
--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -32,6 +32,20 @@ It provides:
 - A networking layer API for Stellar RPC methods and the Horizon API.
 - Facilities for building and signing transactions, for communicating with an RPC instance, for communicating with a Horizon instance, and for submitting transactions or querying network state.
 
+:::info v15.1.0 deprecation
+
+`BalanceResponse.revocable` is deprecated in favour of `authorizedToMaintainLiabilities`. Update any code that reads this field on trustline balance objects returned from `loadAccount()`:
+
+```js
+// Before (deprecated)
+const isRevocable = balance.revocable;
+
+// After
+const isRevocable = balance.authorizedToMaintainLiabilities;
+```
+
+:::
+
 ## Python SDK
 
 [Python SDK](https://github.com/StellarCN/py-stellar-base) | [Docs](https://stellar-sdk.readthedocs.io/en/latest/) | [Examples](https://github.com/StellarCN/py-stellar-base/tree/master/examples)


### PR DESCRIPTION
## Summary

- Adds an `:::info` callout to the JavaScript SDK section of `docs/tools/sdks/client-sdks.mdx` noting the deprecation of `BalanceResponse.revocable` and providing a before/after migration snippet

## Context

`js-stellar-sdk` v15.1.0 was released May 4, 2026. The `revocable` field on `BalanceResponse` (trustline balance objects returned from `loadAccount()`) is now deprecated in favour of `authorizedToMaintainLiabilities`.

Other notable changes in v15.1.0:
- Domain validation in `FederationServer` now follows RFC 1035
- Fixed polling loop logic in `RpcServer.pollTransaction`
- Fixed URL mutation issues in `FederationServer` and `CallBuilder.stream()`
- Fixed trustline flag bitmasks in `getAssetBalance`
- Added `transactions` collection to account responses
- Upgraded axios from 1.14.0 to 1.15.0

No existing code examples used `.revocable` directly, so only the informational callout with a migration snippet was added.

## Test plan

- [ ] Verify the info callout renders correctly on the Client SDKs page
- [ ] Confirm the code snippet in the callout is syntactically valid

https://claude.ai/code/session_0153obE5b1Rb9p6MAFVydK9R

---
_Generated by [Claude Code](https://claude.ai/code/session_0153obE5b1Rb9p6MAFVydK9R)_