### PR TITLE
Rename token approve arg to live_until_ledger

### DIFF
--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -128,7 +128,7 @@ The [`token` module] of the Rust SDK contains two traits, and corresponding clie
 pub trait StellarAssetInterface {
     // All this is available in any SEP-41-compliant contract
     fn allowance(env: Env, from: Address, spender: Address) -> i128;
-    fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32);
+    fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
     fn balance(env: Env, id: Address) -> i128;
     fn transfer(env: Env, from: Address, to: MuxedAddress, amount: i128);
     fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128);

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -67,7 +67,7 @@ pub trait TokenInterface {
     /// # Events
     ///
     /// Emits an event with topics `["approve", from: Address,
-    /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
+    /// spender: Address], data = [amount: i128, live_until_ledger: u32]`
     fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
@@ -194,7 +194,7 @@ The `approve` function overwrites the previous value with `amount`, so it is pos
 
 :::note
 
-As of `soroban-sdk` v27.0.1, the `approve` function's allowance-expiration argument is named `live_until_ledger` (previously `expiration_ledger`), aligning the SDK with the SEP-41 spec. The behavior is unchanged, and the `Approve` event's data field is still named `expiration_ledger` for on-chain compatibility.
+As of `soroban-sdk` v27.0.1, the `approve` function's allowance-expiration argument is named `live_until_ledger` (previously `expiration_ledger`), aligning the SDK with the SEP-41 spec. The behavior is unchanged.
 
 :::
 

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -192,12 +192,6 @@ The `approve` function overwrites the previous value with `amount`, so it is pos
 
 :::
 
-:::note
-
-As of `soroban-sdk` v27.0.1, the `approve` function's allowance-expiration argument is named `live_until_ledger` (previously `expiration_ledger`), aligning the SDK with the SEP-41 spec. The behavior is unchanged.
-
-:::
-
 ### Metadata
 
 Another requirement for complying with the token interface is to write the standard metadata (`decimal`, `name`, and `symbol`) for the token in a specific format. This format allows users to directly read constant data from the ledger instead of invoking a Wasm function. The [token example](https://github.com/stellar/soroban-examples/blob/main/token/src/metadata.rs) demonstrates how to use the Rust [soroban-token-sdk](https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-token-sdk/src/lib.rs) to write the metadata, and we strongly encourage token implementations to follow this approach.

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -59,16 +59,16 @@ pub trait TokenInterface {
     /// * `spender` - The address being authorized to spend the tokens held by
     ///   `from`.
     /// * `amount` - The tokens to be made available to `spender`.
-    /// * `expiration_ledger` - The ledger number where this allowance expires. Cannot
+    /// * `live_until_ledger` - The ledger number where this allowance expires. Cannot
     ///    be less than the current ledger number unless the amount is being set to 0.
-    ///    An expired entry (where expiration_ledger < the current ledger number)
+    ///    An expired entry (where live_until_ledger < the current ledger number)
     ///    should be treated as a 0 amount allowance.
     ///
     /// # Events
     ///
     /// Emits an event with topics `["approve", from: Address,
     /// spender: Address], data = [amount: i128, expiration_ledger: u32]`
-    fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32);
+    fn approve(env: Env, from: Address, spender: Address, amount: i128, live_until_ledger: u32);
 
     /// Returns the balance of `id`.
     ///
@@ -189,6 +189,12 @@ pub trait TokenInterface {
 :::caution[CAUTION WHEN MODIFYING ALLOWANCES]
 
 The `approve` function overwrites the previous value with `amount`, so it is possible for the previous allowance to be spent in an earlier transaction before `amount` is written in a later transaction. The result of this is that `spender` can spend more than intended. This issue can be avoided by first setting the allowance to 0, verifying that the spender didn't spend any portion of the previous allowance, and then setting the allowance to the new desired amount. You can read more about this issue here - https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729.
+
+:::
+
+:::note
+
+As of `soroban-sdk` v27.0.1, the `approve` function's allowance-expiration argument is named `live_until_ledger` (previously `expiration_ledger`), aligning the SDK with the SEP-41 spec. The behavior is unchanged, and the `Approve` event's data field is still named `expiration_ledger` for on-chain compatibility.
 
 :::
 


### PR DESCRIPTION
### What

Rename the `approve` function's allowance-expiration argument from `expiration_ledger` to `live_until_ledger` in the `TokenInterface` and `StellarAssetInterface` trait listings.

### Why

`rs-soroban-sdk` PR [#1932](https://github.com/stellar/rs-soroban-sdk/pull/1932), shipping in `soroban-sdk` v27.0.1, renamed this argument in both traits to align with the SEP-41 spec, since the argument name is part of the generated contract spec XDR. These docs mirrored the old SDK source verbatim, so they were left showing the outdated argument name.