### PR TITLE
fix: use relative .mdx links on Tier 1 Orgs page

### DIFF
--- a/docs/validators/tier-1-orgs.mdx
+++ b/docs/validators/tier-1-orgs.mdx
@@ -17,7 +17,7 @@ Run three geographically dispersed Full Validators, achieve sustained 99.9%+ upt
 
 :::info[Not ready for Tier 1?]
 
-Running a single [Basic or Full Validator](/docs/validators) is a meaningful contribution to network decentralization and a great way to build operational experience. The [Admin Guide](/docs/validators/admin-guide) covers everything you need for single-node setup. This page covers the additional requirements for running three Full Validators as a Tier 1 organization.
+Running a single [Basic or Full Validator](./README.mdx) is a meaningful contribution to network decentralization and a great way to build operational experience. The [Admin Guide](./admin-guide/README.mdx) covers everything you need for single-node setup. This page covers the additional requirements for running three Full Validators as a Tier 1 organization.
 
 :::
 
@@ -25,10 +25,10 @@ Running a single [Basic or Full Validator](/docs/validators) is a meaningful con
 
 | Requirement | Details |
 | --- | --- |
-| **Full Validators** | 3, each [publishing a separate history archive](/docs/validators/admin-guide/publishing-history-archives) |
+| **Full Validators** | 3, each [publishing a separate history archive](./admin-guide/publishing-history-archives.mdx) |
 | **Geographic dispersion** | Nodes in different data centers or cloud regions |
 | **Self-verification** | [SEP-20](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md) on-chain identity linking + [SEP-1](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md) stellar.toml |
-| **Uptime** | 99.9%+ target with 24/7 [monitoring and alerting](/docs/validators/admin-guide/monitoring) |
+| **Uptime** | 99.9%+ target with 24/7 [monitoring and alerting](./admin-guide/monitoring.mdx) |
 | **Coordination** | Active communication with other Tier 1 organizations |
 | **Trust** | Other Tier 1 organizations must choose to include you in their quorum sets |
 
@@ -98,15 +98,15 @@ The checklist below covers the operational work. Completing it is necessary but 
 
 ### Phase 1: First Full Validator
 
-Work through the [Admin Guide](/docs/validators/admin-guide) to stand up a single Full Validator on Mainnet:
+Work through the [Admin Guide](./admin-guide/README.mdx) to stand up a single Full Validator on Mainnet:
 
-- [ ] Review [prerequisites](/docs/validators/admin-guide/prerequisites) and provision a server
-- [ ] [Install](/docs/validators/admin-guide/installation) Stellar Core
-- [ ] [Configure](/docs/validators/admin-guide/configuring) for Mainnet with a validator key pair (`stellar-core gen-seed`)
-- [ ] [Prepare your environment](/docs/validators/admin-guide/environment-preparation) and initialize the database
-- [ ] Set up a [history archive](/docs/validators/admin-guide/publishing-history-archives)
-- [ ] [Start your node](/docs/validators/admin-guide/running-node) and sync to the network
-- [ ] Set up [monitoring](/docs/validators/admin-guide/monitoring) with Prometheus + Grafana
+- [ ] Review [prerequisites](./admin-guide/prerequisites.mdx) and provision a server
+- [ ] [Install](./admin-guide/installation.mdx) Stellar Core
+- [ ] [Configure](./admin-guide/configuring.mdx) for Mainnet with a validator key pair (`stellar-core gen-seed`)
+- [ ] [Prepare your environment](./admin-guide/environment-preparation.mdx) and initialize the database
+- [ ] Set up a [history archive](./admin-guide/publishing-history-archives.mdx)
+- [ ] [Start your node](./admin-guide/running-node.mdx) and sync to the network
+- [ ] Set up [monitoring](./admin-guide/monitoring.mdx) with Prometheus + Grafana
 
 ### Phase 2: Three Full Validators
 
@@ -114,8 +114,8 @@ Scale to the Tier 1 architecture:
 
 - [ ] Provision 2 additional servers in **different geographic regions**
 - [ ] Generate **unique** key pairs for each node — never share seeds
-- [ ] Configure each with its own [history archive](/docs/validators/admin-guide/publishing-history-archives) (one archive per node)
-- [ ] Deploy the standard Tier 1 [quorum set](/docs/validators/admin-guide/configuring#choosing-your-quorum-set) on all three nodes, declaring your own organization as `HIGH` quality
+- [ ] Configure each with its own [history archive](./admin-guide/publishing-history-archives.mdx) (one archive per node)
+- [ ] Deploy the standard Tier 1 [quorum set](./admin-guide/configuring.mdx#choosing-your-quorum-set) on all three nodes, declaring your own organization as `HIGH` quality
 - [ ] Extend monitoring to cover all three nodes
 
 ### Phase 3: Identity and Verification
@@ -168,7 +168,7 @@ The `#validator` channel on the [Stellar Dev Discord](https://discord.gg/stellar
 | Stellar Dev Discord (`#validator`) — primary coordination channel for validator operators. Release announcements, upgrade coordination, incident response. | [discord.gg/stellardev](https://discord.gg/stellardev) |
 | stellar-core GitHub releases — official release notes | [github.com/stellar/stellar-core/releases](https://github.com/stellar/stellar-core/releases) |
 | Obsrvr Radar — public validator uptime and quorum monitoring | [radar.withobsrvr.com](https://radar.withobsrvr.com/) |
-| Admin Guide | [/docs/validators/admin-guide](/docs/validators/admin-guide) |
+| Admin Guide | [Admin Guide](./admin-guide/README.mdx) |
 | Example Mainnet Full Validator config | [stellar/packages on GitHub](https://github.com/stellar/packages/blob/master/docs/examples/pubnet-validator-full/stellar-core.cfg) |
 | SEP-20 (Self-Verification) | [stellar-protocol on GitHub](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0020.md) |
 | SEP-1 (stellar.toml) | [stellar-protocol on GitHub](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md) |


### PR DESCRIPTION
## What

Replaces the absolute `/docs/...` links on the [Tier 1 Organizations page](https://github.com/stellar/stellar-docs/blob/main/docs/validators/tier-1-orgs.mdx) with relative `../path/file.mdx` links, per the [Docusaurus convention](https://docusaurus.io/docs/markdown-features/links) already codified in [`anchor-platform/CONTRIBUTING.md`](https://github.com/stellar/stellar-docs/blob/main/docs/platforms/anchor-platform/CONTRIBUTING.md).

10 distinct link targets updated (14 occurrences). Index pages link to `README.mdx`, matching existing precedent in `docs/README.mdx`. The `#choosing-your-quorum-set` anchor is preserved on the `configuring.mdx` link.

## Why

Relative `.mdx` links are validated at build time by Docusaurus's `onBrokenMarkdownLinks: "throw"`, guarding against future link rot. Absolute route links skip that file-based check.

## Verification

- `grep '](/docs' docs/validators/tier-1-orgs.mdx` → zero internal absolute links remain
- All 9 relative target files confirmed to exist
- Anchor target `#choosing-your-quorum-set` resolves to the `## Choosing Your Quorum Set` heading
- `prettier -c` (matches CI `ci:mdx`) passes

## Follow-up

This fixes the single page. #2547 tracks the repo-wide sweep of the remaining 6 files plus an automated check (CI gate + pre-commit hint) to prevent regressions.

Fixes #2546

🤖 Generated with [Claude Code](https://claude.com/claude-code)