### PR TITLE
Add stellar-build to the Building with AI page

### DIFF
--- a/docs/build/building-with-ai.mdx
+++ b/docs/build/building-with-ai.mdx
@@ -129,7 +129,13 @@ The official skills cover the core areas of Stellar development:
 
 The ecosystem also contributes skills for popular protocols and tools. Browse the full, up-to-date list at [skills.stellar.org](https://skills.stellar.org/). Community skills are maintained by their respective authors, so review each one to confirm it meets your security and maintenance requirements before using it.
 
+### stellar-build
+
 For a more hands-on approach, the community-maintained [stellar-build](https://github.com/kaankacar/stellar-build) installer adds 46 skills plus a set of AI personas to Claude Code or Codex with a single command, guiding you through the whole journey—not just building, but also ideation and validation, all the way to launch.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kaankacar/stellar-build/main/install.sh | bash
+```
 
 ### Installation
 

--- a/docs/build/building-with-ai.mdx
+++ b/docs/build/building-with-ai.mdx
@@ -129,6 +129,8 @@ The official skills cover the core areas of Stellar development:
 
 The ecosystem also contributes skills for popular protocols and tools. Browse the full, up-to-date list at [skills.stellar.org](https://skills.stellar.org/). Community skills are maintained by their respective authors, so review each one to confirm it meets your security and maintenance requirements before using it.
 
+For a more hands-on approach, the community-maintained [stellar-build](https://github.com/kaankacar/stellar-build) installer adds 46 skills plus a set of AI personas to Claude Code or Codex with a single command, guiding you through the whole journey—not just building, but also ideation and validation, all the way to launch.
+
 ### Installation
 
 Skills can be installed on any AI coding tool that supports the [Agent Skills](https://github.com/anthropics/agent-skills) standard. Each tool reads skills from its own directory:
@@ -187,4 +189,5 @@ Popular tools like ChatGPT, Claude, Gemini, and Cursor all support adding custom
 - [Raven (stellar-raven)](https://github.com/kalepail/stellar-raven) - Open source remote MCP server for Stellar docs plus live ecosystem data
 - [Stellar Skills](https://skills.stellar.org/) - Browse AI agent skills for Stellar development
 - [stellar-dev-skill repository](https://github.com/stellar/stellar-dev-skill) - Source and installation for the official skills
+- [stellar-build](https://github.com/kaankacar/stellar-build) - Community one-command installer with 46 skills and AI personas covering the full journey from ideation and validation to launch
 - [Stellar Developer Discord](https://discord.gg/stellardev) - Ask questions and get help from the community


### PR DESCRIPTION
Adds [stellar-build](https://github.com/kaankacar/stellar-build) to the Building with AI page — a one-command installer with 46 skills plus AI personas for a hands-on approach to the whole journey, from ideation and validation through launch. Added as its own subsection under Stellar Skills (with the install command) plus a bullet in Additional resources.

Closes #2628