### PR TITLE
Update Alchemy entry on Indexers page — Stellar Data API is now live

### DIFF
--- a/docs/data/indexers/README.mdx
+++ b/docs/data/indexers/README.mdx
@@ -27,7 +27,7 @@ Lots of apps need this kind of data, and it tends to have a standard shape. This
 
 In the biz, these are called _Portfolio APIs._ Well-known companies offering them:
 
-- [Alchemy]: a widely-used data provider (popular on Ethereum), now live on Stellar. Its [Stellar Data API](https://www.alchemy.com/docs/reference/stellar-data-api-overview) serves indexed **transfer history**, **account balances**, and **NFT holdings** across native, Stellar Classic, and Soroban assets — letting you query this data without running your own indexer (JSON request bodies, opaque `pageKey` pagination). Alchemy also provides [Stellar JSON-RPC](https://www.alchemy.com/docs/reference/stellar-api-quickstart) and appears in the [RPC providers](../apis/rpc/providers.mdx) list.
+- [Alchemy]: a widely-used data provider (popular on Ethereum), now live on Stellar. Its [Stellar Data API](https://www.alchemy.com/docs/reference/stellar-data-api-overview) serves indexed **transfer history**, **account balances**, and **NFT holdings** across native, Stellar Classic, and Soroban assets — letting you query this data without running your own indexer (JSON request bodies, opaque `pageKey` pagination). Alchemy also provides [Stellar JSON-RPC](https://www.alchemy.com/docs/stellar/stellar-api-overview#stellar-apis) and appears in the [RPC providers](../apis/rpc/providers.mdx) list.
 
 - [Allium]: currently building Stellar support, launching Q1 2026
 

--- a/docs/data/indexers/README.mdx
+++ b/docs/data/indexers/README.mdx
@@ -27,7 +27,7 @@ Lots of apps need this kind of data, and it tends to have a standard shape. This
 
 In the biz, these are called _Portfolio APIs._ Well-known companies offering them:
 
-- [Alchemy]: a widely-used data provider (popular on Ethereum), now live on Stellar. Its [Stellar Data API](https://www.alchemy.com/docs/reference/stellar-data-api-overview) serves indexed **transfer history**, **account balances**, and **NFT holdings** across native, Stellar Classic, and Soroban assets — letting you query this data without running your own indexer (JSON request bodies, opaque `pageKey` pagination). Alchemy also provides [Stellar JSON-RPC](https://www.alchemy.com/docs/stellar/stellar-api-overview#stellar-apis) and appears in the [RPC providers](../apis/rpc/providers.mdx) list.
+- [Alchemy]: a widely-used data provider (popular on Ethereum), now live on Stellar. Its [Stellar Data API](https://www.alchemy.com/docs/reference/stellar-data-api-overview) serves indexed **transfer history**, **account balances**, and **NFT holdings** across Stellar assets and contract tokens — letting you query this data without running your own indexer (JSON request bodies, opaque `pageKey` pagination). Alchemy also provides [Stellar RPC](https://www.alchemy.com/docs/stellar/stellar-api-overview#stellar-apis) and appears in the [RPC providers](../apis/rpc/providers.mdx) list.
 
 - [Allium]: currently building Stellar support, launching Q1 2026
 

--- a/docs/data/indexers/README.mdx
+++ b/docs/data/indexers/README.mdx
@@ -27,7 +27,7 @@ Lots of apps need this kind of data, and it tends to have a standard shape. This
 
 In the biz, these are called _Portfolio APIs._ Well-known companies offering them:
 
-- [Alchemy]: most popular choice on Ethereum; now in talks to expand their service to Stellar, with a targeted launch in the first half of 2026.
+- [Alchemy]: a widely-used data provider (popular on Ethereum), now live on Stellar. Its [Stellar Data API](https://www.alchemy.com/docs/reference/stellar-data-api-overview) serves indexed **transfer history**, **account balances**, and **NFT holdings** across native, Stellar Classic, and Soroban assets — letting you query this data without running your own indexer (JSON request bodies, opaque `pageKey` pagination). Alchemy also provides [Stellar JSON-RPC](https://www.alchemy.com/docs/reference/stellar-api-quickstart) and appears in the [RPC providers](../apis/rpc/providers.mdx) list.
 
 - [Allium]: currently building Stellar support, launching Q1 2026
 


### PR DESCRIPTION
The [Indexers overview](https://developers.stellar.org/docs/data/indexers) listed Alchemy as _"most popular choice on Ethereum; now in talks to expand their service to Stellar, with a targeted launch in the first half of 2026."_ That's out of date — Alchemy's Stellar Data API is live.

This updates the entry to describe the actual offering: indexed **transfer history**, **account balances**, and **NFT holdings** across native, Stellar Classic, and Soroban assets (queryable without running your own indexer), and links Alchemy's [Stellar Data API overview](https://www.alchemy.com/docs/reference/stellar-data-api-overview). It also cross-links Alchemy's [Stellar JSON-RPC](https://www.alchemy.com/docs/stellar/stellar-api-overview#stellar-apis) and the existing [RPC providers](https://developers.stellar.org/docs/data/apis/rpc/providers) entry, since Alchemy offers both the Chain/RPC API and the (indexer-style) Data API.

Sourced from Alchemy's own docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)