### PR TITLE
[chore]sdk-examples: fix broken py-stellar-base imports

### DIFF
--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -99,8 +99,7 @@ import time
 
 from stellar_sdk import Network, Keypair, TransactionBuilder
 from stellar_sdk import xdr as stellar_xdr
-from stellar_sdk.soroban import SorobanServer
-from stellar_sdk.soroban.soroban_rpc import TransactionStatus
+from stellar_sdk import SorobanServer
 
 # TODO: You need to replace the following parameters according to the actual situation
 secret = "SAAPYAPTTRZMCUZFPG3G66V4ZMHTK4TWA6NS7U4F7Z3IMUD52EK4DDEV"

--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -119,7 +119,7 @@ source = soroban_server.load_account(kp.public_key)
 tx = (
     TransactionBuilder(source, network_passphrase)
     .set_timeout(300)
-    .append_install_contract_code_op(
+    .append_upload_contract_wasm_op(
         contract=contract_file_path,  # the path to the contract, or binary data
         source=kp.public_key,
     )


### PR DESCRIPTION
Correctness audit against `py-stellar-base` v14.1.1