### PR TITLE
chore(sdk-examples): update Java SDK coordinates to current release

### DIFF
--- a/docs/build/guides/dapps/working-with-contract-specs.mdx
+++ b/docs/build/guides/dapps/working-with-contract-specs.mdx
@@ -356,7 +356,7 @@ print("errorResultXdr:", response.error_result_xdr)
 ```
 
 ```java
-// implementation 'network.lightsail:stellar-sdk:2.1.0'
+// implementation 'network.lightsail:stellar-sdk:3.1.0'
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.Network;
 import org.stellar.sdk.SorobanServer;

--- a/docs/build/guides/transactions/create-account.mdx
+++ b/docs/build/guides/transactions/create-account.mdx
@@ -481,7 +481,7 @@ func check(err error) {
 ```java
 // File: main.java
 // Dependencies (Maven coordinates):
-//   org.stellar:java-stellar-sdk:0.43.0-SNAPSHOT
+//   network.lightsail:stellar-sdk:3.1.0
 //   com.fasterxml.jackson.core:jackson-databind:2.17.2
 
 import java.io.IOException;

--- a/docs/data/apis/rpc/api-reference/methods/getTransaction.mdx
+++ b/docs/data/apis/rpc/api-reference/methods/getTransaction.mdx
@@ -54,7 +54,7 @@ getTransactionDetails(
 ```
 
 ```java
-// implementation 'network.lightsail:stellar-sdk:0.44.0'
+// implementation 'network.lightsail:stellar-sdk:3.1.0'
 
 import org.stellar.sdk.SorobanServer;
 import org.stellar.sdk.responses.sorobanrpc.GetTransactionResponse;

--- a/docs/learn/fundamentals/contract-development/contract-interactions/stellar-transaction.mdx
+++ b/docs/learn/fundamentals/contract-development/contract-interactions/stellar-transaction.mdx
@@ -211,7 +211,7 @@ print(result)
 
 :::tip
 
-[java-stellar-sdk](https://github.com/stellar/java-stellar-sdk) provides support for Soroban, please visit the project homepage for more information.
+[java-stellar-sdk](https://github.com/lightsail-network/java-stellar-sdk) provides support for Soroban, please visit the project homepage for more information.
 
 :::
 

--- a/docs/learn/fundamentals/contract-development/contract-interactions/stellar-transaction.mdx
+++ b/docs/learn/fundamentals/contract-development/contract-interactions/stellar-transaction.mdx
@@ -211,7 +211,7 @@ print(result)
 
 :::tip
 
-[java-stellar-sdk](https://github.com/lightsail-network/java-stellar-sdk) provides support for Soroban, please visit the project homepage for more information.
+[java-stellar-sdk](https://github.com/lightsail-network/java-stellar-sdk) provides support for Soroban. Please visit the project homepage for more information.
 
 :::
 


### PR DESCRIPTION
java-stellar-sdk is published as `network.lightsail:stellar-sdk` (current 3.1.0) from the lightsail-network org. Several examples carried stale coordinates/versions:

- create-account.mdx: `org.stellar:java-stellar-sdk:0.43.0-SNAPSHOT` (obsolete group id + pre-release) -> `network.lightsail:stellar-sdk:3.1.0`
- working-with-contract-specs.mdx: bump `2.1.0` -> `3.1.0`
- getTransaction.mdx: bump `0.44.0` -> `3.1.0`
- stellar-transaction.mdx: repoint the repo link from the old `stellar/java-stellar-sdk` org to `lightsail-network/java-stellar-sdk`

The Java code itself (org.stellar.sdk.* imports) is unchanged — the package namespace did not move, only the build coordinates and repo org.