### PR TITLE
docs: fix network value in bindings example

### DIFF
--- a/docs/build/guides/conventions/cross-contract.mdx
+++ b/docs/build/guides/conventions/cross-contract.mdx
@@ -27,7 +27,7 @@ To depend on a project, we need to know the contract address of the contract to 
 All public functions of a contract can be called. Using a network explorer can be helpful as some allow you to see the Rust interface of a contract. Bindings can also be generated using the CLI:
 
 ```bash
-stellar contract bindings rust --network --contract-id ... --output-dir ...
+stellar contract bindings rust --network testnet --contract-id ... --output-dir ...
 ```
 
 ## Making a cross-contract call


### PR DESCRIPTION
## Summary
- add the missing `testnet` value to the `--network` option in the Rust bindings example
- prevent the CLI from interpreting `--contract-id` as the network name

Closes #2580

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm check:mdx`
- `corepack pnpm build`
- `git diff --check`