### PR TITLE
Document constructor auth recording in tests

### DIFF
--- a/docs/build/guides/testing/test-contract-auth.mdx
+++ b/docs/build/guides/testing/test-contract-auth.mdx
@@ -58,3 +58,32 @@ fn test() {
 For the full example the above snippet is extracted from, see the [auth example contract](../../smart-contracts/example-contracts/auth.mdx).
 
 :::
+
+## Constructor Authorization
+
+`register` and `register_at` run a contract's constructor under a recording auth manager, then restore whatever auth manager was active beforehand. This means a `require_auth()` call made inside a constructor is automatically authorized, so registering a contract whose constructor requires auth doesn't need `mock_all_auths()` or `mock_auths()`.
+
+```rust
+#[test]
+fn test() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+
+    // No mock_all_auths() or mock_auths() call is needed here, even though
+    // OwnedContract's constructor calls `owner.require_auth()`.
+    let contract_id = env.register(OwnedContract, (&owner,));
+    let client = OwnedContractClient::new(&env, &contract_id);
+    // ...
+}
+```
+
+:::info
+
+This is consistent across `register` and `register_at`, and across Wasm and native (Rust `#[contract]` struct, non-Wasm) contracts. Wasm constructors registered with `register` already worked this way; [rs-soroban-sdk PR #1933] extended it to `register_at`, and [rs-soroban-sdk PR #1943] fixed the remaining gap for native contracts, closing [rs-soroban-sdk#1738]. The native contract fix hadn't shipped in a release as of this writing, so it's available starting with the [Soroban Rust SDK] release after v27.0.1.
+
+:::
+
+[rs-soroban-sdk PR #1933]: https://github.com/stellar/rs-soroban-sdk/pull/1933
+[rs-soroban-sdk PR #1943]: https://github.com/stellar/rs-soroban-sdk/pull/1943
+[rs-soroban-sdk#1738]: https://github.com/stellar/rs-soroban-sdk/issues/1738
+[Soroban Rust SDK]: ../../../tools/sdks/contract-sdks.mdx#soroban-rust-sdk


### PR DESCRIPTION
### What
Add a section to the "Test Authorization" guide explaining that `register` and `register_at` run a contract's constructor under a recording auth manager, so a `require_auth()` call inside a constructor is automatically authorized without calling `mock_all_auths()`/`mock_auths()` just to register the contract.

### Why
This behavior has never been documented anywhere in stellar-docs, for either Wasm or native contracts, even though it's been true for Wasm contracts registered with `register` for a while. It's worth documenting now because rs-soroban-sdk just closed out the remaining inconsistencies: [PR #1933](https://github.com/stellar/rs-soroban-sdk/pull/1933) fixed `register_at` to record auth for Wasm constructors, and [PR #1943](https://github.com/stellar/rs-soroban-sdk/pull/1943) fixed native (non-Wasm, directly-registered `#[contract]` struct) constructors for both `register` and `register_at`, closing [rs-soroban-sdk#1738](https://github.com/stellar/rs-soroban-sdk/issues/1738). With those merged, the behavior is now uniform across register vs register_at and Wasm vs native contracts, so this is a good time to document it correctly rather than continue leaving it as tribal knowledge. The native contract fix hasn't shipped in a published release yet, so the doc avoids naming a specific future version number.

### Note
#2666 is an existing draft covering similar ground, opened before rs-soroban-sdk#1943 (the native-contract fix) merged. Left a comment there with the details; happy to close this in favor of an update to #2666, or the reverse, whichever is preferred.