### PR TITLE
Harden Stellar CLI plugin sanitization against markdown/HTML injection

### DIFF
--- a/scripts/stellar_cli_plugins.mjs
+++ b/scripts/stellar_cli_plugins.mjs
@@ -48,7 +48,7 @@ function exportMDX(data) {
 
     const plugin = `### [${escape(item.full_name)}](${encodeURI(item.html_url)})
 
-${escape(item.description)}
+<p>${escape(item.description)}</p>
 
 [${encodeURI(item.html_url)}](${encodeURI(item.html_url)})
 `;

--- a/scripts/stellar_cli_plugins.mjs
+++ b/scripts/stellar_cli_plugins.mjs
@@ -5,16 +5,39 @@ import https from "https";
 // E.g. "user/repo"
 const excludePlugins = ["haqnawaz03329-debug/haqnawaz"];
 
-// GitHub repo descriptions are attacker-controlled (anyone can tag a repo with
-// the `stellar-cli-plugin` topic), and this content is injected into MDX, which
-// renders HTML/JSX. Neutralize characters that could execute as markup/script.
-function sanitize(value) {
-  return (value || "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/{/g, "&#123;")
-    .replace(/}/g, "&#125;");
+const MD_ENTITIES = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+  "*": "&#42;",
+  _: "&#95;",
+  "`": "&#96;",
+  "[": "&#91;",
+  "]": "&#93;",
+  "(": "&#40;",
+  ")": "&#41;",
+  "#": "&#35;",
+  "+": "&#43;",
+  "-": "&#45;",
+  ".": "&#46;",
+  "!": "&#33;",
+  "|": "&#124;",
+  "~": "&#126;",
+  "\\": "&#92;",
+  "{": "&#123;",
+  "}": "&#125;",
+  "=": "&#61;",
+  ":": "&#58;",
+  $: "&#36;",
+};
+
+function escape(value) {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[&<>"'*_`\[\]()#+\-.!|~\\{}=:$]/g, (ch) => MD_ENTITIES[ch]);
 }
 
 function exportMDX(data) {
@@ -23,9 +46,9 @@ function exportMDX(data) {
       return buffer;
     }
 
-    const plugin = `### [${sanitize(item.full_name)}](${encodeURI(item.html_url)})
+    const plugin = `### [${escape(item.full_name)}](${encodeURI(item.html_url)})
 
-${sanitize(item.description)}
+${escape(item.description)}
 
 [${encodeURI(item.html_url)}](${encodeURI(item.html_url)})
 `;


### PR DESCRIPTION
GitHub repo names and descriptions surfaced on the CLI plugins list are attacker-controlled — anyone can tag a repo with the `stellar-cli-plugin` topic — and they're injected into an MDX file that Docusaurus renders as markdown + HTML/JSX. The previous `sanitize()` only escaped `& < > { }`, which stopped HTML/JSX injection but left markdown injection wide open: a description could inject phishing links, remote tracking images, fake headings, code fences, or other block-level structure.

This replaces `sanitize()` with `escape()`, which renders these values as inert literal text:

- Collapses all whitespace (including newlines) to a single space and trims — neutralizes block-level markdown and MDX `import`/`export` injection, which only fire at the start of a line.
- Entity-escapes the full set of HTML/JSX/markdown control characters (`& < > " ' * _ \` [ ] ( ) # + - . ! | ~ \ { } = : $`) via a lookup map, so none of them are parsed as syntax on Docusaurus's render pass.

Applied to both the plugin `full_name` (link text) and the free-form `description`.