### PR TITLE
Remove June 17, 2026 Testnet reset date

### DIFF
--- a/docs/networks/README.mdx
+++ b/docs/networks/README.mdx
@@ -63,7 +63,6 @@ Testnet resets typically happen 2-4 times per year at 17:00 UTC and are announce
 
 Here are the scheduled 2026 dates:
 
-- June 17, 2026
 - December 16, 2026
 
 If you run a Testnet or Futurenet Horizon instance, you need to re-join and re-sync to the network after a reset. Check out how to do that here: [Testnet Reset](https://github.com/stellar/packages/blob/master/docs/testnet-reset.md).


### PR DESCRIPTION
### What

Drop the June 17, 2026 entry from the list of scheduled 2026 Testnet reset dates on the networks page, leaving December 16, 2026 as the remaining scheduled reset.

### Why

The June 17, 2026 reset is no longer on the schedule, so listing it would mislead developers into planning around a reset that will not occur.