### PR TITLE
chore(sdk-examples): update examples and description for python SDK v14.1.0

### DIFF
--- a/docs/build/guides/dapps/working-with-contract-specs.mdx
+++ b/docs/build/guides/dapps/working-with-contract-specs.mdx
@@ -1240,7 +1240,7 @@ env.events()
 ```
 
 ```python
-from stellar_sdk import SorobanServer, scval, stellar_xdr
+from stellar_sdk import SorobanServer, scval, xdr as stellar_xdr
 from stellar_sdk.exceptions import NotFoundError, BadResponseError
 from stellar_sdk.soroban_server import EventFilter, EventFilterType
 

--- a/docs/learn/fundamentals/data-format/xdr.mdx
+++ b/docs/learn/fundamentals/data-format/xdr.mdx
@@ -63,7 +63,7 @@ You can see the full set of options to construct a `Uint64` in the definition fo
 Other languages, such as Python (see `stellar-sdk`'s [uint64.html](https://stellar-sdk.readthedocs.io/en/stable/_modules/stellar_sdk/xdr/uint64.html) documentation), support arbitrarily-sized integers by default, so there are no such variations:
 
 ```python
-import xdr from stellar_sdk;
+from stellar_sdk import xdr
 
 u64 = xdr.Uint64(1_000_000_000_000_000)
 ```

--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -38,7 +38,7 @@ It provides:
 
 **The Python SDK is maintained by dedicated community developers.**
 
-`py-stellar-base` is a Python library for communicating with a Stellar Horizon server. It is used for building Stellar apps on Python. It supports Python 3.7+ as well as PyPy 3.7+.
+`py-stellar-base` is a Python library for communicating with a Stellar Horizon server. It is used for building Stellar apps on Python. It supports Python 3.10+ as well as PyPy 3.10+.
 
 This SDK is maintained by a dedicated community developer.
 


### PR DESCRIPTION
update some python examples to use the latest syntax, conventions, etc. 

also not on the client-sdk page that python `v3.10+` is required now.