### PR TITLE
chore: fix JS SDK default import for @stellar/stellar-sdk v16.0.0

### DIFF
--- a/docs/build/guides/conversions/string-conversions.mdx
+++ b/docs/build/guides/conversions/string-conversions.mdx
@@ -90,7 +90,7 @@ pub fn string_to_val(string: String) -> Val {
 ```
 
 ```js
-import StellarSdk from "@stellar/stellar-sdk";
+import * as StellarSdk from "@stellar/stellar-sdk";
 
 // Example string value
 const stringValue = "Hello, Stellar!";


### PR DESCRIPTION
js-stellar-sdk v16.0.0 removed the ESM default export (and merged @stellar/stellar-base into @stellar/stellar-sdk). The string-to-ScVal example used `import StellarSdk from "@stellar/stellar-sdk"`, which no longer works. Switch to a namespace import (`import * as StellarSdk`) to preserve the `StellarSdk.xdr.ScVal` body unchanged.