### PR TITLE
Document fieldless #[contractevent] structs

### DIFF
--- a/docs/build/guides/events/publish.mdx
+++ b/docs/build/guides/events/publish.mdx
@@ -45,6 +45,14 @@ pub struct Deposit {
     time: u64,
 }
 
+// A struct with no fields at all, written as a unit struct, is also a valid
+// event. It publishes only the default topic derived from the struct name,
+// with no additional topics and no data.
+// This event will be published with the following structure:
+// `["ping"], data = {}`
+#[contractevent]
+pub struct Ping;
+
 // This function does nothing beside publish events.
 pub fn events_function(env: Env, invoker: Address, token: Address) {
     Increment {
@@ -62,6 +70,8 @@ pub fn events_function(env: Env, invoker: Address, token: Address) {
         amount: 321_0000000,
         time: env.ledger().timestamp(),
     }.publish(&env);
+
+    Ping.publish(&env);
 }
 ```
 


### PR DESCRIPTION
### What
Add a `Ping` example to the events publishing guide showing that `#[contractevent]` now accepts a fieldless unit struct, publishing only its default name-derived topic with no data.

### Why
`rs-soroban-sdk` [#1917](https://github.com/stellar/rs-soroban-sdk/pull/1917) removed the compile error that previously rejected unit-struct event definitions like `pub struct MyEvent;`, and no existing doc showed a fieldless event of any kind.