### PR TITLE
Add skills.stellar.org and update Stellar Skills docs on Building with AI page

### DIFF
--- a/docs/build/building-with-ai.mdx
+++ b/docs/build/building-with-ai.mdx
@@ -9,48 +9,62 @@ sidebar_position: 1
 
 Stellar provides resources to help AI assistants and Large Language Models (LLMs) understand our documentation, making it easier for you to get accurate answers about Stellar development.
 
-## Stellar Development Skill
+## Stellar Skills
 
-The [Stellar Development Skill](https://github.com/stellar/stellar-dev-skill) is a comprehensive AI skill that gives coding assistants deep knowledge of the Stellar ecosystem.
+[**skills.stellar.org**](https://skills.stellar.org/) is the home for Stellar Skills—a collection of AI agent skills that give your coding assistant the right Stellar context before it writes code. They work with any AI agent, and you can browse every skill on the website with no installation required.
 
-The skill provides expertise in:
+Skills are open source and maintained in the [stellar/stellar-dev-skill](https://github.com/stellar/stellar-dev-skill) repository.
 
-- Soroban smart contracts (Rust SDK)
-- JavaScript, Python, and Go SDKs for client applications
-- Stellar RPC and Horizon APIs
-- Stellar Assets and Soroban tokens (SAC bridge)
-- Wallet integration (Freighter, Stellar Wallets Kit)
-- Smart accounts with passkeys
-- Testing strategies and security patterns
-- Agentic payment concepts such as x402 and Machine Payments Protocol (MPP)
+### Official skills
 
-### Supported platforms
+The official skills cover the core areas of Stellar development:
 
-The skill can be installed on any AI coding tool that supports the [Agent Skills](https://github.com/anthropics/agent-skills) standard:
+| Skill | What it covers |
+| --- | --- |
+| **Soroban Smart Contracts** | Writing, testing, securing, and shipping Rust smart contracts |
+| **Frontend & Wallets** | Building dApps with the JavaScript SDK, wallet integration (Freighter, Stellar Wallets Kit), and smart accounts with passkeys |
+| **Stellar Assets & SAC** | Classic assets, trustlines, and the Soroban Asset Contract bridge |
+| **RPC & Horizon APIs** | Querying chain data via modern Stellar RPC or the legacy Horizon endpoints |
+| **Agent Payments** | Monetizing AI APIs with x402 and the Machine Payments Protocol (MPP) |
+| **ZK Proofs** | Verifying zero-knowledge proofs on-chain |
+| **SEPs, CAPs & Ecosystem** | Standards and ecosystem integration guidance |
+
+### Community skills
+
+The ecosystem also contributes skills for popular protocols and tools, such as OpenZeppelin Contracts, the DeFindex SDK, the Soroswap SDK, and Trustless Work. Browse the full, up-to-date list at [skills.stellar.org](https://skills.stellar.org/). Community skills are maintained by their respective authors, so review each one to confirm it meets your security and maintenance requirements before using it.
+
+### Installation
+
+Skills can be installed on any AI coding tool that supports the [Agent Skills](https://github.com/anthropics/agent-skills) standard. Each tool reads skills from its own directory:
 
 | Platform | Skills directory |
 | --- | --- |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/skills/` |
-| [OpenCode](https://opencode.ai) | `~/.config/opencode/skills/` |
+| [OpenCode](https://opencode.ai) | `~/.config/opencode/skill/` |
 | [OpenAI Codex](https://openai.com/index/openai-codex/) | `~/.codex/skills/` |
-
-### Installation
 
 #### Claude Code
 
 ```bash
 /plugin marketplace add stellar/stellar-dev-skill
+/plugin install stellar-dev@stellar-dev
 ```
 
-**Using npx (works with any compatible tool):**
+#### OpenAI Codex
+
+```bash
+git clone https://github.com/stellar/stellar-dev-skill ~/.codex/skills/stellar-dev-skill
+```
+
+#### Using npx (works with any compatible tool)
 
 ```bash
 npx skills add https://github.com/stellar/stellar-dev-skill
 ```
 
-**Manual installation:**
+#### Manual installation
 
-[Clone the repository](https://github.com/stellar/stellar-dev-skill) and copy the `skill/` directory to your agent's skills location (see table above).
+[Clone the repository](https://github.com/stellar/stellar-dev-skill) and copy the `skills/` directory to your agent's skills location (see table above).
 
 Once installed, your AI coding assistant will automatically have access to up-to-date Stellar development knowledge when you work on Stellar projects.
 
@@ -83,10 +97,11 @@ You can chat with Stella right here by clicking the yellow icon at the bottom of
 
 Any AI assistant with custom context features can benefit from Stellar's resources. You can add `llms.txt` to your tool's context settings, or paste its contents directly into conversations to give the AI knowledge about Stellar development.
 
-Popular tools like ChatGPT, Claude, Gemini, and Cursor all support adding custom context through their settings. We're actively working on dedicated integrations for more AI tools—check back for updates or follow the [Stellar Development Skill repository](https://github.com/stellar/stellar-dev-skill) for the latest supported platforms.
+Popular tools like ChatGPT, Claude, Gemini, and Cursor all support adding custom context through their settings. We're actively working on dedicated integrations for more AI tools—check back for updates or follow the [Stellar Skills repository](https://github.com/stellar/stellar-dev-skill) for the latest supported platforms.
 
 ## Additional resources
 
-- [Stellar Development Skill](https://github.com/stellar/stellar-dev-skill) - Comprehensive AI skill for coding assistants
+- [Stellar Skills](https://skills.stellar.org/) - Browse AI agent skills for Stellar development
+- [stellar-dev-skill repository](https://github.com/stellar/stellar-dev-skill) - Source and installation for the official skills
 - [Stella AI Bot](../tools/developer-tools/ai-bot.mdx) - Stellar's built-in AI assistant
 - [Stellar Developer Discord](https://discord.gg/stellardev) - Ask questions in #stella-help

--- a/docs/build/building-with-ai.mdx
+++ b/docs/build/building-with-ai.mdx
@@ -64,7 +64,7 @@ npx skills add https://github.com/stellar/stellar-dev-skill
 
 #### Manual installation
 
-[Clone the repository](https://github.com/stellar/stellar-dev-skill) and copy the `skills/` directory to your agent's skills location (see table above).
+[Clone the repository](https://github.com/stellar/stellar-dev-skill) and copy the contents of the `skills/` directory into your agent's skills location (see table above).
 
 Once installed, your AI coding assistant will automatically have access to up-to-date Stellar development knowledge when you work on Stellar projects.
 

--- a/docs/build/building-with-ai.mdx
+++ b/docs/build/building-with-ai.mdx
@@ -31,7 +31,7 @@ The official skills cover the core areas of Stellar development:
 
 ### Community skills
 
-The ecosystem also contributes skills for popular protocols and tools, such as OpenZeppelin Contracts, the DeFindex SDK, the Soroswap SDK, and Trustless Work. Browse the full, up-to-date list at [skills.stellar.org](https://skills.stellar.org/). Community skills are maintained by their respective authors, so review each one to confirm it meets your security and maintenance requirements before using it.
+The ecosystem also contributes skills for popular protocols and tools. Browse the full, up-to-date list at [skills.stellar.org](https://skills.stellar.org/). Community skills are maintained by their respective authors, so review each one to confirm it meets your security and maintenance requirements before using it.
 
 ### Installation
 


### PR DESCRIPTION
Updates the Building with AI page to feature [skills.stellar.org](https://skills.stellar.org/) and reflect that the Stellar Development Skill is now a collection of skills rather than a single one.

## Changes

- Adds tables of the official skills and community skills
- Corrects the install instructions to match the current repo:
  - Claude Code `/plugin install` step
  - Codex clone command
  - OpenCode path
  - `skills/` directory

Closes #2473.