### PR TITLE
Warn against wasm32-unknown-unknown on Rust 1.82+

### DIFF
--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -86,6 +86,12 @@ When you install Rust, the WebAssembly target is installed per-toolchain. If you
 
 :::
 
+:::warning
+
+The `wasm32-unknown-unknown` target is **not supported** for Soroban contracts when using Rust 1.82 or newer. On those versions it enables WebAssembly features that the Soroban runtime does not support, and the SDK build script will reject it with a build error. Always use `wasm32v1-none` (requires Rust 1.84+), or use `stellar contract build` which selects the correct target automatically.
+
+:::
+
 You can learn more about the finer points of what this target brings to the table, in our page all about the [Stellar Rust dialect](../../../learn/fundamentals/contract-development/rust-dialect.mdx#limited-webassembly-features). This page describes the subset of Rust functionality that is available to you within Stellar smart contract environment.
 
 ## Configure an editor

--- a/docs/build/smart-contracts/getting-started/setup.mdx
+++ b/docs/build/smart-contracts/getting-started/setup.mdx
@@ -86,12 +86,6 @@ When you install Rust, the WebAssembly target is installed per-toolchain. If you
 
 :::
 
-:::warning
-
-The `wasm32-unknown-unknown` target is **not supported** for Soroban contracts when using Rust 1.82 or newer. On those versions it enables WebAssembly features that the Soroban runtime does not support, and the SDK build script will reject it with a build error. Always use `wasm32v1-none` (requires Rust 1.84+), or use `stellar contract build` which selects the correct target automatically.
-
-:::
-
 You can learn more about the finer points of what this target brings to the table, in our page all about the [Stellar Rust dialect](../../../learn/fundamentals/contract-development/rust-dialect.mdx#limited-webassembly-features). This page describes the subset of Rust functionality that is available to you within Stellar smart contract environment.
 
 ## Configure an editor

--- a/docs/learn/fundamentals/contract-development/rust-dialect.mdx
+++ b/docs/learn/fundamentals/contract-development/rust-dialect.mdx
@@ -78,7 +78,15 @@ The WebAssembly specification has grown significantly since its initial introduc
 
 Soroban intentionally limits which WebAssembly features it supports, to minimize the security-critical surface area and retain flexibility in choice of WebAssembly implementations. As of Rust `v1.84.0`, a new target `wasm32v1-none` was added to Rust that intentionally restricts itself to the "WebAssembly 1.0" subset of features, all of which Soroban supports.
 
-New Soroban contracts should be built with Rust `v1.84.0` or later, and use the `wasm32v1-none` target.
+New Soroban contracts should be built with Rust `v1.84.0` or later, and use the `wasm32v1-none` target. The easiest way to do this is with `stellar contract build` from [stellar-cli], which targets `wasm32v1-none` and applies all required build settings automatically.
+
+:::warning
+
+The `wasm32-unknown-unknown` target is **not supported** for building Soroban contracts when using Rust 1.82 or newer. On those versions, `wasm32-unknown-unknown` enables WebAssembly features (reference-types, multi-value) that the Soroban runtime does not support. Attempting to build a contract for `wasm32-unknown-unknown` with Rust 1.82+ will produce a build error from the SDK's build script.
+
+Use `wasm32v1-none` (available with Rust 1.84+) as the build target, or use `stellar contract build` which selects the correct target automatically.
+
+:::
 
 :::note
 
@@ -87,3 +95,5 @@ The `wasm32v1-none` target does not, by default, ship with a version of the `std
 The `wasm32v1-none` target _does_ include a copy of the `alloc` crate, which contains most of the _containers_ (such as vectors and maps) that are re-exported by `std`. For example, rather than using `std::vec::Vec` one can use `alloc::vec::Vec`, which is the same code under a different name. But as mentioned above in the section on dynamic memory allocation, generally Soroban contracts should avoid `alloc` as well: a crate like `heapless` will usually perform better.
 
 :::
+
+[stellar-cli]: https://github.com/stellar/stellar-cli


### PR DESCRIPTION
### What

Add `:::warning` admonitions to the "Install the target" section of `setup.mdx` and the "Limited WebAssembly features" section of `rust-dialect.mdx` documenting that `wasm32-unknown-unknown` is not a supported build target for Soroban contracts on Rust 1.82 or newer, that it will produce a build error from the SDK's build script, and that `wasm32v1-none` (via `stellar contract build`) is the correct target.

### Why

The SDK's build script has rejected `wasm32-unknown-unknown` builds on Rust 1.82+ since that target began enabling WebAssembly features (reference-types, multi-value) the Soroban runtime does not support, but the developer docs contained no mention of this constraint. Developers upgrading their Rust toolchain, including the Scout security tooling team who filed rs-soroban-sdk#1843 after a routine upgrade, had no way to discover the supported target from the docs before their builds broke. rs-soroban-sdk#1900 added the documentation to the crate itself; this PR mirrors it in the Stellar developer docs.