### PR TITLE
fix: sanitize CLI plugin descriptions to prevent HTML/script injection

### DIFF
--- a/scripts/stellar_cli_plugins.mjs
+++ b/scripts/stellar_cli_plugins.mjs
@@ -3,7 +3,19 @@ import https from "https";
 
 // In case there are plugins to exclude from the list, add them here.
 // E.g. "user/repo"
-const excludePlugins = [];
+const excludePlugins = ["haqnawaz03329-debug/haqnawaz"];
+
+// GitHub repo descriptions are attacker-controlled (anyone can tag a repo with
+// the `stellar-cli-plugin` topic), and this content is injected into MDX, which
+// renders HTML/JSX. Neutralize characters that could execute as markup/script.
+function sanitize(value) {
+  return (value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/{/g, "&#123;")
+    .replace(/}/g, "&#125;");
+}
 
 function exportMDX(data) {
   const pluginsContent = data.items.reduce((buffer, item) => {
@@ -11,11 +23,11 @@ function exportMDX(data) {
       return buffer;
     }
 
-    const plugin = `### [${item.full_name}](${item.html_url})
+    const plugin = `### [${sanitize(item.full_name)}](${encodeURI(item.html_url)})
 
-${item.description || ""}
+${sanitize(item.description)}
 
-[${item.html_url}](${item.html_url})
+[${encodeURI(item.html_url)}](${encodeURI(item.html_url)})
 `;
 
     return buffer + plugin;


### PR DESCRIPTION
## Problem

The CLI plugins list page (`/docs/tools/cli/plugins-list`) is generated at build time by `scripts/stellar_cli_plugins.mjs`, which queries GitHub for **any** repo tagged with the `stellar-cli-plugin` topic and injects each repo's `description` **verbatim** into the MDX file.

Because MDX renders HTML/JSX, an attacker-controlled repo description containing a `<script>` tag executes in visitors' browsers — a stored XSS.

A repo (`haqnawaz03329-debug/haqnawaz`) exploited this with the description:

```
This is a cool plugin! <script>alert('Website Hacked by Haq Nawaz!')</script>
```

…which produced a "Website Hacked by Haq Nawaz!" popup on the published page.

This vulnerability has existed since the feature shipped in #1900 (`3010ea33`). The malicious payload itself was never committed to this repo — it's pulled in dynamically at build time from the external repo.

## Fix

- Add a `sanitize()` helper that escapes HTML/MDX-significant characters (`& < > { }`) in all injected GitHub fields (covers both HTML `<script>` and MDX/JSX `{...}` expression injection).
- Run repo URLs through `encodeURI`.
- Exclude the offending repo via `excludePlugins`.

Anyone can self-tag a repo with the topic, so sanitization — not just blocking one repo — is the durable fix.

## Follow-ups (not in this PR)
- **Redeploy** is required to clear the popup from the live site (production serves the already-built page).
- Consider reporting `haqnawaz03329-debug/haqnawaz` to GitHub for TOS abuse.
- Consider a Content-Security-Policy disallowing inline scripts as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)