### PR TITLE
Document constructor auth for register/register_at

### DIFF
--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -61,10 +61,10 @@ For the full example the above snippet is extracted from, see the [auth example 
 
 ## Authorization in constructors
 
-If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`), both `env.register(...)` and `env.register_at(...)` switch the environment to recording-auth mode, inherited from the current auth manager, for the duration of the constructor invocation, then restore the previous auth manager afterward. This means constructor auth checks succeed for Wasm contracts registered with either function, without requiring `mock_all_auths()` to be called first.
+If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`), both `env.register(...)` and `env.register_at(...)` switch the environment to recording-auth mode, inherited from the current auth manager, for the duration of the constructor invocation, then restore the previous auth manager afterward. This means constructor auth checks succeed for contracts registered with either function, without requiring `mock_all_auths()` to be called first.
 
 :::caution
 
-This only applies to contracts registered from Wasm bytes. If a contract is registered as a native/mock Rust value for testing (not from Wasm), its constructor invocation does not currently switch to recording auth. In that case, a `require_auth()` call in the constructor still requires `mock_all_auths()` (or explicit auth mocking) to be set up beforehand.
+This behaviour was not consistent in some versions of the `soroban-sdk` due to a issue, but is consistent as of v27.0.2.
 
 :::

--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -67,6 +67,6 @@ To have auth in a constructor execute as it will in production the contract must
 
 :::caution
 
-This behaviour was not consistent in some versions of the `soroban-sdk` due to a issue, but is consistent as of v27.0.2.
+This behaviour was not consistent in some versions of the `soroban-sdk` due to an issue, but is consistent as of v27.0.2.
 
 :::

--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -61,7 +61,7 @@ For the full example the above snippet is extracted from, see the [auth example 
 
 ## Authorization in constructors
 
-If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`), both `env.register(...)` and `env.register_at(...)` switch the environment to recording-auth mode, inherited from the current auth manager, for the duration of the constructor invocation, then restore the previous auth manager afterward. This means constructor auth checks succeed for contracts registered with either function, without requiring `mock_all_auths()` to be called first.
+If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`), both `env.register(...)` and `env.register_at(...)` switch the environment to recording-auth mode for the duration of the constructor invocation, inheriting the mode from the current auth manager. Once the constructor returns, the previous auth manager is restored. This means constructor auth checks succeed for contracts registered with either function, without requiring `mock_all_auths()` to be called first.
 
 To have auth in a constructor execute as it will in production the contract must be deployed in the test using the standard deployment functions after being built to Wasm.
 

--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -65,6 +65,6 @@ If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`
 
 :::caution
 
-This only applies to contracts registered from Wasm bytes. If a contract is registered as a native/mock Rust value for testing (not from Wasm), its constructor invocation does not switch to recording auth. In that case, a `require_auth()` call in the constructor still requires `mock_all_auths()` (or explicit auth mocking) to be set up beforehand.
+This only applies to contracts registered from Wasm bytes. If a contract is registered as a native/mock Rust value for testing (not from Wasm), its constructor invocation does not currently switch to recording auth. In that case, a `require_auth()` call in the constructor still requires `mock_all_auths()` (or explicit auth mocking) to be set up beforehand.
 
 :::

--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -63,6 +63,8 @@ For the full example the above snippet is extracted from, see the [auth example 
 
 If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`), both `env.register(...)` and `env.register_at(...)` switch the environment to recording-auth mode, inherited from the current auth manager, for the duration of the constructor invocation, then restore the previous auth manager afterward. This means constructor auth checks succeed for contracts registered with either function, without requiring `mock_all_auths()` to be called first.
 
+To have auth in a constructor execute as it will in production the contract must be deployed in the test using the standard deployment functions after being built to Wasm.
+
 :::caution
 
 This behaviour was not consistent in some versions of the `soroban-sdk` due to a issue, but is consistent as of v27.0.2.

--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -58,3 +58,13 @@ fn test() {
 For the full example the above snippet is extracted from, see the [auth example contract](../../smart-contracts/example-contracts/auth.mdx).
 
 :::
+
+## Authorization in constructors
+
+If a contract's constructor calls `require_auth()` (or `require_auth_for_args()`), both `env.register(...)` and `env.register_at(...)` switch the environment to recording-auth mode, inherited from the current auth manager, for the duration of the constructor invocation, then restore the previous auth manager afterward. This means constructor auth checks succeed for Wasm contracts registered with either function, without requiring `mock_all_auths()` to be called first.
+
+:::caution
+
+This only applies to contracts registered from Wasm bytes. If a contract is registered as a native/mock Rust value for testing (not from Wasm), its constructor invocation does not switch to recording auth. In that case, a `require_auth()` call in the constructor still requires `mock_all_auths()` (or explicit auth mocking) to be set up beforehand.
+
+:::


### PR DESCRIPTION
### What

Add a new "Authorization in constructors" section to the Test Authorization guide explaining that both `env.register(...)` and `env.register_at(...)` switch the test environment to recording-auth mode for the duration of a Wasm contract's constructor invocation, so a constructor calling `require_auth()` succeeds without `mock_all_auths()`, and note the current caveat that this does not apply to native/mock contracts registered for testing.

### Why

As a result of the following issue and related changes its good to discuss this here:
- https://github.com/stellar/rs-soroban-sdk/issues/1738