### PR TITLE
Add Nethermind Private Payments Demo link

### DIFF
--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -37,7 +37,7 @@ Research prototype, not audited. Do not use in production with real assets.
 Proofs are generated client-side in the browser via WebAssembly — user secrets never leave the device.
 
 - **Repo**: [NethermindEth/stellar-private-payments](https://github.com/NethermindEth/stellar-private-payments)
-- **Docs**: [nethermindeth.github.io/stellar-private-payments](https://nethermindeth.github.io/stellar-private-payments/)
+- **Demo**: [nethermindeth.github.io/stellar-private-payments](https://nethermindeth.github.io/stellar-private-payments/)
 
 ## Confidential Tokens
 


### PR DESCRIPTION
In the [Stellar Private Payments](https://developers.stellar.org/docs/build/apps/privacy#stellar-private-payments) section of `docs/build/apps/privacy.mdx`, the `nethermindeth.github.io/stellar-private-payments` link was labeled **Docs**, but that page is actually an **interactive testnet demo** — it has Freighter wallet connect and live deposit / transfer / withdraw UI (the page titles itself "Stellar Private Payments: Interactive Demo").

This relabels the bullet **Docs → Demo** so it accurately reflects what a reader will find. No URL change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)