### PR TITLE
Add CT DP blog, DP stream, and OZ CT demo links to Confidential Tokens

### DIFF
--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -49,7 +49,7 @@ The [Confidential Token Association](https://www.confidentialtoken.org/) — who
 
 :::caution
 
-Confidential tokens on Stellar are a developer preview. The contracts and demo linked below are unaudited and available on Testnet only — not yet intended for production use or real assets.
+Confidential tokens on Stellar are a developer preview. The contracts and demo linked below are unaudited — not yet intended for production use or real assets.
 
 :::
 

--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -47,7 +47,10 @@ This makes confidential tokens well-suited for payments where parties need confi
 
 The [Confidential Token Association](https://www.confidentialtoken.org/) — whose members include the Stellar Development Foundation, Nethermind, OpenZeppelin, and Zama — is developing an open standard for encryption-based onchain confidentiality compatible with existing token interfaces. Implementation on Stellar is in progress.
 
+Learn more about our work with OpenZeppelin in the post [Developer Preview: Confidential Tokens on Stellar](https://stellar.org/blog/developers/developer-preview-confidential-tokens-on-stellar), published on June 29, 2026 during the Testnet preview, and watch the [Developer Preview stream with OpenZeppelin](https://youtu.be/nfbr3KuYqPE?si=n5jX6g3-azW4Lp1B) that explains more about the architecture and design choices.
+
 - **OpenZeppelin Confidential Token Repo**: [GitHub](https://github.com/OpenZeppelin/stellar-contracts/tree/feat/confidential-verifier-ultrahonk/packages/tokens/src/confidential)
+- **OpenZeppelin Confidential Token Demo**: [demo](https://stellar-confidential-token-demo.billowing-moon-0c6f.workers.dev/), [GitHub](https://github.com/brozorec/stellar-confidential-token-demo), [video walkthrough](https://x.com/BuildOnStellar/status/2072357829353308214?s=20)
 - **Confidential Token Association**: [confidentialtoken.org](https://www.confidentialtoken.org/)
 - **Confidential Token overview/demo by Jay Geng (SDF) at Meridian 2025**: [YouTube](https://www.youtube.com/watch?v=6NnDqVQYOHM)
 

--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -49,7 +49,7 @@ The [Confidential Token Association](https://www.confidentialtoken.org/) — who
 
 :::caution
 
-Confidential tokens on Stellar are a developer preview. The contracts and demo linked below are unaudited and available on Testnet only — do not use in production or with real assets.
+Confidential tokens on Stellar are a developer preview. The contracts and demo linked below are unaudited and available on Testnet only — not yet intended for production use or real assets.
 
 :::
 

--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -50,7 +50,7 @@ The [Confidential Token Association](https://www.confidentialtoken.org/) — who
 Learn more about our work with OpenZeppelin in the post [Developer Preview: Confidential Tokens on Stellar](https://stellar.org/blog/developers/developer-preview-confidential-tokens-on-stellar), published on June 29, 2026 during the Testnet preview, and watch the [Developer Preview stream with OpenZeppelin](https://youtu.be/nfbr3KuYqPE?si=n5jX6g3-azW4Lp1B) that explains more about the architecture and design choices.
 
 - **OpenZeppelin Confidential Token Repo**: [GitHub](https://github.com/OpenZeppelin/stellar-contracts/tree/feat/confidential-verifier-ultrahonk/packages/tokens/src/confidential)
-- **OpenZeppelin Confidential Token Demo**: [demo](https://stellar-confidential-token-demo.billowing-moon-0c6f.workers.dev/), [GitHub](https://github.com/brozorec/stellar-confidential-token-demo), [video walkthrough](https://x.com/BuildOnStellar/status/2072357829353308214?s=20)
+- **OpenZeppelin Confidential Token Demo**: [Demo](https://stellar-confidential-token-demo.billowing-moon-0c6f.workers.dev/), [GitHub](https://github.com/brozorec/stellar-confidential-token-demo), [Video walkthrough](https://x.com/BuildOnStellar/status/2072357829353308214)
 - **Confidential Token Association**: [confidentialtoken.org](https://www.confidentialtoken.org/)
 - **Confidential Token overview/demo by Jay Geng (SDF) at Meridian 2025**: [YouTube](https://www.youtube.com/watch?v=6NnDqVQYOHM)
 

--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -47,6 +47,12 @@ This makes confidential tokens well-suited for payments where parties need confi
 
 The [Confidential Token Association](https://www.confidentialtoken.org/) — whose members include the Stellar Development Foundation, Nethermind, OpenZeppelin, and Zama — is developing an open standard for encryption-based onchain confidentiality compatible with existing token interfaces. Implementation on Stellar is in progress.
 
+:::caution
+
+Confidential tokens on Stellar are a developer preview. The contracts and demo linked below are unaudited and available on Testnet only — do not use in production or with real assets.
+
+:::
+
 Learn more about our work with OpenZeppelin in the post [Developer Preview: Confidential Tokens on Stellar](https://stellar.org/blog/developers/developer-preview-confidential-tokens-on-stellar), published on June 29, 2026 during the Testnet preview, and watch the [Developer Preview stream with OpenZeppelin](https://youtu.be/nfbr3KuYqPE?si=n5jX6g3-azW4Lp1B) that explains more about the architecture and design choices.
 
 - **OpenZeppelin Confidential Token Repo**: [GitHub](https://github.com/OpenZeppelin/stellar-contracts/tree/feat/confidential-verifier-ultrahonk/packages/tokens/src/confidential)


### PR DESCRIPTION
Updates the [Confidential Tokens](https://developers.stellar.org/docs/build/apps/privacy#confidential-tokens) section of `docs/build/apps/privacy.mdx`:

- Adds a paragraph linking to the [Developer Preview: Confidential Tokens on Stellar](https://stellar.org/blog/developers/developer-preview-confidential-tokens-on-stellar) blog post (published June 29, 2026 during the Testnet preview) and the [Developer Preview stream with OpenZeppelin](https://youtu.be/nfbr3KuYqPE?si=n5jX6g3-azW4Lp1B) covering architecture and design choices.
- Adds an **OpenZeppelin Confidential Token Demo** bullet with links to the [demo](https://stellar-confidential-token-demo.billowing-moon-0c6f.workers.dev/), [GitHub](https://github.com/brozorec/stellar-confidential-token-demo), and [video walkthrough](https://x.com/BuildOnStellar/status/2072357829353308214?s=20).