### PR TITLE
Update docs for current Stellar CLI behavior

### DIFF
--- a/docs/build/guides/dapps/soroban-contract-init-template.mdx
+++ b/docs/build/guides/dapps/soroban-contract-init-template.mdx
@@ -207,7 +207,7 @@ That's it! You have an NPM project with an `initialize.js` script (and its suppo
 Let's try it. First, make sure you're running a local Stellar network. Start Docker Desktop or whatever alternative you prefer, then:
 
 ```bash
-stellar network container start local
+stellar container start local
 ```
 
 Let's include one extra contract. Go to [the increment example](https://github.com/stellar/soroban-examples/tree/main/increment) and copy increment files into the root directory.

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -63,7 +63,7 @@ The `testutils` are automatically enabled inside [Rust unit tests] inside the sa
 
 #### `release` Profile
 
-Configuring the `release` profile to optimize the contract build is critical. Soroban contracts have a maximum size of 64KB. Rust programs, even small ones, without these configurations almost always exceed this size.
+Configuring the `release` profile to optimize the contract build is critical. The network enforces a maximum contract size (currently 128KB on Mainnet, a value that can change with network configuration). Rust programs, even small ones, without these configurations almost always exceed this size.
 
 The `Cargo.toml` file has the following release profile configured.
 
@@ -311,7 +311,7 @@ If you get an error like `can't find crate for 'core'`, it means you didn't inst
 
 :::
 
-This is a small wrapper around `cargo build` that sets the target to `wasm32v1-none` and the profile to `release`. You can think of it as a shortcut for the following command:
+This is a small wrapper around `cargo build` that sets the target to `wasm32v1-none` and the profile to `release` (it also [optimizes](#optimizing-builds) the resulting `.wasm` file by default). You can think of it as a shortcut for the following command:
 
 ```sh
 cargo build --target wasm32v1-none --release
@@ -323,17 +323,21 @@ The `.wasm` file contains the logic of the contract, as well as the contract's [
 
 ## Optimizing Builds
 
-Use `stellar contract optimize` to further minimize the size of the `.wasm`:
+The `stellar contract build` command optimizes the generated `.wasm` by default, so there's no extra step needed to minimize the size of your contract. If you'd like to skip that optimization (during quick, iterative development, for example), you can disable it:
 
 ```sh
-stellar contract optimize --wasm target/wasm32v1-none/release/hello_world.wasm
+stellar contract build --optimize=false
 ```
-
-This will optimize and output a new `hello_world.optimized.wasm` file in the same location as the input `.wasm`.
 
 :::tip
 
-Building optimized contracts is only necessary when deploying to a network with fees or when analyzing and profiling a contract to get it as small as possible. If you're just starting out writing a contract, these steps are not necessary. See [Build](#build-the-contract) for details on how to build for development.
+Optimized contract builds are only necessary when deploying to a network with fees or when analyzing and profiling a contract to get it as small as possible. If you're just starting out writing a contract, un-optimized builds will work just fine.
+
+:::
+
+:::note
+
+Older versions of the Stellar CLI provided a standalone `stellar contract optimize` command. That command is now deprecated in favor of the (default) `--optimize` flag on `stellar contract build`.
 
 :::
 

--- a/docs/tools/lab/quickstart-with-lab.mdx
+++ b/docs/tools/lab/quickstart-with-lab.mdx
@@ -14,7 +14,7 @@
 Quickstart can be started for different networks. In this example, we will start Quickstart for `testnet`. Start Quickstart with the Stellar CLI using the following command:
 
 ```sh
-stellar network container start testnet
+stellar container start testnet
 ```
 
 Quickstart will usually start on `http://localhost:8000`. With this information, we can now configure Stellar Lab to use the local network.


### PR DESCRIPTION
Batch quick-fix for two Raven-reported CLI drift issues, verified against the current CLI and live network settings.

## Changes

### Removed `network container` subcommand (#2598)

`stellar network container start` no longer exists (removed in CLI v23.0.0; the current command is `stellar container start <network>`, verified against `stellar container start --help`). Updated the two live pages that still teach the old form:

- `docs/tools/lab/quickstart-with-lab.mdx`
- `docs/build/guides/dapps/soroban-contract-init-template.mdx`

The `network container` references in `software-versions.mdx` release notes and the install-cli video-tutorial label are historical/quoted content and intentionally left alone.

### Deprecated `contract optimize` + stale max contract size (#2601)

- Reworked the hello-world "Optimizing Builds" section: `stellar contract optimize` is deprecated, and `stellar contract build` now optimizes by default (`--optimize`, default `true`; pass `--optimize=false` to disable). Added a note about the deprecated standalone command for readers who encounter it elsewhere.
- Noted in the build section that `stellar contract build` optimizes by default, since the "shortcut for `cargo build`" equivalence is no longer the whole story.
- Corrected the maximum contract size claim: 64KB → 128KB, per live mainnet `contract_max_size_bytes` = 131072 (checked via `stellar network settings --network mainnet`), with a hedge that the value is network-configurable.

Closes #2598
Closes #2601

🤖 Generated with [Claude Code](https://claude.com/claude-code)