### PR TITLE
[chore] fix anchors page pagination

### DIFF
--- a/docs/platforms/anchor-platform/README.mdx
+++ b/docs/platforms/anchor-platform/README.mdx
@@ -3,6 +3,7 @@ title: "The Anchor Platform: Build and Manage On/Off-Ramps on the Stellar Networ
 sidebar_position: 10
 sidebar_label: Product Overview
 description: "Learn how the Anchor Platform (AP) simplifies the process of building and managing a Stellar on and off-ramp. Learn about integrating with the AP or get API information."
+pagination_next: platforms/anchor-platform/admin-guide/README
 ---
 
 # Anchor Platform

--- a/docs/platforms/anchor-platform/admin-guide/_category_.json
+++ b/docs/platforms/anchor-platform/admin-guide/_category_.json
@@ -1,5 +1,4 @@
 {
-  "label": "Admin Guide",
   "collapsed": false
 }
 


### PR DESCRIPTION
fixes the strange pagination on the "frontpage" of the anchor platform section. applies `pagination_next` to the file's frontmatter, and points it at the admin guide section.

Closes #2181 