### PR TITLE
chore(sdk-examples): update JS SDK import path to scoped package

### DIFF
--- a/docs/build/apps/example-application-tutorial/confirmation-modal.mdx
+++ b/docs/build/apps/example-application-tutorial/confirmation-modal.mdx
@@ -72,7 +72,7 @@ The basic parts of this component look like this:
   import { CopyIcon } from "svelte-feather-icons";
   import { errorMessage } from "$lib/stores/alertsStore";
   import { walletStore } from "$lib/stores/walletStore";
-  import { Networks, TransactionBuilder } from "stellar-sdk";
+  import { Networks, TransactionBuilder } from "@stellar/stellar-sdk";
 
   // A Svelte "context" is used to control when to `open` and `close` a given
   // modal from within other components
@@ -110,7 +110,7 @@ We can now use this modal component whenever we need to confirm something from t
 
 ```html title="/src/routes/signup/+page.svelte"
 <script>
-  import { Keypair } from "stellar-sdk";
+  import { Keypair } from "@stellar/stellar-sdk";
   import TruncatedKey from "$lib/components/TruncatedKey.svelte";
   import ConfirmationModal from "$lib/components/ConfirmationModal.svelte";
   import { goto } from "$app/navigation";

--- a/docs/build/apps/example-application-tutorial/contacts-list.mdx
+++ b/docs/build/apps/example-application-tutorial/contacts-list.mdx
@@ -30,7 +30,7 @@ This tutorial code is simplified for display here. The code is fully typed, docu
 ```js title="/src/lib/stores/contactsStore.js"
 import { v4 as uuidv4 } from "uuid";
 import { persisted } from "svelte-local-storage-store";
-import { StrKey } from "stellar-sdk";
+import { StrKey } from "@stellar/stellar-sdk";
 import { error } from "@sveltejs/kit";
 import { get } from "svelte/store";
 

--- a/docs/build/apps/wallet/sep24.mdx
+++ b/docs/build/apps/wallet/sep24.mdx
@@ -262,7 +262,7 @@ suspend fun depositDifferentAccount(): InteractiveFlowResponse {
 ```
 
 ```typescript
-import { Memo, MemoText } from "stellar-sdk";
+import { Memo, MemoText } from "@stellar/stellar-sdk";
 
 const recipientAccount = "G...";
 const depositDifferentAccount = async (): Promise<InteractiveFlowResponse> => {

--- a/docs/build/guides/basics/verify-trustlines.mdx
+++ b/docs/build/guides/basics/verify-trustlines.mdx
@@ -22,7 +22,7 @@ To check if a trustline exists for a specific asset, you can use the Stellar RPC
 
 ```js
 import { Asset, StrKey, xdr } from "@stellar/stellar-sdk";
-import { Server } from "stellar-sdk/rpc";
+import { Server } from "@stellar/stellar-sdk/rpc";
 
 // Initialize Soroban RPC server for testnet
 const rpc = new Server("https://soroban-testnet.stellar.org");
@@ -247,7 +247,7 @@ Given a receiver addresss, the following code snippet demonstrates how to simula
 ```js
 import { Asset, Networks } from "@stellar/stellar-sdk";
 import { Client } from "sac";
-import { Server } from "stellar-sdk/rpc";
+import { Server } from "@stellar/stellar-sdk/rpc";
 
 // Initialize Soroban RPC server for testnet
 const rpc = new Server("https://soroban-testnet.stellar.org");

--- a/docs/build/guides/basics/verify-trustlines.mdx
+++ b/docs/build/guides/basics/verify-trustlines.mdx
@@ -21,7 +21,7 @@ To check if a trustline exists for a specific asset, you can use the Stellar RPC
 <CodeExample>
 
 ```js
-import { Asset, StrKey, xdr } from "stellar-sdk";
+import { Asset, StrKey, xdr } from "@stellar/stellar-sdk";
 import { Server } from "stellar-sdk/rpc";
 
 // Initialize Soroban RPC server for testnet
@@ -138,7 +138,7 @@ Given a receiver address, the following code snippet demonstrates how to check i
 <CodeExample>
 
 ```js
-import * as StellarSdk from "stellar-sdk";
+import * as StellarSdk from "@stellar/stellar-sdk";
 
 // Initialize Horizon server for testnet
 const server = new StellarSdk.Horizon.Server(
@@ -245,7 +245,7 @@ Given a receiver addresss, the following code snippet demonstrates how to simula
 <CodeExample>
 
 ```js
-import { Asset, Networks } from "stellar-sdk";
+import { Asset, Networks } from "@stellar/stellar-sdk";
 import { Client } from "sac";
 import { Server } from "stellar-sdk/rpc";
 

--- a/docs/data/apis/horizon/api-reference/structure/pagination/README.mdx
+++ b/docs/data/apis/horizon/api-reference/structure/pagination/README.mdx
@@ -38,7 +38,7 @@ To move between pages of a collection of records, use the links in the `next` an
 <CodeExample title="Example Request">
 
 ```js
-var StellarSdk = require("stellar-sdk");
+var StellarSdk = require("@stellar/stellar-sdk");
 var server = new StellarSdk.Horizon.Server(
   "https://horizon-testnet.stellar.org",
 );

--- a/docs/data/apis/horizon/api-reference/structure/pagination/page-arguments.mdx
+++ b/docs/data/apis/horizon/api-reference/structure/pagination/page-arguments.mdx
@@ -37,7 +37,7 @@ curl "https://horizon-testnet.stellar.org/ledgers/26478723/operations?cursor=113
 ```
 
 ```js
-var StellarSdk = require("stellar-sdk");
+var StellarSdk = require("@stellar/stellar-sdk");
 var server = new StellarSdk.Horizon.Server(
   "https://horizon-testnet.stellar.org",
 );

--- a/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
+++ b/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
@@ -151,7 +151,7 @@ The following code sets up the accounts and defines some helper functions. These
 const sdk = require("@stellar/stellar-sdk");
 const BigNumber = require("bignumber.js");
 
-let server = new sdk.Server("https://horizon-testnet.stellar.org");
+let server = new sdk.Horizon.Server("https://horizon-testnet.stellar.org");
 
 /// Helps simplify creating & signing a transaction.
 function buildTx(source, signer, ...ops) {

--- a/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
+++ b/docs/learn/fundamentals/liquidity-on-stellar-sdex-liquidity-pools.mdx
@@ -148,7 +148,7 @@ The following code sets up the accounts and defines some helper functions. These
 <CodeExample>
 
 ```js
-const sdk = require("stellar-sdk");
+const sdk = require("@stellar/stellar-sdk");
 const BigNumber = require("bignumber.js");
 
 let server = new sdk.Server("https://horizon-testnet.stellar.org");

--- a/docs/platforms/stellar-disbursement-platform/admin-guide/making-your-wallet-sdp-ready.mdx
+++ b/docs/platforms/stellar-disbursement-platform/admin-guide/making-your-wallet-sdp-ready.mdx
@@ -105,7 +105,7 @@ Below is a JavaScript snippet demonstrating how to verify the signature:
 ```js
 #!/usr/bin/env node
 
-const { Keypair } = require("stellar-sdk");
+const { Keypair } = require("@stellar/stellar-sdk");
 
 // The SDP's stellar.toml SIGNING_KEY
 //

--- a/docs/tokens/control-asset-access.mdx
+++ b/docs/tokens/control-asset-access.mdx
@@ -113,7 +113,7 @@ The following example sets authorization to be both required and revocable:
 <CodeExample>
 
 ```js
-var StellarSdk = require("stellar-sdk");
+var StellarSdk = require("@stellar/stellar-sdk");
 var server = new StellarSdk.Horizon.Server(
   "https://horizon-testnet.stellar.org",
 );

--- a/docs/tokens/how-to-issue-an-asset.mdx
+++ b/docs/tokens/how-to-issue-an-asset.mdx
@@ -201,7 +201,7 @@ If you’d like to avoid your users having to deal with trustlines or XLM, consi
 <CodeExample>
 
 ```js
-const StellarSdk = require("stellar-sdk");
+const StellarSdk = require("@stellar/stellar-sdk");
 const server = new StellarSdk.Horizon.Server(
   "https://horizon-testnet.stellar.org",
 );
@@ -497,7 +497,7 @@ transaction, _ := txnbuild.NewTransaction(
 <CodeExample title="Issuing an Asset">
 
 ```js
-var StellarSdk = require("stellar-sdk");
+var StellarSdk = require("@stellar/stellar-sdk");
 var server = new StellarSdk.Horizon.Server(
   "https://horizon-testnet.stellar.org",
 );

--- a/docs/tokens/publishing-asset-info.mdx
+++ b/docs/tokens/publishing-asset-info.mdx
@@ -159,7 +159,7 @@ server {
 <CodeExample title="Set Home Domain">
 
 ```js
-var StellarSdk = require("stellar-sdk");
+var StellarSdk = require("@stellar/stellar-sdk");
 var server = new StellarSdk.Horizon.Server(
   "https://horizon-testnet.stellar.org",
 );

--- a/docs/tokens/quickstart.mdx
+++ b/docs/tokens/quickstart.mdx
@@ -16,7 +16,7 @@ import {
   Operation,
   Asset,
   BASE_FEE,
-} from "stellar-sdk";
+} from "@stellar/stellar-sdk";
 
 const horizonUrl = "https://horizon-testnet.stellar.org";
 const friendbotUrl = "https://friendbot.stellar.org";


### PR DESCRIPTION
The JavaScript SDK was renamed from the unscoped `stellar-sdk` npm package to `@stellar/stellar-sdk` in v11.0.0 (current latest v15.1.0). The unscoped package is deprecated and pins to a pre-v11 release.

Update all 16 import/require statements across 12 docs pages to the scoped `@stellar/stellar-sdk` package name. No API usage changed — these pages already use current APIs (Horizon.Server, rpc namespace, etc.).