### PR TITLE
SDP-2102 fix: update broken SDP recipient_registration_attempts query

### DIFF
--- a/docs/platforms/stellar-disbursement-platform/admin-guide/troubleshooting.mdx
+++ b/docs/platforms/stellar-disbursement-platform/admin-guide/troubleshooting.mdx
@@ -249,7 +249,7 @@ The most frequent cause is the receiver entering a different email or phone numb
 
 ```sql
 SELECT * FROM sdp_<tenant_name>.receiver_registration_attempts
-ORDER BY created_at DESC
+ORDER BY attempt_ts DESC
 LIMIT 20;
 ```
 


### PR DESCRIPTION
### What

Update DB query listed under [Receiver Not Receiving OTP During Registration](https://developers.stellar.org/docs/platforms/stellar-disbursement-platform/admin-guide/troubleshooting#receiver-not-receiving-otp) to use `attempt_ts` column instead of `created_at`.

### Why

- The current `ORDER BY created_at DESC` refers to a column that doesn't exist under the `receiver_registration_attempts` table, therefore running this query returns `Error in query (7): ERROR: column "created_at" does not exist`. 
- Instead, `attempt_ts` is the correct column name containing the intended rows.