### PR TITLE
🔧 Update vanity toolkit repo reference

### DIFF
--- a/docs/tokens/how-to-issue-an-asset.mdx
+++ b/docs/tokens/how-to-issue-an-asset.mdx
@@ -72,7 +72,7 @@ fmt.Println("Issuer Secret Key:", issuerKeypair.Seed())
 
 :::info
 
-Your account address will not change once you issue your asset, even if you modify its [signers](../learn/fundamentals/transactions/signatures-multisig.mdx). Many issuers employ [vanity public keys](https://github.com/JFWooten4/py-stellar-vanity-toolkit) related to their asset. For instance, you might configure a custom signer in [base32](../learn/glossary.mdx#account-id) like `GASTRO...USD`.
+Your account address will not change once you issue your asset, even if you modify its [signers](../learn/fundamentals/transactions/signatures-multisig.mdx). Many issuers employ [vanity public keys](https://github.com/JFWooten4/stellar-vanity-toolkit) related to their asset. For instance, you might configure a custom signer in [base32](../learn/glossary.mdx#account-id) like `GASTRO...USD`.
 
 :::
 


### PR DESCRIPTION
This project has branches which expand into other languages for complex computations, hence it has dropped the py-prefix (inspired by Overcat)