### PR TITLE
Document sponsored account creation and merge sponsorship blockers

### DIFF
--- a/docs/build/guides/transactions/create-account.mdx
+++ b/docs/build/guides/transactions/create-account.mdx
@@ -18,7 +18,9 @@ Before creating an account, you need to generate your own keypair; we'll learn h
 
 ## Create an Account
 
-A valid keypair alone does not make an account. To prevent unused entries from bloating the ledger, Stellar requires every account to hold a [minimum balance](../../../learn/fundamentals/lumens.mdx#minimum-balance) of 1 XLM before it actually exists.
+A valid keypair alone does not make an account. To prevent unused entries from bloating the ledger, Stellar requires every account to hold a [minimum balance](../../../learn/fundamentals/lumens.mdx#minimum-balance) — currently two base reserves, or 1 XLM — before it actually exists. This is the ordinary, self-funded path shown throughout this tutorial.
+
+Alternatively, an account can be created with a `startingBalance` of `0` when another account sponsors its reserves (CAP-0033 sponsored reserves): the sponsor carries the two base reserves on the new account's behalf, so the account exists without holding the minimum balance itself. See the [Sponsored Reserves guide](sponsored-reserves.mdx) for how to set this up.
 
 On the test network you can ask Friendbot — a friendly funding service — to create and fund the account for you. In the SDK examples, below, you'll see that we "discover" the Friendbot endpoint via the RPC's `getNetwork` call, then issue a funding request.
 

--- a/docs/build/guides/transactions/create-account.mdx
+++ b/docs/build/guides/transactions/create-account.mdx
@@ -18,7 +18,7 @@ Before creating an account, you need to generate your own keypair; we'll learn h
 
 ## Create an Account
 
-A valid keypair alone does not make an account. To prevent unused entries from bloating the ledger, Stellar requires every account to hold a [minimum balance](../../../learn/fundamentals/lumens.mdx#minimum-balance) — currently two base reserves, or 1 XLM — before it actually exists. This is the ordinary, self-funded path shown throughout this tutorial.
+A valid keypair alone does not make an account. To prevent unused entries from bloating the ledger, Stellar requires every account to hold a [minimum balance](../../../learn/fundamentals/lumens.mdx#minimum-balance) of two base reserves before it actually exists (at the current base reserve of 0.5 XLM that works out to 1 XLM, but validators can change the base reserve — see the linked section for the current value). This is the ordinary, self-funded path shown throughout this tutorial.
 
 Alternatively, an account can be created with a `startingBalance` of `0` when another account sponsors its reserves (CAP-0033 sponsored reserves): the sponsor carries the two base reserves on the new account's behalf, so the account exists without holding the minimum balance itself. See the [Sponsored Reserves guide](sponsored-reserves.mdx) for how to set this up.
 

--- a/docs/build/guides/transactions/create-account.mdx
+++ b/docs/build/guides/transactions/create-account.mdx
@@ -20,7 +20,7 @@ Before creating an account, you need to generate your own keypair; we'll learn h
 
 A valid keypair alone does not make an account. To prevent unused entries from bloating the ledger, Stellar requires every account to hold a [minimum balance](../../../learn/fundamentals/lumens.mdx#minimum-balance) of two base reserves before it actually exists (at the current base reserve of 0.5 XLM that works out to 1 XLM, but validators can change the base reserve — see the linked section for the current value). This is the ordinary, self-funded path shown throughout this tutorial.
 
-Alternatively, an account can be created with a `startingBalance` of `0` when another account sponsors its reserves (CAP-0033 sponsored reserves): the sponsor carries the two base reserves on the new account's behalf, so the account exists without holding the minimum balance itself. See the [Sponsored Reserves guide](sponsored-reserves.mdx) for how to set this up.
+Alternatively, an account can be created with a `startingBalance` of `0` when another account sponsors its reserves ([CAP-33](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0033.md) sponsored reserves): the sponsor carries the two base reserves on the new account's behalf, so the account exists without holding the minimum balance itself. See the [Sponsored Reserves guide](sponsored-reserves.mdx) for how to set this up.
 
 On the test network you can ask Friendbot — a friendly funding service — to create and fund the account for you. In the SDK examples, below, you'll see that we "discover" the Friendbot endpoint via the RPC's `getNetwork` call, then issue a funding request.
 

--- a/docs/build/guides/transactions/sponsored-reserves.mdx
+++ b/docs/build/guides/transactions/sponsored-reserves.mdx
@@ -65,6 +65,8 @@ When account A is sponsoring future reserves for account B, any reserve requirem
 
 When a sponsored entry or subentry is removed, `numSponsoring` is decreased on the sponsoring account and `numSponsored` is decreased on the sponsored account.
 
+Because sponsorship can cover an account's own base reserves as well as its subentries, a brand-new account can be created with a `startingBalance` of `0`: wrap the `CreateAccount` operation in a `BeginSponsoringFutureReserves`/`EndSponsoringFutureReserves` sandwich (as in the examples below) and the sponsor carries the two base reserves so the account never has to hold the minimum balance itself.
+
 To learn more about minimum balance requirements, see our section on [Lumens](../../../learn/fundamentals/lumens.mdx#minimum-balance).
 
 ## Effect on claimable balances

--- a/docs/data/apis/horizon/api-reference/errors/result-codes/operation-specific/account-merge.mdx
+++ b/docs/data/apis/horizon/api-reference/errors/result-codes/operation-specific/account-merge.mdx
@@ -23,12 +23,15 @@ Learn more about the [`Account Merge` operation](../../../../../../../learn/fund
   - The source account has AUTH_IMMUTABLE flag set.
 - op_has_sub_entries
   - ACCOUNT_MERGE_HAS_SUB_ENTRIES
-  - The source account has trustlines and/or offers.
+  - The source account still has non-signer subentries (trustlines, offers, or data entries). Signers are not a blocker — they are removed automatically as part of the merge.
 - op_seq_num_too_far
   - ACCOUNT_MERGE_SEQNUM_TOO_FAR
   - Source account sequence number is too high.
 - op_dest_full
   - ACCOUNT_MERGE_DEST_FULL
   - The destination account cannot receive the balance of the source account and still satisfy its lumen buying liabilities.
+- op_is_sponsor
+  - ACCOUNT_MERGE_IS_SPONSOR
+  - The source account is sponsoring reserves for other accounts (it is responsible for future reserves). Those sponsorships must be revoked before the account can be merged. Note that merely being sponsored by another account is not a blocker.
 
 </AttributeTable>

--- a/docs/data/apis/horizon/api-reference/errors/result-codes/operation-specific/account-merge.mdx
+++ b/docs/data/apis/horizon/api-reference/errors/result-codes/operation-specific/account-merge.mdx
@@ -32,6 +32,6 @@ Learn more about the [`Account Merge` operation](../../../../../../../learn/fund
   - The destination account cannot receive the balance of the source account and still satisfy its lumen buying liabilities.
 - op_is_sponsor
   - ACCOUNT_MERGE_IS_SPONSOR
-  - The source account is sponsoring reserves for other accounts (it is responsible for future reserves). Those sponsorships must be revoked before the account can be merged. Note that merely being sponsored by another account is not a blocker.
+  - The source account cannot be merged because it is sponsoring reserves. This covers two cases: it is already sponsoring reserves for other accounts (`numSponsoring > 0`), which must be revoked first; or it has an open is-sponsoring-future-reserves relationship earlier in the same transaction, which must be ended with `EndSponsoringFutureReserves` (there may be no created reserve to revoke in this case). Merely being sponsored by another account is not a blocker.
 
 </AttributeTable>

--- a/docs/learn/fundamentals/lumens.mdx
+++ b/docs/learn/fundamentals/lumens.mdx
@@ -35,7 +35,7 @@ For example, an account with one trustline, two offers, and a claimable balance 
 
 2 base reserves (1 XLM) + 3 subentries/base reserves (1.5 XLM) + 1 ledger entry/base reserve (1 XLM) = 3.5 XLM
 
-When you close a subentry, the associated base reserve will be added to your available balance. An account must always pay its own minimum balance unless a subentry is being sponsored by another account. For information about this, see our [Sponsored Reserves guide](../../build/guides/transactions/sponsored-reserves.mdx).
+When you close a subentry, the associated base reserve will be added to your available balance. An account must always pay its own minimum balance unless it is being sponsored by another account. Sponsorship can cover both an account's subentries and its own two base reserves — so a sponsored account can even be created with a starting balance of `0`, with the sponsor carrying its reserves. For information about this, see our [Sponsored Reserves guide](../../build/guides/transactions/sponsored-reserves.mdx).
 
 ## Rent
 

--- a/docs/learn/fundamentals/transactions/list-of-operations.mdx
+++ b/docs/learn/fundamentals/transactions/list-of-operations.mdx
@@ -347,7 +347,9 @@ This operation is deprecated as of Protocol 17- prefer [_SetTrustlineFlags_](#se
 
 Transfers the XLM balance of an account to another account and removes the source account from the ledger
 
-A source account can only be merged once it holds no non-signer subentries: any trustlines, offers, or data entries must be removed first. Signers are _not_ a blocker — they (including sponsored signers) are removed automatically during the merge. Separately, an account that is _sponsoring_ reserves for other accounts (i.e. responsible for future reserves) cannot be merged until those sponsorships are revoked; merely being sponsored by another account does not block a merge.
+A source account can only be merged once it holds no non-signer subentries: any trustlines, offers, or data entries must be removed first. Signers are _not_ a blocker — they (including sponsored signers) are removed automatically during the merge.
+
+Sponsorship also blocks a merge (`ACCOUNT_MERGE_IS_SPONSOR`), and this covers two distinct conditions with different remedies: (1) the account is already _sponsoring_ reserves for other accounts (`numSponsoring > 0`) — revoke those sponsorships first; or (2) the account has an open is-sponsoring-future-reserves relationship earlier in the same transaction — that relationship must be ended (with `EndSponsoringFutureReserves`) before the merge, and in this case there may be no created reserve to revoke. In either case, merely _being_ sponsored by another account does not block a merge.
 
 **SDKs**: [JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.accountMerge) | [Java](https://github.com/lightsail-network/java-stellar-sdk/blob/master/src/main/java/org/stellar/sdk/operations/AccountMergeOperation.java) | [Go](https://godoc.org/github.com/stellar/go-stellar-sdk/txnbuild#AccountMerge)  
 **Threshold**: High  
@@ -368,7 +370,7 @@ A source account can only be merged once it holds no non-signer subentries: any 
 | `ACCOUNT_MERGE_HAS_SUB_ENTRIES` | -4 | The source account still has non-signer subentries (trustlines, offers, or data entries). Signers do not block the merge and are removed automatically. |
 | `ACCOUNT_MERGE_SEQNUM_TOO_FAR` | -5 | Source's account sequence number is too high. It must be less than `(ledgerSeq << 32) = (ledgerSeq * 0x100000000)`. |
 | `ACCOUNT_MERGE_DEST_FULL` | -6 | The `destination` account cannot receive the balance of the source account and still satisfy its lumen buying liabilities. |
-| `ACCOUNT_MERGE_IS_SPONSOR` | -7 | The source account is sponsoring reserves for other accounts and cannot be merged until those sponsorships are revoked. |
+| `ACCOUNT_MERGE_IS_SPONSOR` | -7 | The source account cannot be merged because it is sponsoring reserves. Either it is already sponsoring reserves for other accounts (`numSponsoring > 0`), which must be revoked first, or it has an open is-sponsoring-future-reserves relationship in the same transaction, which must be ended with `EndSponsoringFutureReserves`. |
 
 ## Manage data
 

--- a/docs/learn/fundamentals/transactions/list-of-operations.mdx
+++ b/docs/learn/fundamentals/transactions/list-of-operations.mdx
@@ -347,6 +347,8 @@ This operation is deprecated as of Protocol 17- prefer [_SetTrustlineFlags_](#se
 
 Transfers the XLM balance of an account to another account and removes the source account from the ledger
 
+A source account can only be merged once it holds no non-signer subentries: any trustlines, offers, or data entries must be removed first. Signers are _not_ a blocker — they (including sponsored signers) are removed automatically during the merge. Separately, an account that is _sponsoring_ reserves for other accounts (i.e. responsible for future reserves) cannot be merged until those sponsorships are revoked; merely being sponsored by another account does not block a merge.
+
 **SDKs**: [JavaScript](http://stellar.github.io/js-stellar-sdk/Operation.html#.accountMerge) | [Java](https://github.com/lightsail-network/java-stellar-sdk/blob/master/src/main/java/org/stellar/sdk/operations/AccountMergeOperation.java) | [Go](https://godoc.org/github.com/stellar/go-stellar-sdk/txnbuild#AccountMerge)  
 **Threshold**: High  
 **Result**: `AccountMergeResult`  
@@ -363,10 +365,10 @@ Transfers the XLM balance of an account to another account and removes the sourc
 | `ACCOUNT_MERGE_MALFORMED` | -1 | The operation is malformed because the source account cannot merge with itself. The `destination` must be a different account. |
 | `ACCOUNT_MERGE_NO_ACCOUNT` | -2 | The `destination` account does not exist. |
 | `ACCOUNT_MERGE_IMMUTABLE_SET` | -3 | The source account has `AUTH_IMMUTABLE` flag set. |
-| `ACCOUNT_MERGE_HAS_SUB_ENTRIES` | -4 | The source account has trustlines/offers. |
+| `ACCOUNT_MERGE_HAS_SUB_ENTRIES` | -4 | The source account still has non-signer subentries (trustlines, offers, or data entries). Signers do not block the merge and are removed automatically. |
 | `ACCOUNT_MERGE_SEQNUM_TOO_FAR` | -5 | Source's account sequence number is too high. It must be less than `(ledgerSeq << 32) = (ledgerSeq * 0x100000000)`. |
 | `ACCOUNT_MERGE_DEST_FULL` | -6 | The `destination` account cannot receive the balance of the source account and still satisfy its lumen buying liabilities. |
-| `ACCOUNT_MERGE_IS_SPONSOR` | -7 | The source account is a sponsor. |
+| `ACCOUNT_MERGE_IS_SPONSOR` | -7 | The source account is sponsoring reserves for other accounts and cannot be merged until those sponsorships are revoked. |
 
 ## Manage data
 


### PR DESCRIPTION
Fixes [#2590](https://github.com/stellar/stellar-docs/issues/2590). The account-lifecycle docs presented the ordinary unsponsored path as if it were universal and under-documented current account-merge behavior. All claims verified against CAP-0033 and stellar-core `CreateAccountOpFrame` / `MergeOpFrame`.

## Changes

### Sponsored account creation (CAP-0033)

- **`create-account.mdx`** — the 1-XLM minimum is now framed as the ordinary, self-funded path, with a note that a sponsored account can be created with `startingBalance = 0` (the sponsor carries the two base reserves).
- **`lumens.mdx`** — the minimum-balance section now notes sponsorship can cover an account's own base reserves, not just its subentries.
- **`sponsored-reserves.mdx`** — added a note on the `BeginSponsoringFutureReserves` → `CreateAccount` → `EndSponsoringFutureReserves` pattern for 0-balance creation.

### Account merge blockers

- **Horizon `account-merge.mdx` result-codes page** — was missing `ACCOUNT_MERGE_IS_SPONSOR` (-7) entirely; added it. Also clarified `ACCOUNT_MERGE_HAS_SUB_ENTRIES`: the blockers are non-signer subentries (trustlines, offers, data entries), while signers — including sponsored signers — are removed automatically during the merge.
- **`list-of-operations.mdx`** — added the same clarification to the Account Merge description, and sharpened the `HAS_SUB_ENTRIES` / `IS_SPONSOR` row descriptions. (The full result-code table here already listed -7; the Horizon page did not.)

The key correction: the blocking relationship is asymmetric — an account that is *sponsoring* reserves for others cannot merge, but merely *being* sponsored is not a blocker, and signer-only accounts merge fine.

Closes #2590

🤖 Generated with [Claude Code](https://claude.com/claude-code)