### PR TITLE
📝 Clarify unused Horizon offer effects

### DIFF
--- a/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
+++ b/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
@@ -92,24 +92,22 @@ There are eight groups of effect types. Each effect type has its own set of attr
   - STATUS / OPERATION(S)
 - Offer Created
   - skip
-  - Unused; not emitted by Horizon.
+  - Unused; not emitted
 - Offer Removed
   - skip
-  - Unused; not emitted by Horizon.
+  - Unused; not emitted
 - Offer Updated
   - skip
-  - Unused; not emitted by Horizon.
+  - Unused; not emitted
 - Trade
   - skip
   - manage_buy_offer, manage_sell_offer, create_passive_sell_offer, path_payment
 
 </AttributeTable>
 
-:::note Offer lifecycle tracking
+:::note Offer Lifecycle
 
-Horizon does not emit the `offer_created`, `offer_removed`, or `offer_updated` effect types (30–32), which are [marked as unused in the current Horizon source](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L115-L122). To determine the outcome of a manage-offer operation, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
-
-Use [List All Offers](../../get-all-offers.api.mdx) to inspect currently open offers and [Retrieve an Offer's Trades](../../get-trades-by-offer-id.api.mdx) for retained trade history associated with an offer.
+Although offer identifiers were [historically defined](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L114-L122), they don't have ingestion code. To view manage-offer effects, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
 
 :::
 

--- a/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
+++ b/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
@@ -107,7 +107,7 @@ There are eight groups of effect types. Each effect type has its own set of attr
 
 :::note Offer Lifecycle
 
-Although offer identifiers were [historically defined](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L114-L122), they don't have ingestion code. To view manage-offer effects, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
+Although offer identifiers were [historically defined](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L114-L122), [manage_offer](../../../../../../learn/fundamentals/transactions/list-of-operations.mdx#manage-sell-offer)'s effects don't have ingestion code. To view them, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
 
 :::
 

--- a/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
+++ b/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
@@ -105,7 +105,7 @@ There are eight groups of effect types. Each effect type has its own set of attr
 
 </AttributeTable>
 
-:::note Offer Lifecycle
+:::note[Offer Lifecycle]
 
 Although offer identifiers were [historically defined](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L114-L122), [manage_offer](../../../../../../learn/fundamentals/transactions/list-of-operations.mdx#manage-sell-offer)'s effects don't have ingestion code. To view them, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
 

--- a/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
+++ b/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
@@ -109,6 +109,8 @@ There are eight groups of effect types. Each effect type has its own set of attr
 
 Although offer identifiers were [historically defined](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L114-L122), [manage_offer](../../../../../../learn/fundamentals/transactions/list-of-operations.mdx#manage-sell-offer)'s effects don't have ingestion code. To view them, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
 
+Use [List All Offers](../../get-all-offers.api.mdx) to inspect currently open offers and [Retrieve an Offer's Trades](../../get-trades-by-offer-id.api.mdx) for retained trade history associated with an offer.
+
 :::
 
 ### Data Effects

--- a/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
+++ b/docs/data/apis/horizon/api-reference/resources/effects/types.mdx
@@ -89,21 +89,29 @@ There are eight groups of effect types. Each effect type has its own set of attr
 
 - TYPE
   - skip
-  - OPERATION(S)
+  - STATUS / OPERATION(S)
 - Offer Created
   - skip
-  - manage_buy_offer, manage_sell_offer, create_passive_sell_offer
+  - Unused; not emitted by Horizon.
 - Offer Removed
   - skip
-  - manage_buy_offer, manage_sell_offer, create_passive_sell_offer, path_payment
+  - Unused; not emitted by Horizon.
 - Offer Updated
   - skip
-  - manage_buy_offer, manage_sell_offer, create_passive_sell_offer, path_payment
+  - Unused; not emitted by Horizon.
 - Trade
   - skip
   - manage_buy_offer, manage_sell_offer, create_passive_sell_offer, path_payment
 
 </AttributeTable>
+
+:::note Offer lifecycle tracking
+
+Horizon does not emit the `offer_created`, `offer_removed`, or `offer_updated` effect types (30–32), which are [marked as unused in the current Horizon source](https://github.com/stellar/stellar-horizon/blob/main/internal/db2/history/main.go#L115-L122). To determine the outcome of a manage-offer operation, decode the transaction's [`result_xdr`](../../structure/xdr.mdx), which contains the `ManageOfferSuccessResult`.
+
+Use [List All Offers](../../get-all-offers.api.mdx) to inspect currently open offers and [Retrieve an Offer's Trades](../../get-trades-by-offer-id.api.mdx) for retained trade history associated with an offer.
+
+:::
 
 ### Data Effects
 


### PR DESCRIPTION
Closes #2604. I've been extracting offer meta from tx_result for four years, and it is an eye-wrenching process. But it does work if you have the full XDR history.