### PR TITLE
Add Stellar Developer Meeting notes for 2026-05-21 and 2026-06-11

### DIFF
--- a/meeting-notes/2026-05-21.mdx
+++ b/meeting-notes/2026-05-21.mdx
@@ -4,13 +4,9 @@ authors: kaankacar
 tags: [developer]
 ---
 
-<iframe
-  src="https://www.youtube.com/embed/isaeBeur6ro"
-  title="Stellar Developer Meeting 2026-05-21 recording"
-  width="640"
-  height="480"
-  allow="autoplay"
-></iframe>
+import YouTube from "@site/src/components/YouTube";
+
+<YouTube ID="isaeBeur6ro" />
 
 ## Another Two-Part Meeting
 

--- a/meeting-notes/2026-05-21.mdx
+++ b/meeting-notes/2026-05-21.mdx
@@ -1,0 +1,90 @@
+---
+title: "2026-05-21"
+authors: kaankacar
+tags: [developer]
+---
+
+<iframe
+  src="https://www.youtube.com/embed/isaeBeur6ro"
+  title="Stellar Developer Meeting 2026-05-21 recording"
+  width="640"
+  height="480"
+  allow="autoplay"
+></iframe>
+
+## Another Two-Part Meeting
+
+This week splits in half again. The first half belongs to our guest — a builder out of Kolkata who joined the community last October and started shipping ZK tooling almost immediately. He's here to present Root14 — a privacy _toolkit_ for Stellar built on the zero-knowledge primitives that landed in recent protocol upgrades. The second half is mine: a fast tour through roughly ten open-source, mostly-free AI tools, continuing the orchestrator theme from last week. If cryptography isn't your thing, skip to the tools. If you've had enough of me talking about agents, the first half is the one for you.
+
+A quick reframing before he starts, because it's load-bearing for everything he says: Root14 is **not** a private payments app. It's not a mixer and it's not a shielded pool. It's the cryptographic infrastructure that sits _underneath_ all of those things. The analogy he uses is OpenSSL versus a single HTTPS website — Root14 isn't the website, it's the part every website ends up importing.
+
+## The Substrate: Why the Economics Only Work on Stellar
+
+He grounds the whole talk in CAP-0059, which shipped the native BLS12-381 host functions to Soroban: G1/G2 addition, scalar multiplication, multi-scalar multiplication, pairing checks, and full scalar-field arithmetic. That's the complete substrate you need to do production-grade Groth16 verification natively, available to any contract.
+
+His pitch for _why Stellar_ comes down to cost. A pairing check that would take tens of millions of Wasm instructions on another chain runs as a single host call here. No other smart-contract chain has this combination at this cost point today — which is exactly what pulled him to the network and got him researching ZK on it in the first place.
+
+## What's in the Toolkit
+
+Root14 is a layered toolkit, and he walked through it piece by piece:
+
+- **Root14 Core** — a single contract that does two things. You call `register` and get back a content-addressed circuit identifier (the SHA-256 of the verification key, so the binding is unforgeable). After that, any contract on the network calls `verify` with a circuit ID, a proof, and the public inputs, and gets back a boolean. That's the entire interface. The contract holds no business logic, no value, no decisions — just registered verification keys and pairing checks. It's live on testnet today. The load-bearing insight: every existing privacy project on Stellar embeds its own verifier inside its own contract and pays for its own audit on essentially the same pairing code. A shared registry makes that duplication disappear.
+- **Circuit Library** — a set of vetted primitive circuits with published constraint counts and content-addressed identifiers: range proofs (credit thresholds, age bounds), set membership (KYC allow-lists), set non-membership (sanctions screening), and knowledge-of-preimage (ownership groups). Register a primitive once and every dapp on the network can use it.
+- **SDK and CLI** — a single `cargo add` gets you proof generation and serialization in Rust; the CLI is a human-friendly shell over the same SDK, with templates for generating contracts.
+- **MCP server** — the part he's most excited about. It lets Claude or any MCP-compatible model register a circuit, generate a proof, and trigger a verify call through natural language. As far as he can tell, it's the first ZK-on-Stellar MCP integration anywhere. A registry indexer streams on-chain events so developers can discover which circuits exist and how to compose them.
+
+## The zkTLS Bridge
+
+The piece closest to his heart is Root14's zkTLS. It bridges web2 and web3 trust: a user generates a zero-knowledge proof that they received a _specific response_ from a _specific web2 server_ without revealing the rest of the session. Prove you have over $1,000 in a bank account without showing the statement. Prove a KYC status with a particular issuer without exposing the underlying credential. Prove a tweet exists at a URL without leaking the OAuth token. There's a prototype today and production integration is on the roadmap; combined with the verifier registry, it's a clean way to pull real-world data into Soroban contracts without trusting a centralized oracle.
+
+## Private Payments, Honestly
+
+He was candid about the one piece that isn't usable right now. His original SCF submission leaned on private payments, and the mainnet privacy-pool deployments lagged on the AML/KYT-sensitive side — building privacy-preserving payments without thinking hard about compliance is how you get into legal trouble. So that part is currently down while he reworks it to be KYC/AML-aware. The developer-facing shape is still the goal, though: you don't write pairing code, you don't run a trusted-setup ceremony, you don't touch arkworks — you write your application contract, bind it to the relevant circuit identifiers in the registry, and call `verify` when you need a proof checked.
+
+## Production Readiness
+
+This isn't framed as a research prototype. Verification keys registered on mainnet will be immutable and content-addressed — no upgrade method, no admin power to silently re-point an identifier. Canonical registration transactions go through an SDF-approved multisig. The phase-2 trusted-setup ceremony will be multi-party with public transcripts and end-to-end-verified attestations from every contributor, and everything is open source under the Root14 name.
+
+## The Q&A: AI, Groth16 vs. PLONK, and the Business Question
+
+We tend to roast our guests with hard questions so they've already sweated out the answers before they reach an SCF panel, and the audience delivered:
+
+- **How much AI, and what's the setup?** He works ZK problems out with pen and paper first, then drives Claude Code layer by layer — architecture, then circuits, then verifier — prototyping, testing, and bouncing the output off other agents before moving on. He also leaned on the `llms.txt` file from the docs to make the model Stellar-aware out of the gate. His honest caveat matches mine: AI tends to cut corners on ZK, so it's an accelerant, not an autopilot.
+- **Long-term sustainability?** A shared verifier registry doesn't make much money on its own — maybe a small fee on registrations or calls. The real business is zkTLS as a B2B product: managing ZK infrastructure for Stellar-native teams and selling into developer/user onboarding flows.
+- **Why Groth16 over PLONK, and who runs the ceremony?** Groth16 won on cost and proof size for a hackathon timeline; PLONK needs more pairings and polynomial-commitment work, roughly double the budget for the same proof. He reuses an existing phase-1 powers-of-tau output (the Ethereum or Aztec ignition ceremonies, both public and audited with 100+ contributors) and only runs phase 2 per-circuit. Nothing about Root14 is religiously locked to Groth16.
+
+Root14 is in SCF #43 — the docs site is mid-rebuild, so keep an eye out and vote it up when public voting opens.
+
+## The Orchestrator Theme, Continued
+
+The pivot to the second half: last week I made the case that the job is shifting from _facilitator_ (you write the code, you stay close to the work) to _orchestrator_ (you manage a fleet of agents). This week's theme is narrower and a little more pointed. Stop writing "make no mistakes" to your model. If you can't steer the build, it's usually because you don't understand what's being built — and if you _wouldn't_ be able to build it without AI, that's the most dangerous place to be. The tools below are all attempts to keep you hands-on enough to understand the thing you're shipping.
+
+## Hands-On Frameworks: BMAD and Superpowers
+
+[The BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD) is the one I most wanted to show. It installs locally and free with `npx bmad-method install` — it's just a set of skills, hooks, and workflows, scoped to your project rather than installed globally. The point is spec-driven development with an Agile shape: it slows you down on purpose and walks you through brainstorming, market and domain research, technical research, and then planning out a PRD and stories. Each phase has a named agent — Mary is the business analyst you brainstorm with — and `/bmad-help` is your "what do I do next" button at any point. I kicked off a "Hey Mary, I want to build something with agentic payments on Stellar but I don't know what" session live to show the brainstorming loop.
+
+[Superpowers](https://github.com/obra/superpowers) is an alternative skills framework that does more or less the same job minus the explicit Agile emphasis. Try both and keep whichever fits how you think. The shared point of both: a more hands-on approach so you actually understand what's being built.
+
+## Letting Agents Use a Browser: kernel.sh and browser-use
+
+Claude Code and Codex can fetch a page's data but can't really _drive_ a browser — and they can't touch Chrome extensions, which is painful if you're testing a Stellar wallet extension. [kernel.sh](https://www.kernel.sh) fixes that: it spins up cloud browsers and lets your agent build automated workflows (it calls them "apps") through a free MCP server. My demo had Claude Code's kernel MCP walk stellar.expert for mainnet stats, click into the Soroban tab, hop to CoinGecko for the XLM/USD price, and capture it all to JSON. It's open-source infra with a free tier; the paid plan exists, but the free MCP is enough to expand your sense of what's possible.
+
+[browser-use](https://github.com/browser-use/browser-use) is the tool your model reaches for _first_ when you ask for browser automation — which is exactly why I show it. First-recommended isn't the same as best. It wants its own API keys (Google's and Anthropic's), and I'd rather point an agent at tools that ride the CLI I'm already paying for. Useful to know it exists, but kernel was the smoother experience for me.
+
+## Free Compute: freebuff
+
+[freebuff](https://freebuff.com) is the free tier of CodeBuff — it gives you a few hours a day of DeepSeek V4 Flash for free, with ads. The agent ("Buffy") does the usual implementation, codebase navigation, testing, and multi-agent orchestration (it'll spawn a stack of sub-agents), and it drives a browser using browser-use under the hood, so you get the browser-automation demo and the free-compute demo in one. DeepSeek V4 Flash is light but genuinely good for exploratory work when you don't want to burn frontier-model budget. CodeBuff's paid tier is around $100/month; if you're going to consider that, spend your free hours first.
+
+## Memory: claude-mem, mnemon, and Raindrop Workshop
+
+The unsolved problem under all of this is memory — how does the agent remember where it left off? Three takes:
+
+- **[claude-mem](https://github.com/thedotmack/claude-mem)** is the most widely used, and it's my favorite plug-in for this. It runs locally, works with Claude Code and Codex, and at the end of each session it scans the whole thing — what you discussed, what the agent did, where it went wrong, how it reached its conclusions — and writes session summaries plus, my favorite part, _discoveries_. Open the folder again and the agent already knows where it left off. No more hand-written handoff markdown. The trade-off is that it stores a lot, including things you didn't need.
+- **[mnemon](https://github.com/mnemon-dev/mnemon)** is the same idea but LLM-supervised: it lets your model decide _what_ to remember and _when_ to recall it, which keeps the store much tighter. It's newer and smaller than claude-mem, has an MCP server, and persists across sessions. Import claude-mem's history into mnemon's graph and you can see what the former would look like with structure; run mnemon on its own and you get a clean "mind palace."
+- **[Raindrop Workshop](https://github.com/raindrop-ai/workshop)** is the outsider. It's a local debugger that doesn't store everything and isn't LLM-supervised — it stores _workflows_, the step-by-step way to do a recurring thing. Ask the agent to do that thing again and it fetches the tree and follows it. It's cost-efficient precisely because it only remembers _how_, not _what_.
+
+## Where This Is Going
+
+We covered a lot at a shallow depth on purpose. I want your help picking which of these deserves a full, hour-long deep dive in an upcoming session — tell me on Discord. The throughline of the whole second half: software is getting fast and cheap, and cheap software is also dangerous software. A more hands-on approach is the cheapest insurance you can buy. Stop writing "make no mistakes," start writing `/bmad-help`, and understand the thing you're building.
+
+One housekeeping note worth repeating: CCTP is live on Stellar now, so cross-chain interop apps are something you can start building today.

--- a/meeting-notes/2026-06-11.mdx
+++ b/meeting-notes/2026-06-11.mdx
@@ -4,13 +4,9 @@ authors: kaankacar
 tags: [developer]
 ---
 
-<iframe
-  src="https://www.youtube.com/embed/AdhPqUbZXvA"
-  title="Stellar Developer Meeting 2026-06-11 recording"
-  width="640"
-  height="480"
-  allow="autoplay"
-></iframe>
+import YouTube from "@site/src/components/YouTube";
+
+<YouTube ID="AdhPqUbZXvA" />
 
 ## Back After a Week
 

--- a/meeting-notes/2026-06-11.mdx
+++ b/meeting-notes/2026-06-11.mdx
@@ -1,0 +1,69 @@
+---
+title: "2026-06-11"
+authors: kaankacar
+tags: [developer]
+---
+
+<iframe
+  src="https://www.youtube.com/embed/AdhPqUbZXvA"
+  title="Stellar Developer Meeting 2026-06-11 recording"
+  width="640"
+  height="480"
+  allow="autoplay"
+></iframe>
+
+## Back After a Week
+
+We skipped a week — the DevRel team was in Istanbul for the hackathon we threw during Istanbul Blockchain Week, and the side event at the end gathered more than 400 people. This week we're back, and the guests are Paul and David from Sodax. You may know them from Balanced or Hana Wallet; they're some of the OGs, and they walked us through what Sodax is and why a Stellar builder should care. The plan was to close with a new AI package from our side, but the Sodax half earned its time, so that one slid to next week.
+
+## Sodax: Cross-Network Liquidity as Developer Tooling
+
+Sodax is a cross-network execution and liquidity system — an intent-based one — and the framing David led with is that it's essential _developer tooling_, not a destination app. If you're building on Stellar and you want to open your front door to users who hold assets on other networks, you normally have to build bridges, source liquidity, and maintain infrastructure. Sodax does that part so you don't: you stay on Stellar, build the way you want, and reach users elsewhere through a single developer SDK.
+
+The liquidity piece is the part that's easy to underrate. It isn't only cross-network _connectivity_ — Sodax has already sourced the liquidity, so the cross-network swaps and DeFi actions actually settle. As a developer you stop worrying about where the depth comes from.
+
+## From ICON to Sodax
+
+Paul gave the origin story, and it's a good one. The Sodax brand is new — early 2025 — but the team isn't. Before Sodax they were ICON (the ICX token), a layer-1 from the ICO era with an interoperability vision that was years ahead of its time. Over time the lesson landed: to do intent-based, liquidity-powered interoperability you don't actually need to run your own blockchain. So they spun the L1 down, put their logic hub on Sonic (a fast, sub-second-finality EVM chain), and built the smart contracts out across Stellar, Solana, Sui, and more — deliberately spanning EVM and non-EVM networks to open routes other systems treat as impossible.
+
+Balanced (once the number-one DEX on ICON) and Hana Wallet (formerly the ICON wallet, now a self-custodial multi-network wallet on mobile and desktop) both come from those same ICON roots and are now powered by Sodax under the hood. Both went through Stellar's SCF program — they pitched at Meridian in London two years ago and Hana again at Meridian Brazil last year.
+
+## The Spoke-Chain Model
+
+In the Sodax model, Stellar is a **spoke chain** — which means everything in the Sodax docs applies to and for Stellar builders. The count keeps climbing, but they're on roughly 20 networks now, and they recently plugged in native Bitcoin, which they're rightly proud of. Some of the more exotic spokes are Near, Stacks (a Bitcoin L2), and Injective (Cosmos).
+
+The asset model is worth understanding. When you swap into "BTC" on Stellar through Sodax, you get a **soda variant** — a trading- and liquidity-backed Sodax representation of Bitcoin that lives on Stellar but is plugged into real Bitcoin liquidity on the Bitcoin network. The solver sees native-asset liquidity across all 20 networks at once and reasons across all of it when a trade fires, so there's depth without anyone provisioning pools — and you can withdraw straight back out to a native Bitcoin wallet. If you've used something like Near Intents, the UX will feel familiar.
+
+## Three Lines to a Cross-Network Swap
+
+Paul's honest line was that the demo is hard to make sound impressive because the SDK abstracts so much away. Integration is three steps:
+
+1. **Quote** — ask for the price of the swap you want.
+2. **Swap** — do it. One line.
+3. **Status** — poll for `not started`, `solved`, or `failed`.
+
+If a swap fails, the recovery system automatically returns funds — even if they'd already left the wallet. There's also a built-in wallet-connection component (wrap it around your frontend, stack the providers, done), which matters when you're juggling 20 networks, and Stellar trustlines are handled inside the SDK. `npm install` the SDK (or `pnpm add` it) and that's most of what you need to ship a real cross-network app.
+
+## Earn, and a Bit of Alpha
+
+Beyond swaps, the SDK exposes a cross-network money market — your end users can deposit, borrow, and earn supply interest. David dropped a bit of alpha too: leveraged staking yield is coming, so things like native ETH or native Solana staking would become accessible to your users even if your app lives entirely on Stellar or some other unrelated network.
+
+## Built for Agents
+
+This is the part that fit the room. Sodax shipped a best-in-class **builder MCP server** ([builders.sodax.com](https://builders.sodax.com)) — plug it into Claude or your cursor agent and it levels your agent up into a "prime Sodax developer." You don't need a docs-indexer like Context7; the MCP _is_ the docs. Even before you commit to building with Sodax, you can point the builder MCP at your existing Stellar repo and have it assess, in about ten minutes, where Sodax could open up cross-network opportunity for you. On top of that, they've embedded agent skills directly inside the SDK, so even if you never wire up the MCP, an agent crawling the package runs into the skills and uses the swap/lend/borrow modules correctly — in their words, "so that even Sonnet 4.6 doesn't make mistakes."
+
+I can vouch for that last claim. The morning of the meeting I didn't even use the MCP — I pointed Sonnet 4.6 (not the strongest model) at `docs.sodax.com` with roughly "surprise me," and about thirty minutes and 20% of a Pro plan later I had a one-shot mainnet demo: assets, addresses, cross-chain swaps, bridge limits, every supported chain. The question stopped being _can_ you vibe-code something on Sodax and became _why not_.
+
+## The Fee Model
+
+Sodax takes a flat **0.1%** on swaps — the same shape as a Uniswap-style backend fee. The interesting part for builders: any partner integrating the SDK can set their _own_ partner fee on top. A wallet like Hana, or your own app, can add (say) 0.5% and keep it. You have full control over what you charge your users, which means an integrator can end up earning more per swap than Sodax itself.
+
+## Why Mainnet Only
+
+A recurring audience question: does it support testnet? Short answer, no — and the reason is structural. The solver sources real liquidity from real markets, and there's no monetary value backing assets on testnet, so the solver simply has nothing to solve. Replicating it would mean standing up and maintaining dozens of testnet liquidity pools, bridges, and staking platforms in parallel. They're open to bringing _parts_ of the stack to testnet and want to hear from developers about which parts would actually help — but for now Sodax is a mainnet product, which is also fine, because you're not deploying your own contracts. It's a plug you put into your app and it works.
+
+Where to go next: [docs.sodax.com](https://docs.sodax.com) for the SDK, [builders.sodax.com](https://builders.sodax.com) for the MCP, and [sodax.com/partners](https://www.sodax.com/partners) to see how the integration and fee split work. Their whole team hangs out in Discord and answers builder questions directly.
+
+## Next Week
+
+I ran out of time to show the AI package we built, so set a reminder. Next week's is the one I've been most excited about: the tool the SDF DevRel team shipped that drops 42 skills and hooks into your setup, packs in information about every project ever built on Stellar for market research, and wraps the whole thing in an Agile workflow. It needs a full half-hour to do it justice. See you then.

--- a/routes.txt
+++ b/routes.txt
@@ -904,6 +904,8 @@
 /meetings/2026/04/23
 /meetings/2026/05/07
 /meetings/2026/05/14
+/meetings/2026/05/21
+/meetings/2026/06/11
 /meetings/archive
 /meetings/authors
 /meetings/authors/carstenjacobsen


### PR DESCRIPTION
Adds the meeting-notes MDX files for two Stellar Developer Meetings. Closes #2494.

| Date | Recording | Topics |
| --- | --- | --- |
| 2026-05-21 | https://www.youtube.com/watch?v=isaeBeur6ro | Root14, a zero-knowledge privacy toolkit for Stellar (shared verifier registry, circuit library, zkTLS, SDK/CLI/MCP), followed by a tour of open-source AI dev tooling (BMAD, Superpowers, kernel.sh, browser-use, freebuff, claude-mem, mnemon, Raindrop Workshop). |
| 2026-06-11 | https://www.youtube.com/watch?v=AdhPqUbZXvA | Sodax — cross-network, intent-based execution and liquidity with Stellar as a spoke chain (builder MCP, SDK-embedded agent skills, 0.1% fee model, mainnet-only solver). |

Both files follow the existing meeting-notes format (frontmatter + embedded recording + narrative sections). `routes.txt` was regenerated with `yarn build`, adding the new `/meetings/2026/05/21` and `/meetings/2026/06/11` routes. The site builds cleanly and the Prettier pre-commit check passes.

The notes follow each meeting's recording. A couple of the date/topic pairings in the issue body were transposed (the Rinat Enikeev session was the previously-published 2026-05-14 meeting), so the content here reflects what is actually in each recording.
