### PR TITLE
add a 3-day cooldown for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "02:00"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 2
     groups:
       all-actions:
@@ -36,6 +38,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "02:00"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 2
     groups:
       all-docker:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "02:00"
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 2
     groups:
       minor-and-patch:


### PR DESCRIPTION
configuring [`cooldown`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) for the dependabot pull requests. we've already configured a `pnpm` cooldown for packages of 3 days. dependabot can sometimes create pull requests with too-recent packages, which then fail to build (see #2540)