### PR TITLE
🧹 Hide Markdown actions on directory pages

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -255,3 +255,8 @@ select[data-testid="example-pairing-select"] {
     }
   }
 }
+
+[class~="docs-doc-id-README"] .markdown-actions-container,
+[class*="docs-doc-id-"][class*="/README"] .markdown-actions-container {
+  display: none;
+}


### PR DESCRIPTION
This implements the first part of #2617, adding "Open Markdown" on directory folder pages. As you can see, it doesn't even display the subitems:

<img width="1410" height="804" alt="image" src="https://github.com/user-attachments/assets/10d50cbb-6ad0-4766-ae22-7e8e483b9043" />

And for [pages without a descriptive](https://developers.stellar.org/docs/learn/fundamentals/transactions.md) README, it's just blank.