### PR TITLE
Update CT and verifier links in privacy.mdx

### DIFF
--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -47,8 +47,9 @@ This makes confidential tokens well-suited for payments where parties need confi
 
 The [Confidential Token Association](https://www.confidentialtoken.org/) — whose members include the Stellar Development Foundation, Nethermind, OpenZeppelin, and Zama — is developing an open standard for encryption-based onchain confidentiality compatible with existing token interfaces. Implementation on Stellar is in progress.
 
-- **Website**: [confidentialtoken.org](https://www.confidentialtoken.org/)
-- **Overview/demo video**: [youtube.com/watch?v=6NnDqVQYOHM](https://www.youtube.com/watch?v=6NnDqVQYOHM)
+- **OpenZeppelin Confidential Token Repo**: [GitHub](https://github.com/OpenZeppelin/stellar-contracts/tree/feat/confidential-verifier-ultrahonk/packages/tokens/src/confidential)
+- **Confidential Token Association**: [confidentialtoken.org](https://www.confidentialtoken.org/)
+- **Confidential Token overview/demo by Jay Geng (SDF) at Meridian 2025**: [YouTube](https://www.youtube.com/watch?v=6NnDqVQYOHM)
 
 ## Onchain ZK Verifiers
 
@@ -66,7 +67,7 @@ The Stellar Private Payments prototype includes a deployable verifier contract. 
 A verifier for circuits built with Aztec's Noir language and Barretenberg backend.
 
 - **Repo**:
-  - [ultrahonk verifier](https://github.com/yugocabrio/rs-soroban-ultrahonk)
+  - [Ultrahonk verifier](https://github.com/NethermindEth/rs-soroban-ultrahonk)
   - [ultrahonk Stellar smart contract](https://github.com/indextree/ultrahonk_soroban_contract)
 
 ## ZK Cryptographic Primitives


### PR DESCRIPTION
Added OpenZeppelin's Confidential Tokens repo, updated Ultrahonk verifier repo link to Nethermind's org, and updated description for video of Jay's CT presentation at Meridian.