### PR TITLE
Fix event-testing assertion in events example to use ContractEvents

### DIFF
--- a/docs/build/smart-contracts/example-contracts/events.mdx
+++ b/docs/build/smart-contracts/example-contracts/events.mdx
@@ -32,18 +32,18 @@ With the release of Whisk, Protocol 23, the syntax for publishing smart contract
 
 [open-in-github-codespaces]: https://github.com/codespaces/new?repo=stellar/soroban-examples&editor=web
 [open-in-code-anywhere]: https://app.codeanywhere.com/#https://github.com/stellar/soroban-examples
-[events example]: https://github.com/stellar/soroban-examples/tree/v23.0.0/events
+[events example]: https://github.com/stellar/soroban-examples/tree/main/events
 [storing data example]: ../getting-started/storing-data.mdx
 [Rust SDK documentation]: https://docs.rs/soroban-sdk/latest/soroban_sdk/_migrating/v23_contractevent/index.html
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v23.0.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `main` branch of the `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```sh
-git clone -b v23.0.0 https://github.com/stellar/soroban-examples
+git clone -b main https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [GitHub Codespaces][open-in-github-codespaces] or [Code Anywhere][open-in-code-anywhere].
@@ -102,7 +102,7 @@ impl IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v23.0.0/events
+Ref: https://github.com/stellar/soroban-examples/tree/main/events
 
 ## How it Works
 
@@ -176,7 +176,7 @@ Published events are discarded if a contract invocation fails due to a panic, bu
 
 ## Tests
 
-Open the [`events/src/test.rs`](https://github.com/stellar/soroban-examples/tree/v23.0.0/events/src/test.rs) file to follow along.
+Open the [`events/src/test.rs`](https://github.com/stellar/soroban-examples/tree/main/events/src/test.rs) file to follow along.
 
 ```rust title="events/src/test.rs"
 #[test]
@@ -185,34 +185,33 @@ fn test() {
     let contract_id = env.register(IncrementContract, ());
     let client = IncrementContractClient::new(&env, &contract_id);
 
+    // Assert on the events emitted by the last contract invocation using
+    // the contract's event struct defined with #[contractevent] macro to
+    // construct the expected event in xdr form for comparison.
     assert_eq!(client.increment(), 1);
     assert_eq!(
         env.events().all(),
-        vec![
-            &env,
-            (
-                contract_id.clone(),
-                (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
-                1u32.into_val(&env)
-            ),
-        ]
+        std::vec![IncrementEvent { count: 1 }.to_xdr(&env, &contract_id)]
     );
+
+    // Assert on the events emitted by the last contract invocation that
+    // were emitted by a contract with a specific contract id. This is
+    // useful when your contract might call other contracts that also emit events.
     assert_eq!(client.increment(), 2);
     assert_eq!(
-        env.events().all(),
-        vec![
-            &env,
-            (
-                contract_id.clone(),
-                (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
-                2u32.into_val(&env)
-            ),
-        ]
+        env.events().all().filter_by_contract(&contract_id),
+        std::vec![IncrementEvent { count: 2 }.to_xdr(&env, &contract_id)]
     );
+
+    // Assert on the events emitted by the last contract invocation by
+    // building a tuple form of the event manually. This is useful
+    // when the contract does not define its events using the #[contractevent] macro.
+    //
+    // Tuple Format: (contract_id: Address, topics: Val, data: Val)
     assert_eq!(client.increment(), 3);
     assert_eq!(
         env.events().all(),
-        vec![
+        soroban_sdk::vec![
             &env,
             (
                 contract_id,
@@ -248,17 +247,37 @@ The example invokes the contract several times.
 assert_eq!(client.increment(), 1);
 ```
 
-The example asserts that the event was published.
+The example asserts that the event was published. `env.events().all()` returns a `ContractEvents` value containing all the events published by the last contract invocation, which can be compared in a few different ways.
+
+The event struct defined with `#[contractevent]` can be converted to its XDR form with `to_xdr` and compared directly, which is the most convenient way to assert on events when the contract defines them using the macro.
 
 ```rust
 assert_eq!(
     env.events().all(),
-    vec![
+    std::vec![IncrementEvent { count: 1 }.to_xdr(&env, &contract_id)]
+);
+```
+
+`filter_by_contract` narrows the events down to those emitted by a specific contract address, which is useful when a contract invocation calls into other contracts that also emit events.
+
+```rust
+assert_eq!(
+    env.events().all().filter_by_contract(&contract_id),
+    std::vec![IncrementEvent { count: 2 }.to_xdr(&env, &contract_id)]
+);
+```
+
+The event can also be compared by building its tuple form manually, as `(contract_id, topics, data)`, which is useful when the contract does not define its events using the `#[contractevent]` macro.
+
+```rust
+assert_eq!(
+    env.events().all(),
+    soroban_sdk::vec![
         &env,
         (
-            contract_id.clone(),
+            contract_id,
             (symbol_short!("COUNTER"), symbol_short!("increment")).into_val(&env),
-            1u32.into_val(&env)
+            3u32.into_val(&env)
         ),
     ]
 );


### PR DESCRIPTION
### What
Update the test's event assertions to use the SDK's current event-testing APIs (XDR comparison via `to_xdr`, `filter_by_contract`), and point the example link at the current version.

### Why
The old tuple-vec comparison no longer type-checks against the current SDK, so the example as shown would fail to compile.