### PR TITLE
Document RPC pagination limits

### DIFF
--- a/docs/data/apis/rpc/api-reference/structure/pagination.mdx
+++ b/docs/data/apis/rpc/api-reference/structure/pagination.mdx
@@ -6,7 +6,15 @@ title: Pagination
 For methods which support it, the pagination arguments are passed as a final object argument with two values:
 
 - `cursor`: string - (optional) An opaque string which acts as a paging token. Each response will include a `cursor` field which can be included in a subsequent request to obtain the next page of results.
-- `limit`: number - (optional) The maximum number of records returned. The limit for [getEvents](../methods/getEvents.mdx) can range from 1 to 10000 - an upper limit that is hardcoded in Stellar-RPC for performance reasons. If this argument isn't designated, it defaults to 100.
+- `limit`: number - (optional) The maximum number of records returned. Each paginated method has a method-specific range and default.
+
+| Method | Limit range | Default limit |
+| --- | --- | --- |
+| [`getEvents`](../methods/getEvents.mdx) | 1 to 10000 | 100 |
+| [`getLedgers`](../methods/getLedgers.mdx) | 1 to 200 | 50 |
+| [`getTransactions`](../methods/getTransactions.mdx) | 1 to 200 | 50 |
+
+These upper limits are hardcoded in Stellar RPC for performance reasons.
 
 For example, calling a method with pagination parameter set:
 

--- a/docs/data/apis/rpc/api-reference/structure/pagination.mdx
+++ b/docs/data/apis/rpc/api-reference/structure/pagination.mdx
@@ -14,7 +14,7 @@ For methods which support it, the pagination arguments are passed as a final obj
 | [`getLedgers`](../methods/getLedgers.mdx) | 1 to 200 | 50 |
 | [`getTransactions`](../methods/getTransactions.mdx) | 1 to 200 | 50 |
 
-These upper limits are hardcoded in Stellar RPC for performance reasons.
+These upper limits default to the values shown above, but are configurable per RPC instance (via the `max-events-limit`, `max-ledgers-limit`, and `max-transactions-limit` options), so a specific provider's limits may differ.
 
 For example, calling a method with pagination parameter set:
 

--- a/docs/data/apis/rpc/api-reference/structure/pagination.mdx
+++ b/docs/data/apis/rpc/api-reference/structure/pagination.mdx
@@ -14,7 +14,7 @@ For methods which support it, the pagination arguments are passed as a final obj
 | [`getLedgers`](../methods/getLedgers.mdx) | 1 to 200 | 50 |
 | [`getTransactions`](../methods/getTransactions.mdx) | 1 to 200 | 50 |
 
-These upper limits default to the values shown above, but are configurable per RPC instance (via the `max-events-limit`, `max-ledgers-limit`, and `max-transactions-limit` options), so a specific provider's limits may differ.
+These upper limits are hardcoded in Stellar RPC for performance reasons.
 
 For example, calling a method with pagination parameter set:
 


### PR DESCRIPTION
## What

- Adds a method-specific pagination limits table to the indexed Stellar RPC pagination structure page.

## Why

The RPC method reference renders the correct per-method pagination limits from OpenRPC, but those generated/reference details are not reliably discoverable through the current DocSearch index. The indexed pagination structure page only described `getEvents`, which can lead consumers to miss the `getLedgers` and `getTransactions` limits/defaults.

Related to #2566.

## Validation

- `prettier --config .prettierrc.js --check docs/data/apis/rpc/api-reference/structure/pagination.mdx docs/tools/cli/install-cli.mdx`
- `git diff --check`

Note: full `pnpm` checks in a fresh worktree were blocked by an existing dependency postinstall/Corepack/Yarn failure in `postman-code-generators`, before project checks could run.
