### PR TITLE
chore(sdk-examples): update Go SDK RPC client import paths

### DIFF
--- a/docs/build/guides/transactions/claimable-balances.mdx
+++ b/docs/build/guides/transactions/claimable-balances.mdx
@@ -226,8 +226,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/stellar/stellar-rpc/client"
-	"github.com/stellar/stellar-rpc/protocol"
+	client "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
@@ -442,8 +442,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/stellar/stellar-rpc/client"
-	"github.com/stellar/stellar-rpc/protocol"
+	client "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
@@ -595,8 +595,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/stellar/stellar-rpc/client"
-	"github.com/stellar/stellar-rpc/protocol"
+	client "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"

--- a/docs/build/guides/transactions/create-account.mdx
+++ b/docs/build/guides/transactions/create-account.mdx
@@ -282,8 +282,8 @@ import (
   "github.com/stellar/go-stellar-sdk/txnbuild"
   "github.com/stellar/go-stellar-sdk/xdr"
 
-  "github.com/stellar/stellar-rpc/client"
-  "github.com/stellar/stellar-rpc/protocol"
+  client "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+  protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
 const (

--- a/docs/build/guides/transactions/send-and-receive-payments.mdx
+++ b/docs/build/guides/transactions/send-and-receive-payments.mdx
@@ -313,8 +313,8 @@ import (
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
-	sdk "github.com/stellar/stellar-rpc/client"
-	"github.com/stellar/stellar-rpc/protocol"
+	sdk "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
 // friendbotFund funds an account using the Stellar testnet friendbot
@@ -739,8 +739,8 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/strkey"
 	"github.com/stellar/go-stellar-sdk/xdr"
-	sdk "github.com/stellar/stellar-rpc/client"
-	"github.com/stellar/stellar-rpc/protocol"
+	sdk "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
 func main() {
@@ -1085,7 +1085,6 @@ mkdir -p payments_example/sender
 cd payments_example
 go mod init payments_example
 go get github.com/stellar/go-stellar-sdk@latest
-go get github.com/stellar/stellar-rpc@latest
 # save sender.go code to sender/sender.go file
 go build -o sender sender/sender.go
 ./sender

--- a/docs/build/guides/transactions/sponsored-reserves.mdx
+++ b/docs/build/guides/transactions/sponsored-reserves.mdx
@@ -139,8 +139,8 @@ import (
   "github.com/stellar/go-stellar-sdk/keypair"
   "github.com/stellar/go-stellar-sdk/network"
   "github.com/stellar/go-stellar-sdk/txnbuild"
-  sdk "github.com/stellar/stellar-rpc/client"
-  protocol "github.com/stellar/stellar-rpc/protocol"
+  sdk "github.com/stellar/go-stellar-sdk/clients/rpcclient"
+  protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
 func main() {

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/architecture.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/architecture.mdx
@@ -11,4 +11,4 @@ Ingest SDK is organized into three main components:
 
 1. **[Ledger Backends](./ledgerbackends/README.mdx)**: Used to stream ledgers from the Stellar network. `https://github.com/stellar/go-stellar-sdk/tree/main/ingest/ledgerbackend`
 2. **[Ledger Readers](./ledgerreaders.mdx)** : Iterators to extract individual changes or transactions from a ledger. `https://github.com/stellar/go-stellar-sdk/tree/main/ingest`
-3. **[Ledger Processors](https://github.com/stellar/go-stellar-sdk/tree/main/ingest/processors)** : Functions to process individual changes or transactions and extract meaningful data such as accounts, offers, claimable balance, etc. They are used in conjunction with `Ledger Readers` to interpret and transform ledger data.
+3. **[Ledger Processors](https://github.com/stellar/go-stellar-sdk/tree/main/processors)** : Functions to process individual changes or transactions and extract meaningful data such as accounts, offers, claimable balance, etc. They are used in conjunction with `Ledger Readers` to interpret and transform ledger data.

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/bufferedstoragebackend.mdx
@@ -12,7 +12,7 @@ sidebar_position: 5
 - **Parallel Downloads**: Downloads multiple ledgers concurrently and buffers them in memory for fast access. This is particularly useful for fetching large historical ledger ranges.
 - **Schema-Aware**: Reads multi-ledger files based on the datastore schema, extracting one ledger at a time.
 - **Automatic Retries**: Handles request failures by retrying failed requests.
-- **XDR Output**: Returns ledger metadata in XDR format, enabling easy integration with other packages in ingest SDK (e.g., [processors](https://github.com/stellar/go-stellar-sdk/tree/main/ingest/processors)).
+- **XDR Output**: Returns ledger metadata in XDR format, enabling easy integration with other packages in ingest SDK (e.g., [processors](https://github.com/stellar/go-stellar-sdk/tree/main/processors)).
 
 ## Prerequisites
 

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -21,7 +21,7 @@ Usage of the RPCLedgerBackend implies having awareness of the retention window a
 
 ### Code
 
-A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go-stellar-sdk/blob/main/ingest/ledgerbackend/rpc_backend.go) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/stellar-rpc/blob/main/client/main.go) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
+A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go-stellar-sdk/blob/main/ingest/ledgerbackend/rpc_backend.go) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/go-stellar-sdk/blob/main/clients/rpcclient/main.go) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
 
 Prerequisites:
 

--- a/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
+++ b/docs/data/indexers/build-your-own/ingest-sdk/developer_guide/ledgerbackends/rpcledgerbackend.mdx
@@ -21,7 +21,7 @@ Usage of the RPCLedgerBackend implies having awareness of the retention window a
 
 ### Code
 
-A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go-stellar-sdk/blob/main/ingest/ledgerbackend/rpc_backend.go) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/go-stellar-sdk/blob/main/clients/rpcclient/main.go) which uses the same RPC url to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
+A working example demonstrating programmatic usage of [RPCLedgerBackend](https://github.com/stellar/go-stellar-sdk/blob/main/ingest/ledgerbackend/rpc_backend.go) to print a stream of latest ledgers emitted from the Stellar Testnet Network. Note the additional usage of the [RPC Go Client](https://github.com/stellar/go-stellar-sdk/blob/main/clients/rpcclient/main.go) which uses the same RPC URL to get the latest ledger from the RPC server. This is used to prime our live streaming example to use the latest known ledger on RPC as the starting ledger when requesting the unbounded range.
 
 Prerequisites:
 

--- a/docs/data/indexers/build-your-own/processors/token-transfer-processor/README.mdx
+++ b/docs/data/indexers/build-your-own/processors/token-transfer-processor/README.mdx
@@ -5,7 +5,7 @@ sidebar_position: 0
 
 ## Overview
 
-The Token Transfer Processor (TTP) is a [Go package](https://github.com/stellar/go-stellar-sdk/tree/main/ingest/processors/token_transfer) which uses the [ingest-sdk](../../ingest-sdk/README.mdx) to parse Stellar network transaction data and derive token transfer events. Before TTP, developers had to manually parse complex ledger data, operation results, and ledger entry changes to understand when and how value moved between accounts, contracts, and other entities on the network.
+The Token Transfer Processor (TTP) is a [Go package](https://github.com/stellar/go-stellar-sdk/tree/main/processors/token_transfer) which uses the [ingest-sdk](../../ingest-sdk/README.mdx) to parse Stellar network transaction data and derive token transfer events. Before TTP, developers had to manually parse complex ledger data, operation results, and ledger entry changes to understand when and how value moved between accounts, contracts, and other entities on the network.
 
 Prior to [CAP-67 Unified Events][cap67], tracking token transfers required significant custom logic to handle different operation types, interpret ledger changes, and reconstruct the flow of assets. CAP-67 introduced a standardized event format that simplifies this process by providing a unified way to represent all token transfer activities.
 
@@ -43,7 +43,7 @@ For more details on operational modes, see the [Modes of Operation](#modes-of-op
 
 ## Events
 
-TTP generates events in Go bindings based on [protobuf definitions](https://github.com/stellar/go-stellar-sdk/blob/main/protos/ingest/processors/token_transfer/token_transfer_event.proto). The definitions codify an IDL for the standardized token transfer event models put forth in CAP-67. Each event contains metadata and type-specific information structured as follows:
+TTP generates events in Go bindings based on [protobuf definitions](https://github.com/stellar/go-stellar-sdk/blob/main/protos/processors/token_transfer/token_transfer_event.proto). The definitions codify an IDL for the standardized token transfer event models put forth in CAP-67. Each event contains metadata and type-specific information structured as follows:
 
 | Event Type | Description | Key Fields | When Generated |
 | --- | --- | --- | --- |

--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -127,7 +127,7 @@ This SDK is split up into separate packages, all of which you can find in the [G
 
 - `txnbuild` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/txnbuild) | [Docs](https://godoc.org/github.com/stellar/go-stellar-sdk/txnbuild): enables the construction, signing, and encoding of Stellar transactions.
 - `Horizon Client` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/clients/horizonclient) | [Docs](https://godoc.org/github.com/stellar/go-stellar-sdk/clients/horizonclient): provides a web client for interfacing with Horizon server REST endpoints to retrieve ledger information and submit transactions built with `txnbuild`.
-- `RPC Client` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/clients/rpcclient) | [Docs](https://pkg.go.dev/github.com/stellar/go-stellar-sdk/clients/rpcclient): provide sdk wrapper to invoke RPC endpoints.
+- `RPC Client` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/clients/rpcclient) | [Docs](https://pkg.go.dev/github.com/stellar/go-stellar-sdk/clients/rpcclient): provides an SDK wrapper to invoke RPC endpoints.
 - [Ingest SDK](../../data/indexers/build-your-own/ingest-sdk/README.mdx): acquire and parse data from the Stellar network.
 
 ## C# .NET

--- a/docs/tools/sdks/client-sdks.mdx
+++ b/docs/tools/sdks/client-sdks.mdx
@@ -127,7 +127,7 @@ This SDK is split up into separate packages, all of which you can find in the [G
 
 - `txnbuild` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/txnbuild) | [Docs](https://godoc.org/github.com/stellar/go-stellar-sdk/txnbuild): enables the construction, signing, and encoding of Stellar transactions.
 - `Horizon Client` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/clients/horizonclient) | [Docs](https://godoc.org/github.com/stellar/go-stellar-sdk/clients/horizonclient): provides a web client for interfacing with Horizon server REST endpoints to retrieve ledger information and submit transactions built with `txnbuild`.
-- `RPC Client` [SDK](https://github.com/stellar/stellar-rpc/tree/main/client) | [Docs](https://pkg.go.dev/github.com/stellar/stellar-rpc/client): provide sdk wrapper to invoke RPC endpoints.
+- `RPC Client` [SDK](https://github.com/stellar/go-stellar-sdk/tree/main/clients/rpcclient) | [Docs](https://pkg.go.dev/github.com/stellar/go-stellar-sdk/clients/rpcclient): provide sdk wrapper to invoke RPC endpoints.
 - [Ingest SDK](../../data/indexers/build-your-own/ingest-sdk/README.mdx): acquire and parse data from the Stellar network.
 
 ## C# .NET

--- a/docs/validators/admin-guide/running-node.mdx
+++ b/docs/validators/admin-guide/running-node.mdx
@@ -95,7 +95,7 @@ And will then move through the various phases of downloading and applying state,
 
 For the fastest sync — including for new Full Validators and Tier 1 candidates — leave `CATCHUP_RECENT` at its default and do **not** set `CATCHUP_COMPLETE=true`. Your node will sync against current network state in minutes to hours rather than weeks.
 
-`CATCHUP_COMPLETE=true` makes the node replay the _entire history_ of the network on startup, which takes weeks and is almost never the right choice for a validator — see [Why local disk stays bounded](./prerequisites.mdx#why-local-disk-stays-bounded). The standard pattern for new validators that want to publish a complete history archive is to sync against current state first, publish forward from that point, and use the [`stellar-archivist mirror`](https://github.com/stellar/go/tree/master/tools/stellar-archivist) tool to backfill historical data into the published archive as a separate offline operation. See the [complete example configuration] for more details.
+`CATCHUP_COMPLETE=true` makes the node replay the _entire history_ of the network on startup, which takes weeks and is almost never the right choice for a validator — see [Why local disk stays bounded](./prerequisites.mdx#why-local-disk-stays-bounded). The standard pattern for new validators that want to publish a complete history archive is to sync against current state first, publish forward from that point, and use the [`stellar-archivist mirror`](https://github.com/stellar/go-stellar-sdk/tree/main/tools/stellar-archivist) tool to backfill historical data into the published archive as a separate offline operation. See the [complete example configuration] for more details.
 
 :::info
 


### PR DESCRIPTION
As of go-stellar-sdk v0.6.0 / stellar-rpc v27.0.0, the Go RPC client moved out of the stellar-rpc repo and into the Go SDK:
- github.com/stellar/stellar-rpc/client   -> github.com/stellar/go-stellar-sdk/clients/rpcclient (package rpcclient)
- github.com/stellar/stellar-rpc/protocol -> github.com/stellar/go-stellar-sdk/protocols/rpc (package protocol)
Both old paths are 404 at the current tags.

- Update the 8 import sites across the create-account, send-and-receive-payments, sponsored-reserves, and claimable-balances transaction guides, preserving each file's existing package identifiers (client/sdk/protocol) via aliases so the code bodies stay valid.
- Drop the now-redundant `go get github.com/stellar/stellar-rpc@latest` line; the client ships in go-stellar-sdk.
- Fix the RPC Go client link and the RPC Client entry on the client-sdks page (both pointed at the removed stellar-rpc/client path).
- Repoint ingest/processors links to the relocated top-level processors package (incl. the token_transfer protobuf path).
- Point the stellar-archivist link at go-stellar-sdk (was the archived stellar/go), matching the sibling publishing-history-archives guide.