### PR TITLE
Pin Wallets Kit to v1 in the example app tutorial (stopgap)

### DIFF
--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -202,9 +202,9 @@ npm install --save-dev @esbuild-plugins/node-globals-polyfill @esbuild-plugins/n
     path @rollup/plugin-inject buffer svelte-local-storage-store uuid
 ```
 
-:::note
+:::info[Stellar Wallets Kit v1]
 
-The Stellar Wallets Kit dependency is pinned to `@^1` on purpose. This tutorial and its companion [`stellar/basic-payment-app`](https://github.com/stellar/basic-payment-app) are written against the Kit v1 API (`new StellarWalletsKit(...)`). Installing the package unpinned now resolves to v2.x, whose initialization API (`StellarWalletsKit.init(...)`) is incompatible, so the tutorial code would break. The pin keeps the tutorial working until it and BasicPay are migrated to v2 together.
+The Stellar Wallets Kit dependency is pinned to `@^1` on purpose. This tutorial and its companion [`stellar/basic-payment-app`](https://github.com/stellar/basic-payment-app) are written against the Kit v1 API (`new StellarWalletsKit(...)`). Installing the package unpinned now resolves to v2.x, whose initialization API is incompatible. This pin keeps the tutorial working until it and BasicPay are migrated to v2 together.
 
 :::
 

--- a/docs/build/apps/example-application-tutorial/overview.mdx
+++ b/docs/build/apps/example-application-tutorial/overview.mdx
@@ -196,11 +196,17 @@ To work with the Stellar network, datastructures, and locally stored keypairs, w
 # Stellar SDKs
 npm install @stellar/stellar-sdk @stellar/typescript-wallet-sdk-km
 # Wallet integration packages (required for vite.config.js SSR bundling)
-npm install @creit.tech/stellar-wallets-kit @stellar/freighter-api @lobstrco/signer-extension-api
+npm install @creit.tech/stellar-wallets-kit@^1 @stellar/freighter-api @lobstrco/signer-extension-api
 # We will need some polyfills to make things available client-side
 npm install --save-dev @esbuild-plugins/node-globals-polyfill @esbuild-plugins/node-modules-polyfill \
     path @rollup/plugin-inject buffer svelte-local-storage-store uuid
 ```
+
+:::note
+
+The Stellar Wallets Kit dependency is pinned to `@^1` on purpose. This tutorial and its companion [`stellar/basic-payment-app`](https://github.com/stellar/basic-payment-app) are written against the Kit v1 API (`new StellarWalletsKit(...)`). Installing the package unpinned now resolves to v2.x, whose initialization API (`StellarWalletsKit.init(...)`) is incompatible, so the tutorial code would break. The pin keeps the tutorial working until it and BasicPay are migrated to v2 together.
+
+:::
 
 We will use a `window.js` file to inject Buffer into our client-side code, since that's required by some parts of the `@stellar/stellar-sdk`.
 


### PR DESCRIPTION
Docs-side stopgap for [#2609](https://github.com/stellar/stellar-docs/issues/2609). The example-application tutorial installs `@creit.tech/stellar-wallets-kit` **unpinned**, which now resolves to v2.5.0. But the tutorial and its companion app [`stellar/basic-payment-app`](https://github.com/stellar/basic-payment-app) are written against the Kit **v1** API (`new StellarWalletsKit(...)` / `allowAllModules()`). The v2 init API (`StellarWalletsKit.init(...)` / `defaultModules()`) is incompatible, so a reader following the tutorial today gets a broken mismatch.

## Change

- Pinned the install to `@creit.tech/stellar-wallets-kit@^1` in `overview.mdx` and added a `:::note` explaining why the pin exists and that it's temporary.

## Not in this PR (tracked on #2609)

The durable fix is to migrate **both** the tutorial and BasicPay to the Kit v2 API in lockstep — that's cross-repo work (touches `stellar/basic-payment-app`) and out of scope for a docs stopgap. This PR just stops the tutorial from breaking in the meantime.

> Note: the issue's claim that "the npm scope is the legacy v1" is inaccurate — v2.5.0 also publishes to the `@creit.tech` npm scope; that's precisely why an unpinned install breaks. The obsolete Spanish `dapp-frontend` section referenced in the issue was already removed with the i18n deletion (#2410).

Refs #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)