### PR TITLE
fix: update install-deploy-contract guide

### DIFF
--- a/docs/build/guides/transactions/install-deploy-contract-with-code.mdx
+++ b/docs/build/guides/transactions/install-deploy-contract-with-code.mdx
@@ -24,7 +24,7 @@ Before you begin, ensure you have the following installed:
 
 1. [Rust](https://www.rust-lang.org/) and Cargo (for compiling smart contracts)
 2. [Node.js](https://nodejs.org/en) and npm (for running JavaScript deployment scripts)
-3. [Soroban CLI](../../smart-contracts/getting-started/setup.mdx#install-the-stellar-cli)
+3. [Stellar CLI](../../smart-contracts/getting-started/setup.mdx#install-the-stellar-cli)
 
 ## Initialize a sample Rust Contract
 
@@ -34,7 +34,7 @@ cd hello-world
 stellar contract build
 ```
 
-This sequence of commands creates a new directory for your project, initializes a new Soroban smart contract within that directory, and builds the contract. The build generates .wasm file in the path `hello-word/target/wasm32v1-none/release/hello_world.wasm`
+This sequence of commands creates a new directory for your project, initializes a new Soroban smart contract within that directory, and builds the contract. The build generates .wasm file in the path `hello-world/target/wasm32v1-none/release/hello_world.wasm`
 
 ## Create a Node Project
 
@@ -49,14 +49,14 @@ cd deploy-contract
 
 ```bash
 npm init -y
-npm install @stellar/stellar-sdk fs
+npm install @stellar/stellar-sdk
 ```
 
 ## Set Up Deployment Scripts
 
 ### Imports
 
-Import necessary modules in your JavaScript file:
+Import necessary modules in your JavaScript file (save it as `deploy.mjs` to enable ES module imports):
 
 ```javascript
 import * as StellarSDK from "@stellar/stellar-sdk";


### PR DESCRIPTION
Fixes #1854

## Changes
- Fixed prerequisite label: "Soroban CLI" → "Stellar CLI"
- Removed `fs` from npm install (it's a Node.js built-in, not an npm package)
- Added `.mjs` filename guidance for ES module `import` syntax to work
- Fixed typo in wasm path: `hello-word` → `hello-world`

## Testing
All steps were manually tested and confirmed working on Node.js v24 + Stellar CLI v26.1.0