### PR TITLE
Fix heading level for stellar multicall / router sdk section

### DIFF
--- a/docs/tools/sdks/contract-sdks.mdx
+++ b/docs/tools/sdks/contract-sdks.mdx
@@ -79,7 +79,7 @@ Refer to the [OpenZeppelin for Stellar Contracts](../openzeppelin-contracts.mdx#
 
 Axelar has created a Rust crate with useful macros for Stellar smart contract development. Please see Rust Crate [`stellar_axelar_std_derive`](https://axelarnetwork.github.io/axelar-amplifier-stellar/stellar_axelar_std_derive/index.html) for Attribute Macros and Derive Macros, and additional information.
 
-### Stellar Multicall / Router SDK
+## Stellar Multicall / Router SDK
 
 The Stellar Router SDK is a lightweight multicall contract that enables developers to execute multiple Soroban contract calls within a single transaction. While Soroban normally allows only one contract invocation per transaction, the Router bundles multiple calls through a single entry point, effectively enable complex, multi-step workflows to be executed atomically.
 


### PR DESCRIPTION
### What

Change the heading level of the Stellar Multicall / Router SDK section to be one higher.

### Why

The section is a sub-section of the Axelar Stellar crate but the two are unrelated and should be listed side-by-side, not tested.