### PR TITLE
Wording and consistency fixes: state archival, Starlight, Horizon lifecycle, allocator, Lab keypairs

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -21,7 +21,7 @@ Information on how to issue assets on the Stellar network and create contract to
 
 ### [Data](./data/README.mdx)
 
-Discover various data availability options: RPC, Hubble, Galexie, the Ingest SDK, and Horizon (deprecated).
+Discover various data availability options: RPC, Hubble, Galexie, the Ingest SDK, and Horizon (nearing end-of-life).
 
 ### [Tools](./tools/README.mdx)
 

--- a/docs/build/guides/archival/create-restoration-footprint-js.mdx
+++ b/docs/build/guides/archival/create-restoration-footprint-js.mdx
@@ -6,7 +6,7 @@ description: Manually set up a restoration footprint with JavaScript SDK
 
 :::info
 
-The manual operation (`RestoreFootprintOp`) is, for the most part, no longer needed starting in Protocol 23, as archived entries included in a transaction's restore list (usually populated during transaction simulation) are [automatically restored](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration) when the `InvokeHostFunctionOp` executes. `RestoreFootprintOp` can be used in rare use cases [described in this section](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration).
+The manual operation (`RestoreFootprintOp`) is, for the most part, no longer needed starting in Protocol 23, as archived entries included in a transaction's restore list (usually populated during transaction simulation) are [automatically restored](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration) when the `InvokeHostFunctionOp` executes. `RestoreFootprintOp` can be used in rare use cases [described in this section](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#restorefootprintop).
 
 :::
 

--- a/docs/build/guides/archival/create-restoration-footprint-js.mdx
+++ b/docs/build/guides/archival/create-restoration-footprint-js.mdx
@@ -6,7 +6,7 @@ description: Manually set up a restoration footprint with JavaScript SDK
 
 :::info
 
-The manual operation (`RestoreFootprintOp`) is, for the most part, no longer needed starting in Protocol 23, as archived entries are automatically restored when they appear in a footprint during `InvokeHostFunctionOp`. `RestoreFootprintOp` can be used in rare use cases [described in this section](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration).
+The manual operation (`RestoreFootprintOp`) is, for the most part, no longer needed starting in Protocol 23, as archived entries included in a transaction's restore list (usually populated during transaction simulation) are [automatically restored](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration) when the `InvokeHostFunctionOp` executes. `RestoreFootprintOp` can be used in rare use cases [described in this section](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration).
 
 :::
 

--- a/docs/build/guides/storage/choosing-the-right-storage.mdx
+++ b/docs/build/guides/storage/choosing-the-right-storage.mdx
@@ -34,7 +34,7 @@ Read more about state archival [here](../../../learn/fundamentals/contract-devel
 
 This storage type is used for storing data on the network over an indefinitely long time period.
 
-For persistent storage, when the TTL reaches zero, the entry is moved to the archival storage. It can then be restored when needed using the `RestoreFootprintOp` operation.
+For persistent storage, when the TTL reaches zero, the entry is moved to the archival storage. It can then be restored when needed — usually [automatically](../../../learn/fundamentals/contract-development/storage/state-archival.mdx#contract-data-automatic-restoration), by including the entry in a transaction's restore list (which transaction simulation typically populates for you), or manually using the `RestoreFootprintOp` operation.
 
 Persistent storage is the default storage type use-case-wise. Instance and temporary storage are only useful for the specific use cases described in the respective sections. Stellar protocol also uses persistent storage to store the contracts and their Wasm executables, so that they always can be accessed or restored.
 

--- a/docs/build/smart-contracts/getting-started/hello-world.mdx
+++ b/docs/build/smart-contracts/getting-started/hello-world.mdx
@@ -145,7 +145,7 @@ The contract imports the types and macros that it needs from the `soroban-sdk` c
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 ```
 
-Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts. The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
+Many of the types available in typical Rust programs, such as `std::vec::Vec`, are not available, as there is no allocator and no heap memory in Soroban contracts by default (the SDK does provide an opt-in allocator through its `alloc` feature — see the [alloc example](../example-contracts/alloc.mdx)). The `soroban-sdk` provides a variety of types like `Vec`, `Map`, `Bytes`, `BytesN`, `Symbol`, that all utilize the Soroban environment's memory and native capabilities. Primitive values like `u128`, `i128`, `u64`, `i64`, `u32`, `i32`, and `bool` can also be used. Floats and floating point math are not supported.
 
 Contract inputs must not be references.
 

--- a/docs/data/apis/README.mdx
+++ b/docs/data/apis/README.mdx
@@ -29,7 +29,7 @@ RPC is the recommended API for accessing and interacting with Stellar network da
 
 :::warning
 
-Horizon is considered deprecated in favor of Stellar RPC. While it will continue to receive updates to maintain compatiblity with upcoming protocol releases, it won't receive significant new feature development.
+Horizon is nearing end-of-life and will eventually be deprecated in favor of Stellar RPC and [Portfolio APIs](../indexers/README.mdx#portfolio-apis). While it will continue to receive updates to maintain compatibility with upcoming protocol releases, it won't receive new feature development.
 
 :::
 

--- a/docs/learn/fundamentals/contract-development/storage/state-archival.mdx
+++ b/docs/learn/fundamentals/contract-development/storage/state-archival.mdx
@@ -93,7 +93,7 @@ If you would like to extend the contract code or contract instance separately, y
 
 Here are some important points to keep in mind when it comes to archived entries -
 
-1. A Soroban transaction that has a key to an archived Persistent entry in the footprint will fail immediately during the apply stage prior to contract execution. It does not matter if the contract itself was going to access the entry.
+1. A Soroban transaction that has a key to an archived Persistent entry in the footprint, but not in the transaction's restore list, will fail immediately during the apply stage prior to contract execution. It does not matter if the contract itself was going to access the entry. (If the entry _is_ included in the restore list, it's [automatically restored](#contract-data-automatic-restoration) before the host function runs instead.)
 2. Due to the previous point that archived entries can never make it into smart contract logic, there is no reason to write code in your contract to handle archived entries. The same applies to contract test cases - while you may want to write tests that check if your extension logic is correct, you don't need to write archival tests because the transaction will fail before getting to the contract. It is possible though to access an archived entry in a Soroban test case, in which case the host will panic. You can read more about this in [Test TTL Extensions](../../../../build/guides/archival/test-ttl-extension.mdx).
 3. Archived persistent entries can never be re-created. They must instead be restored. Once they are restored, then they can be modified or deleted.
 
@@ -161,7 +161,7 @@ liveUntilLedger that is large enough.
 
 ### RestoreFootprintOp
 
-`RestoreFootprintOp` is, for the most part, no longer needed starting in Protocol 23, as archived entries are automatically restored when they appear in a footprint during `InvokeHostFunctionOp`.
+`RestoreFootprintOp` is, for the most part, no longer needed starting in Protocol 23, as archived entries included in a transaction's [restore list](#contract-data-automatic-restoration) (usually populated during transaction simulation) are automatically restored when the `InvokeHostFunctionOp` executes.
 
 `RestoreFootprintOp` can still be used in rare use cases, such as:
 
@@ -201,7 +201,7 @@ We've done our best to build tooling around state archival in both the Stellar R
 
 :::info
 
-The manual operation (`RestoreFootprintOp`) is, for the most part, no longer needed starting in Protocol 23, as archived entries are automatically restored when they appear in a footprint during `InvokeHostFunctionOp`. `RestoreFootprintOp` can be used in rare use cases [described above](#restorefootprintop).
+The manual operation (`RestoreFootprintOp`) is, for the most part, no longer needed starting in Protocol 23, as archived entries included in a transaction's [restore list](#contract-data-automatic-restoration) (usually populated during transaction simulation) are automatically restored when the `InvokeHostFunctionOp` executes. `RestoreFootprintOp` can be used in rare use cases [described above](#restorefootprintop).
 
 :::
 

--- a/docs/learn/glossary.mdx
+++ b/docs/learn/glossary.mdx
@@ -299,7 +299,7 @@ The account that originates a transaction. This account also provides the fee an
 
 ### Starlight
 
-Stellar’s layer 2 protocol that allows for bi-directional payment channels.
+An experimental layer 2 payment channel protocol for Stellar that allowed for bi-directional payment channels. The project is no longer maintained, and its [repository](https://github.com/stellar-deprecated/starlight) has been archived since April 2024.
 
 ### Stellar
 

--- a/docs/tools/lab/api-explorer/horizon-endpoint.mdx
+++ b/docs/tools/lab/api-explorer/horizon-endpoint.mdx
@@ -2,7 +2,7 @@
 
 :::warning
 
-Horizon is considered deprecated. It will receive changes necessary to support protocol upgrades but won't be releasing new features. Consider switching to [Stellar RPC or another data product](../../../data/apis/README.mdx).
+Horizon is nearing end-of-life and will eventually be deprecated in favor of Stellar RPC and [Portfolio APIs](../../../data/indexers/README.mdx#portfolio-apis). While it will continue to receive updates to maintain compatibility with upcoming protocol releases, it won't receive new feature development. Consider switching to [Stellar RPC or another data product](../../../data/apis/README.mdx).
 
 :::
 

--- a/docs/tools/lab/saved/keypairs.mdx
+++ b/docs/tools/lab/saved/keypairs.mdx
@@ -17,7 +17,7 @@ You can only save keypairs on test networks—never on Mainnet—and you should 
 
 ![Lab: Saved Keypairs](/assets/lab/lab-account-saved.png)
 
-This page shows you saved keypairs for the selected network (only Testnet and Futurenet) in the browser's local storage. Saved keypairs are obfuscated, but _not_ encrypted — treat any secret key saved here as recoverable by anyone (or any script) with access to your browser (and note that keypairs saved before September 2025 may remain in plain text until they're re-saved). Every keypair has the following:
+This page shows your saved keypairs for the selected network (only Testnet and Futurenet) in the browser's local storage. Saved keypairs are obfuscated, but _not_ encrypted — treat any secret key saved here as recoverable by anyone (or any script) with access to your browser (and note that keypairs saved before September 2025 may remain in plain text until they're re-saved). Every keypair has the following:
 
 1. Name - makes it easy to find the keypair you're looking for. You can update the name anytime by clicking the edit button and saving the new name.
 2. Public key - the public account address. You can quickly copy it with a click of a button.

--- a/docs/tools/lab/saved/keypairs.mdx
+++ b/docs/tools/lab/saved/keypairs.mdx
@@ -17,7 +17,7 @@ You can only save keypairs on test networks—never on Mainnet—and you should 
 
 ![Lab: Saved Keypairs](/assets/lab/lab-account-saved.png)
 
-This page shows you saved keypairs for the selected network (only Testnet and Futurenet) in the browser's local storage. Every keypair has the following:
+This page shows you saved keypairs for the selected network (only Testnet and Futurenet) in the browser's local storage. Saved keypairs are obfuscated, but _not_ encrypted — treat any secret key saved here as recoverable by anyone (or any script) with access to your browser (and note that keypairs saved before September 2025 may remain in plain text until they're re-saved). Every keypair has the following:
 
 1. Name - makes it easy to find the keypair you're looking for. You can update the name anytime by clicking the edit button and saving the new name.
 2. Public key - the public account address. You can quickly copy it with a click of a button.


### PR DESCRIPTION
Batch quick-fix for five Raven-reported wording/consistency issues. All claims verified against CAP-0066, stellar-core behavior, live repos, and Lab source before editing.

## Changes

### State archival auto-restore nuance (#2568)

`state-archival.mdx:96` claimed an archived-entry footprint "will fail immediately" unqualified, contradicting the CAP-0066 auto-restoration section on the same page. But the two-edit fix suggested in the issue would have left the page self-contradictory in the *opposite* direction — several spots overstate auto-restore by omitting the restore-list requirement. Fixed all surfaces consistently:

- `state-archival.mdx` — the "fail immediately" claim now carries the restore-list qualifier; the two "automatically restored when they appear in a footprint" sentences now say entries must be in the transaction's restore list (usually populated by simulation)
- `create-restoration-footprint-js.mdx` — same overstated sentence, repeated verbatim, same fix
- `choosing-the-right-storage.mdx` — no longer presents `RestoreFootprintOp` as the only restoration path

### Starlight glossary entry (#2591)

The glossary described Starlight in the present tense as "Stellar's layer 2 protocol." It was an experimental project whose repo ([stellar-deprecated/starlight](https://github.com/stellar-deprecated/starlight)) has been archived since April 2024. Reworded with the repo link.

### Horizon lifecycle wording (#2592)

PR #2146 deliberately settled on "nearing end-of-life…" wording for Horizon (on `stellar-stack.mdx`), but three pages still carried the older, stronger phrasing. Copied the sanctioned wording to:

- `docs/data/apis/README.mdx` (also fixes a "compatiblity" typo)
- `docs/tools/lab/api-explorer/horizon-endpoint.mdx`
- `docs/README.mdx` — the docs landing page still said "Horizon (deprecated)" flat-out

### Allocator claim in Hello World (#2594)

`hello-world.mdx` claimed absolutely that there is "no allocator and no heap memory in Soroban contracts," contradicting our own [alloc example](https://developers.stellar.org/docs/build/smart-contracts/example-contracts/alloc) and the SDK's opt-in `alloc` feature. Softened to "by default" with a link. (The similar "no memory allocator" statement on `environment-concepts.mdx` describes the raw Wasm VM and is correct as-is, so it's untouched.)

### Lab saved keypairs storage disclosure (#2605)

The Lab UI already warns inline that saved keypairs are unencrypted; the docs page didn't mention the security property at all. Added a sentence: saved keypairs are obfuscated (XOR with a public constant), **not** encrypted — treat them as recoverable — and keypairs saved before September 2025 may remain literal plaintext until re-saved.

Closes #2568
Closes #2591
Closes #2592
Closes #2594
Closes #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)