### PR TITLE
remove the old announcement bar about AI translated Spanish pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -150,10 +150,6 @@ const config: Config = {
   ],
   headTags: headTags,
   themeConfig: {
-    announcementBar: {
-      id: 'announcementBar-translation',
-      content: '<strong>Disclaimer:</strong> This documentation has been automatically translated and may contain inaccuracies. For the most accurate information, please refer to the original English version. We are not responsible for translation errors.',
-    },
     docs: {
       sidebar: {
         autoCollapseCategories: false,


### PR DESCRIPTION
i removed the swizzled component which only displayed the announcement bar on the `/es/*` paths in #2512. however, i forgot to disable the announcement bar itself, so it may display on any page, for new visitors. sorry 'bout that!