### PR TITLE
Update soroban-sdk version reference and add BytesN array conversion for 26.1.0

### DIFF
--- a/docs/build/guides/conversions/bytes-conversions.mdx
+++ b/docs/build/guides/conversions/bytes-conversions.mdx
@@ -114,7 +114,7 @@ sc_val = stellar_sdk.scval.to_bytes(raw_bytes)
 
 ## BytesN to Fixed-Size Array
 
-`BytesN<N>` is a fixed-length byte buffer used for values like hashes and public keys. It can be converted to a native Rust `[u8; N]` array using the `to_array()` method or the standard `Into` trait. As of soroban-sdk 26.1.0, this conversion uses a zero-copy approach that avoids memory allocation, reducing CPU usage by up to 80% compared to earlier versions.
+`BytesN<N>` is a fixed-length byte buffer used for values like hashes and public keys. It can be converted to a native Rust `[u8; N]` array using the `to_array()` method or the standard `Into` trait.
 
 <CodeExample>
 

--- a/docs/build/guides/conversions/bytes-conversions.mdx
+++ b/docs/build/guides/conversions/bytes-conversions.mdx
@@ -111,3 +111,30 @@ sc_val = stellar_sdk.scval.to_bytes(raw_bytes)
 ```
 
 </CodeExample>
+
+## BytesN to Fixed-Size Array
+
+`BytesN<N>` is a fixed-length byte buffer used for values like hashes and public keys. It can be converted to a native Rust `[u8; N]` array using the `to_array()` method or the standard `Into` trait. As of soroban-sdk 26.1.0, this conversion uses a zero-copy approach that avoids memory allocation, reducing CPU usage by up to 80% compared to earlier versions.
+
+<CodeExample>
+
+```rust
+use soroban_sdk::BytesN;
+
+// Convert by value using to_array()
+pub fn bytesn_to_array(b: BytesN<32>) -> [u8; 32] {
+    b.to_array()
+}
+
+// Convert by value using Into — delegates to to_array() internally
+pub fn bytesn_into_array(b: BytesN<32>) -> [u8; 32] {
+    b.into()
+}
+
+// Convert by reference — original BytesN is not consumed
+pub fn bytesn_ref_to_array(b: &BytesN<32>) -> [u8; 32] {
+    b.into()
+}
+```
+
+</CodeExample>

--- a/docs/build/guides/conversions/bytes-conversions.mdx
+++ b/docs/build/guides/conversions/bytes-conversions.mdx
@@ -126,12 +126,12 @@ pub fn bytesn_to_array(b: BytesN<32>) -> [u8; 32] {
     b.to_array()
 }
 
-// Convert by value using Into — delegates to to_array() internally
+// Convert by value using Into
 pub fn bytesn_into_array(b: BytesN<32>) -> [u8; 32] {
     b.into()
 }
 
-// Convert by reference — original BytesN is not consumed
+// Convert by reference (original BytesN is not consumed)
 pub fn bytesn_ref_to_array(b: &BytesN<32>) -> [u8; 32] {
     b.into()
 }

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -20,7 +20,7 @@ Create a new project using the `init` command to create a `soroban-hello-world` 
 stellar contract init soroban-hello-world
 ```
 
-The `init` command will create a Rust workspace project, using the recommended structure for including Soroban contracts. Let’s take a look at the project structure:
+The `init` command will create a Rust workspace project, using the recommended structure for including Soroban contracts. Let's take a look at the project structure:
 
 ```
 .
@@ -29,11 +29,11 @@ The `init` command will create a Rust workspace project, using the recommended s
 ├── README.md
 └── contracts
     ├── hello_world
-    │   ├── Cargo.toml
-    │   ├── Makefile
-    │   ├── src
-    │   │   ├── lib.rs
-    │   │   └── test.rs
+    │   ├── Cargo.toml
+    │   ├── Makefile
+    │   ├── src
+    │   │   ├── lib.rs
+    │   │   └── test.rs
 ```
 
 ### Cargo.toml
@@ -42,7 +42,7 @@ The `Cargo.toml` file at the root of the project is set up as Rust Workspace, wh
 
 #### Rust Workspace
 
-The `Cargo.toml` file sets the workspace’s members as all contents of the `contracts` directory and sets the workspace’s `soroban-sdk` dependency version including the `testutils` feature, which will allow test utilities to be generated for calling the contract in tests.
+The `Cargo.toml` file sets the workspace's members as all contents of the `contracts` directory and sets the workspace's `soroban-sdk` dependency version including the `testutils` feature, which will allow test utilities to be generated for calling the contract in tests.
 
 ```toml title="Cargo.toml"
 [workspace]
@@ -52,7 +52,7 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "22"
+soroban-sdk = "26"
 ```
 
 :::info
@@ -131,7 +131,7 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 
 #### Contract Source Code
 
-Creating a Soroban contract involves writing Rust code in the project’s `lib.rs` file.
+Creating a Soroban contract involves writing Rust code in the project's `lib.rs` file.
 
 All contracts should begin with `#![no_std]` to ensure that the Rust standard library is not included in the build. The Rust standard library is large and not well suited to being deployed into small programs like those deployed to blockchains.
 
@@ -186,7 +186,7 @@ impl Contract {
 mod test;
 ```
 
-Note the `mod test` line at the bottom, this will tell Rust to compile and run the test code, which we’ll take a look at next.
+Note the `mod test` line at the bottom, this will tell Rust to compile and run the test code, which we'll take a look at next.
 
 #### Contract Unit Tests
 

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -29,11 +29,11 @@ The `init` command will create a Rust workspace project, using the recommended s
 ├── README.md
 └── contracts
     ├── hello_world
-    │   ├── Cargo.toml
-    │   ├── Makefile
-    │   ├── src
-    │   │   ├── lib.rs
-    │   │   └── test.rs
+    │   ├── Cargo.toml
+    │   ├── Makefile
+    │   ├── src
+    │   │   ├── lib.rs
+    │   │   └── test.rs
 ```
 
 ### Cargo.toml

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -20,7 +20,7 @@ Create a new project using the `init` command to create a `soroban-hello-world` 
 stellar contract init soroban-hello-world
 ```
 
-The `init` command will create a Rust workspace project, using the recommended structure for including Soroban contracts. Let's take a look at the project structure:
+The `init` command will create a Rust workspace project, using the recommended structure for including Soroban contracts. Let’s take a look at the project structure:
 
 ```
 .
@@ -42,7 +42,7 @@ The `Cargo.toml` file at the root of the project is set up as Rust Workspace, wh
 
 #### Rust Workspace
 
-The `Cargo.toml` file sets the workspace's members as all contents of the `contracts` directory and sets the workspace's `soroban-sdk` dependency version including the `testutils` feature, which will allow test utilities to be generated for calling the contract in tests.
+The `Cargo.toml` file sets the workspace’s members as all contents of the `contracts` directory and sets the workspace’s `soroban-sdk` dependency version including the `testutils` feature, which will allow test utilities to be generated for calling the contract in tests.
 
 ```toml title="Cargo.toml"
 [workspace]
@@ -57,7 +57,7 @@ soroban-sdk = "26"
 
 :::info
 
-The `testutils` are automatically enabled inside [Rust unit tests] inside the same crate as your contract. If you write tests from another crate, you'll need to require the `testutils` feature for those tests and enable the `testutils` feature when running your tests with `cargo test --features testutils` to be able to use those test utilities.
+The `testutils` are automatically enabled inside [Rust unit tests] inside the same crate as your contract. If you write tests from another crate, you’ll need to require the `testutils` feature for those tests and enable the `testutils` feature when running your tests with `cargo test --features testutils` to be able to use those test utilities.
 
 :::
 
@@ -131,7 +131,7 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 
 #### Contract Source Code
 
-Creating a Soroban contract involves writing Rust code in the project's `lib.rs` file.
+Creating a Soroban contract involves writing Rust code in the project’s `lib.rs` file.
 
 All contracts should begin with `#![no_std]` to ensure that the Rust standard library is not included in the build. The Rust standard library is large and not well suited to being deployed into small programs like those deployed to blockchains.
 
@@ -145,7 +145,7 @@ The contract imports the types and macros that it needs from the `soroban-sdk` c
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 ```
 
-Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
+Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment’s memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
 
 Contract inputs must not be references.
 
@@ -186,11 +186,11 @@ impl Contract {
 mod test;
 ```
 
-Note the `mod test` line at the bottom, this will tell Rust to compile and run the test code, which we'll take a look at next.
+Note the `mod test` line at the bottom, this will tell Rust to compile and run the test code, which we’ll take a look at next.
 
 #### Contract Unit Tests
 
-Writing tests for Soroban contracts involves writing Rust code using the test facilities and toolchain that you'd use for testing any Rust code.
+Writing tests for Soroban contracts involves writing Rust code using the test facilities and toolchain that you’d use for testing any Rust code.
 
 Given our `Contract`, a simple test will look like this.
 
@@ -307,7 +307,7 @@ stellar contract build
 
 :::tip
 
-If you get an error like `can't find crate for 'core'`, it means you didn't install the wasm32 target during the [setup step](./setup.mdx#install-the-target). You can do so by running `rustup target add wasm32v1-none` (reminder, this requires Rust `v1.84.0` or higher).
+If you get an error like `can't find crate for 'core'`, it means you didn’t install the wasm32 target during the [setup step](./setup.mdx#install-the-target). You can do so by running `rustup target add wasm32v1-none` (reminder, this requires Rust `v1.84.0` or higher).
 
 :::
 
@@ -319,7 +319,7 @@ cargo build --target wasm32v1-none --release
 
 A `.wasm` file will be outputted in the `target` directory, at `target/wasm32v1-none/release/hello_world.wasm`. The `.wasm` file is the built contract.
 
-The `.wasm` file contains the logic of the contract, as well as the contract's [specification / interface types](../../../learn/fundamentals/contract-development/types/fully-typed-contracts.mdx), which can be imported into other contracts who wish to call it. This is the only artifact needed to deploy the contract, share the interface with others, or integration test against the contract.
+The `.wasm` file contains the logic of the contract, as well as the contract’s [specification / interface types](../../../learn/fundamentals/contract-development/types/fully-typed-contracts.mdx), which can be imported into other contracts who wish to call it. This is the only artifact needed to deploy the contract, share the interface with others, or integration test against the contract.
 
 ## Optimizing Builds
 
@@ -333,7 +333,7 @@ This will optimize and output a new `hello_world.optimized.wasm` file in the sam
 
 :::tip
 
-Building optimized contracts is only necessary when deploying to a network with fees or when analyzing and profiling a contract to get it as small as possible. If you're just starting out writing a contract, these steps are not necessary. See [Build](#build-the-contract) for details on how to build for development.
+Building optimized contracts is only necessary when deploying to a network with fees or when analyzing and profiling a contract to get it as small as possible. If you’re just starting out writing a contract, these steps are not necessary. See [Build](#build-the-contract) for details on how to build for development.
 
 :::
 
@@ -341,7 +341,7 @@ Building optimized contracts is only necessary when deploying to a network with 
 
 In this section, we wrote a simple contract that can be deployed to a Soroban network.
 
-Next we'll learn to deploy the HelloWorld contract to Stellar's Testnet network and interact with it over RPC using the CLI.
+Next we’ll learn to deploy the HelloWorld contract to Stellar’s Testnet network and interact with it over RPC using the CLI.
 
 [rust unit tests]: https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html
 [`stellar-cli`]: setup.mdx#install-the-stellar-cli

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -57,7 +57,7 @@ soroban-sdk = "26"
 
 :::info
 
-The `testutils` are automatically enabled inside [Rust unit tests] inside the same crate as your contract. If you write tests from another crate, you’ll need to require the `testutils` feature for those tests and enable the `testutils` feature when running your tests with `cargo test --features testutils` to be able to use those test utilities.
+The `testutils` are automatically enabled inside [Rust unit tests] inside the same crate as your contract. If you write tests from another crate, you'll need to require the `testutils` feature for those tests and enable the `testutils` feature when running your tests with `cargo test --features testutils` to be able to use those test utilities.
 
 :::
 
@@ -145,7 +145,7 @@ The contract imports the types and macros that it needs from the `soroban-sdk` c
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 ```
 
-Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment’s memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
+Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
 
 Contract inputs must not be references.
 
@@ -190,7 +190,7 @@ Note the `mod test` line at the bottom, this will tell Rust to compile and run t
 
 #### Contract Unit Tests
 
-Writing tests for Soroban contracts involves writing Rust code using the test facilities and toolchain that you’d use for testing any Rust code.
+Writing tests for Soroban contracts involves writing Rust code using the test facilities and toolchain that you'd use for testing any Rust code.
 
 Given our `Contract`, a simple test will look like this.
 
@@ -307,7 +307,7 @@ stellar contract build
 
 :::tip
 
-If you get an error like `can't find crate for 'core'`, it means you didn’t install the wasm32 target during the [setup step](./setup.mdx#install-the-target). You can do so by running `rustup target add wasm32v1-none` (reminder, this requires Rust `v1.84.0` or higher).
+If you get an error like `can't find crate for 'core'`, it means you didn't install the wasm32 target during the [setup step](./setup.mdx#install-the-target). You can do so by running `rustup target add wasm32v1-none` (reminder, this requires Rust `v1.84.0` or higher).
 
 :::
 
@@ -319,7 +319,7 @@ cargo build --target wasm32v1-none --release
 
 A `.wasm` file will be outputted in the `target` directory, at `target/wasm32v1-none/release/hello_world.wasm`. The `.wasm` file is the built contract.
 
-The `.wasm` file contains the logic of the contract, as well as the contract’s [specification / interface types](../../../learn/fundamentals/contract-development/types/fully-typed-contracts.mdx), which can be imported into other contracts who wish to call it. This is the only artifact needed to deploy the contract, share the interface with others, or integration test against the contract.
+The `.wasm` file contains the logic of the contract, as well as the contract's [specification / interface types](../../../learn/fundamentals/contract-development/types/fully-typed-contracts.mdx), which can be imported into other contracts who wish to call it. This is the only artifact needed to deploy the contract, share the interface with others, or integration test against the contract.
 
 ## Optimizing Builds
 
@@ -333,7 +333,7 @@ This will optimize and output a new `hello_world.optimized.wasm` file in the sam
 
 :::tip
 
-Building optimized contracts is only necessary when deploying to a network with fees or when analyzing and profiling a contract to get it as small as possible. If you’re just starting out writing a contract, these steps are not necessary. See [Build](#build-the-contract) for details on how to build for development.
+Building optimized contracts is only necessary when deploying to a network with fees or when analyzing and profiling a contract to get it as small as possible. If you're just starting out writing a contract, these steps are not necessary. See [Build](#build-the-contract) for details on how to build for development.
 
 :::
 
@@ -341,7 +341,7 @@ Building optimized contracts is only necessary when deploying to a network with 
 
 In this section, we wrote a simple contract that can be deployed to a Soroban network.
 
-Next we’ll learn to deploy the HelloWorld contract to Stellar’s Testnet network and interact with it over RPC using the CLI.
+Next we'll learn to deploy the HelloWorld contract to Stellar's Testnet network and interact with it over RPC using the CLI.
 
 [rust unit tests]: https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html
 [`stellar-cli`]: setup.mdx#install-the-stellar-cli


### PR DESCRIPTION
### What

Refresh the smart contract getting-started documentation for the soroban-sdk 26.1.0 release by bringing the Hello World dependency example up to the current major version and documenting how to convert a `BytesN<N>` into a native fixed-size `[u8; N]` array.

### Why

The Hello World guide pinned `soroban-sdk = "22"`, four major versions behind the released crate, so developers following the quickstart started against a stale SDK; and the `BytesN<N>` to `[u8; N]` conversion, exercised and optimized in the 26.1.0 release ([rs-soroban-sdk#1903](https://github.com/stellar/rs-soroban-sdk/pull/1903)), had no entry in the conversions guide despite being a routine operation when working with hashes and keys. Deeper 26.1.0 changes that warrant their own pages are tracked separately in [stellar-docs#2480](https://github.com/stellar/stellar-docs/issues/2480).