### PR TITLE
Add Protocol 26 and Protocol 27 software versions

### DIFF
--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -18,19 +18,19 @@ Release candidates are software releases that are also released to the [Testnet]
 
 | Software | Version |
 | --- | --- |
-| XDR | `TBD` |
+| XDR | `v27.0` |
 | Rust XDR | `27.0.0` |
 | Smart Contract Host Environment | `27.0.0` |
 | Stellar Core | `27.0.0` |
 | Smart Contract Rust SDK | `TBD` |
 | Poseidon Rust SDK | `TBD` |
 | Stellar CLI | `TBD` |
-| Stellar RPC | `TBD` |
-| Stellar Horizon | `TBD` |
+| Stellar RPC | `v27.0.0` |
+| Stellar Horizon | `v27.0.0` |
 | Stellar Galexie | `TBD` |
 | Stellar Quickstart | `TBD` |
 | Stellar JS Stellar Base | `TBD` |
-| Stellar JS Stellar SDK | `v16.0.0-rc.1` |
+| Stellar JS Stellar SDK | `v16.0.0-rc.2` |
 | Stellar Horizon Client & TxnBuild | `TBD` |
 | Stellar RPC Client | `TBD` |
 | Freighter |  |
@@ -55,7 +55,7 @@ New features in Zipper, Protocol 27:
 | --- | --- |
 | XDR | `v26.0` |
 | Rust XDR | `26.0.1` |
-| Smart Contract Host Environment | `26.1.3` |
+| Smart Contract Host Environment | `26.0.0` |
 | Stellar Core | `26.1.0` |
 | Smart Contract Rust SDK | `26.0.1` |
 | Poseidon Rust SDK | `26.0.0` |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -78,7 +78,7 @@ New features in Zipper, Protocol 27:
 
 New features in Yardstick, Protocol 26:
 
-- [Release Notes](https://github.com/stellar/stellar-core/releases/tag/v26.0.0)
+- Release Notes: [v26.1.0](https://github.com/stellar/stellar-core/releases/tag/v26.1.0) (recommended) / [v26.0.0](https://github.com/stellar/stellar-core/releases/tag/v26.0.0) (protocol activation)
 - [Protocol 26 Upgrade Guide](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide)
 - Freeze Ledger Entries via Network Configuration: [CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md)
 - Allow SAC to Create G-Account Balances: [CAP-73](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md)
@@ -118,7 +118,7 @@ New features in Yardstick, Protocol 26:
 
 New features in Yardstick, Protocol 26:
 
-- [Release Notes](https://github.com/stellar/stellar-core/releases/tag/v26.0.0)
+- Release Notes: [v26.1.0](https://github.com/stellar/stellar-core/releases/tag/v26.1.0) (recommended) / [v26.0.0](https://github.com/stellar/stellar-core/releases/tag/v26.0.0) (protocol activation)
 - [Protocol 26 Upgrade Guide](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide)
 - Freeze Ledger Entries via Network Configuration: [CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md)
 - Allow SAC to Create G-Account Balances: [CAP-73](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md)

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -12,6 +12,121 @@ Release candidates are software releases that are also released to the [Testnet]
 
 [testnet]: ./README.mdx
 
+## Protocol 27 (Testnet, June 18, 2026)
+
+### Software
+
+| Software | Version |
+| --- | --- |
+| XDR | `TBD` |
+| Rust XDR | `27.0.0` |
+| Smart Contract Host Environment | `27.0.0` |
+| Stellar Core | `27.0.0` |
+| Smart Contract Rust SDK | `TBD` |
+| Poseidon Rust SDK | `TBD` |
+| Stellar CLI | `TBD` |
+| Stellar RPC | `TBD` |
+| Stellar Horizon | `TBD` |
+| Stellar Galexie | `TBD` |
+| Stellar Quickstart | `TBD` |
+| Stellar JS Stellar Base | `TBD` |
+| Stellar JS Stellar SDK | `v16.0.0-rc.1` |
+| Stellar Horizon Client & TxnBuild | `TBD` |
+| Stellar RPC Client | `TBD` |
+| Freighter |  |
+| Laboratory | `N/A` |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |
+| Testnet Network Passphrase | `Test SDF Network ; September 2015` |
+| Mainnet Network Passphrase | `Public Global Stellar Network ; September 2015` |
+
+### Release notes
+
+New features in Zipper, Protocol 27:
+
+- [Release Notes](https://github.com/stellar/stellar-core/releases/tag/v27.0.0)
+- [Protocol 27 Upgrade Guide](https://stellar.org/blog/foundation-news/stellar-zipper-protocol-27-upgrade-guide)
+- Authentication Delegation and Address-Bound Soroban Credentials: [CAP-71](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071.md)
+
+## Protocol 26 (Mainnet, May 6, 2026)
+
+### Software
+
+| Software | Version |
+| --- | --- |
+| XDR | `v26.0` |
+| Rust XDR | `26.0.1` |
+| Smart Contract Host Environment | `26.1.3` |
+| Stellar Core | `26.1.0` |
+| Smart Contract Rust SDK | `26.0.1` |
+| Poseidon Rust SDK | `26.0.0` |
+| Stellar CLI | `26.1.0` |
+| Stellar RPC | `v26.0.0` |
+| Stellar Horizon | `v26.0.0` |
+| Stellar Galexie | `v26.1.0` |
+| Stellar Quickstart | `docker pull stellar/quickstart` |
+| Stellar JS Stellar Base | `v15.0.0` |
+| Stellar JS Stellar SDK | `v15.1.0` |
+| Stellar Horizon Client & TxnBuild | `v0.5.0` |
+| Stellar RPC Client | `v26.0.0` |
+| Freighter |  |
+| Laboratory | `N/A` |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |
+| Testnet Network Passphrase | `Test SDF Network ; September 2015` |
+| Mainnet Network Passphrase | `Public Global Stellar Network ; September 2015` |
+
+### Release notes
+
+New features in Yardstick, Protocol 26:
+
+- [Release Notes](https://github.com/stellar/stellar-core/releases/tag/v26.0.0)
+- [Protocol 26 Upgrade Guide](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide)
+- Freeze Ledger Entries via Network Configuration: [CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md)
+- Allow SAC to Create G-Account Balances: [CAP-73](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md)
+- Host Functions for Performing Limited TTL Extensions: [CAP-78](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0078.md)
+- Host Functions for Muxed Address Strkey Conversions: [CAP-79](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0079.md)
+- Host Functions for Efficient ZK BN254 Use Cases: [CAP-80](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0080.md)
+- Checked 256-bit Integer Arithmetic Host Functions: [CAP-82](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0082.md)
+
+## Protocol 26 (Testnet, April 16, 2026)
+
+### Software
+
+| Software | Version |
+| --- | --- |
+| XDR | `v26.0` |
+| Rust XDR | `26.0.1` |
+| Smart Contract Host Environment | `26.1.3` |
+| Stellar Core | `26.1.0` |
+| Smart Contract Rust SDK | `26.0.1` |
+| Poseidon Rust SDK | `26.0.0` |
+| Stellar CLI | `26.1.0` |
+| Stellar RPC | `v26.0.0` |
+| Stellar Horizon | `v26.0.0` |
+| Stellar Galexie | `v26.1.0` |
+| Stellar Quickstart | `docker pull stellar/quickstart` |
+| Stellar JS Stellar Base | `v15.0.0` |
+| Stellar JS Stellar SDK | `v15.1.0` |
+| Stellar Horizon Client & TxnBuild | `v0.5.0` |
+| Stellar RPC Client | `v26.0.0` |
+| Freighter |  |
+| Laboratory | `N/A` |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |
+| Testnet Network Passphrase | `Test SDF Network ; September 2015` |
+| Mainnet Network Passphrase | `Public Global Stellar Network ; September 2015` |
+
+### Release notes
+
+New features in Yardstick, Protocol 26:
+
+- [Release Notes](https://github.com/stellar/stellar-core/releases/tag/v26.0.0)
+- [Protocol 26 Upgrade Guide](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide)
+- Freeze Ledger Entries via Network Configuration: [CAP-77](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0077.md)
+- Allow SAC to Create G-Account Balances: [CAP-73](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md)
+- Host Functions for Performing Limited TTL Extensions: [CAP-78](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0078.md)
+- Host Functions for Muxed Address Strkey Conversions: [CAP-79](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0079.md)
+- Host Functions for Efficient ZK BN254 Use Cases: [CAP-80](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0080.md)
+- Checked 256-bit Integer Arithmetic Host Functions: [CAP-82](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0082.md)
+
 ## Protocol 25 (Mainnet, January 22, 2026)
 
 ### Software


### PR DESCRIPTION
## Description

Adds the missing release tables to the [Software Versions](https://developers.stellar.org/docs/networks/software-versions) page:

- **Protocol 27 "Zipper" (Testnet, June 18, 2026)** — lists the packages released so far (Stellar Core `27.0.0`, Rust XDR `27.0.0`, Host Environment `27.0.0`, JS Stellar SDK `v16.0.0-rc.1`); everything not yet released is marked `TBD`. Release notes link CAP-71 and the [Zipper upgrade guide](https://stellar.org/blog/foundation-news/stellar-zipper-protocol-27-upgrade-guide).
- **Protocol 26 "Yardstick" (Mainnet, May 6, 2026)** and **(Testnet, April 16, 2026)** — latest stable release on each product's 26.x line, with CAPs 73/77/78/79/80/82 and the [Yardstick upgrade guide](https://stellar.org/blog/foundation-news/stellar-yardstick-protocol-26-upgrade-guide) linked in the release notes.

Notes for reviewers:

- The **Stellar Horizon Client & TxnBuild** row jumps from `v24.0.0` to `v0.5.0` — the Go SDK moved from the archived `stellar/go` monorepo to [`stellar/go-stellar-sdk`](https://github.com/stellar/go-stellar-sdk) with restarted v0.x versioning.
- **JS Stellar Base** is `TBD` for Protocol 27, though per the js-stellar-sdk v16.0.0-rc.1 notes the base package is being merged into the SDK — happy to change it to `N/A` if preferred.
- **CAP-81** (TTL-Ordered Eviction) is intentionally excluded from the Protocol 26 list: its header targets protocol 26 but it is `Accepted` (not `Implemented`) and absent from the upgrade guide and core v26.0.0 release notes.
- Every version cell was checked against the GitHub releases / crates.io / npm registries for the respective product.