### PR TITLE
Fix Tutorial 1's __check_auth example to match the current CustomAccountInterface trait

### DIFF
--- a/docs/build/guides/auth/check-auth-tutorials.mdx
+++ b/docs/build/guides/auth/check-auth-tutorials.mdx
@@ -36,7 +36,7 @@ The contract will store the time limit and last transfer time for each token in 
 
 use soroban_sdk::{
     auth::{Context, CustomAccountInterface}, contract, contracterror, contractimpl, contracttype, symbol_short, Address,
-    BytesN, Env, Symbol, Vec,
+    BytesN, Env, Hash, Symbol, Vec,
 };
 #[contract]
 struct AccountContract;
@@ -127,7 +127,7 @@ impl CustomAccountInterface for AccountContract {
     #[allow(non_snake_case)]
     fn __check_auth(
         env: Env,
-        signature_payload: BytesN<32>,
+        signature_payload: Hash<32>,
         signatures: Vec<Signature>,
         auth_context: Vec<Context>,
     ) -> Result<(), AccError> {
@@ -165,7 +165,7 @@ impl CustomAccountInterface for AccountContract {
 ```rust
  fn authenticate(
         env: &Env,
-        signature_payload: &BytesN<32>,
+        signature_payload: &Hash<32>,
         signatures: &Vec<Signature>,
 ) -> Result<(), AccError> {
     for i in 0..signatures.len() {
@@ -216,6 +216,7 @@ fn verify_authorization_policy(
                 c
             }
             Context::CreateContractHostFn(_) => return Err(AccError::InvalidContext),
+            Context::CreateContractWithCtorHostFn(_) => return Err(AccError::InvalidContext),
         };
 
         if contract_context.fn_name != TRANSFER_FN
@@ -260,7 +261,7 @@ Here are all the snippets stacked together in a single file for convenience:
 #![no_std]
 use soroban_sdk::{
     auth::{Context, CustomAccountInterface}, contract, contracterror, contractimpl, contracttype, symbol_short, Address,
-    BytesN, Env, Symbol, Vec,
+    BytesN, Env, Hash, Symbol, Vec,
 };
 #[contract]
 struct AccountContract;
@@ -323,7 +324,7 @@ impl CustomAccountInterface for AccountContract {
     #[allow(non_snake_case)]
     fn __check_auth(
         env: Env,
-        signature_payload: BytesN<32>,
+        signature_payload: Hash<32>,
         signatures: Vec<Signature>,
         auth_context: Vec<Context>,
     ) -> Result<(), AccError> {
@@ -354,7 +355,7 @@ impl CustomAccountInterface for AccountContract {
 
 fn authenticate(
     env: &Env,
-    signature_payload: &BytesN<32>,
+    signature_payload: &Hash<32>,
     signatures: &Vec<Signature>,
 ) -> Result<(), AccError> {
     for i in 0..signatures.len() {
@@ -397,6 +398,7 @@ fn verify_authorization_policy(
             c
         }
         Context::CreateContractHostFn(_) => return Err(AccError::InvalidContext),
+        Context::CreateContractWithCtorHostFn(_) => return Err(AccError::InvalidContext),
     };
 
     if contract_context.fn_name != TRANSFER_FN

--- a/docs/build/guides/auth/check-auth-tutorials.mdx
+++ b/docs/build/guides/auth/check-auth-tutorials.mdx
@@ -36,7 +36,7 @@ The contract will store the time limit and last transfer time for each token in 
 
 use soroban_sdk::{
     auth::{Context, CustomAccountInterface}, contract, contracterror, contractimpl, contracttype, symbol_short, Address,
-    BytesN, Env, Hash, Symbol, Vec,
+    crypto::Hash, BytesN, Env, Symbol, Vec,
 };
 #[contract]
 struct AccountContract;


### PR DESCRIPTION
### What
Correct the custom account example's `__check_auth` signature to use the right signature-payload type, and make its `Context` match exhaustive against the current enum.

### Why
As written, this tutorial's account contract does not compile against the current SDK, so anyone copying it hits a wall immediately — and it was already inconsistent with Tutorial 2 in the same file, which had the correct type.