### PR TITLE
Fix test code in deploying-a-sac guide

### DIFF
--- a/docs/build/guides/tokens/deploying-a-sac.mdx
+++ b/docs/build/guides/tokens/deploying-a-sac.mdx
@@ -67,24 +67,31 @@ impl SacDeployer {
 You need to test the deployment to ensure everything works as expected. The following code demonstrates how to test the SacDeployer contract using the Soroban Rust SDK's test utilities.
 
 ```rust
-#[cfg(feature = "testutils")]
-fn main() {
-    let env = TestEnv::default();
-    let serialized_asset = Bytes::from("actual serialized asset"); // Replace with actual serialized asset info
-    let sac_deployer = SacDeployer::default();
-    let sac_address = sac_deployer.deploy_sac(env.clone(), serialized_asset);
-    println!("SAC Address: {}", sac_address.to_string());
+#[test]
+fn test() {
+    use soroban_sdk::{
+        xdr::{Asset, Limits, WriteXdr},
+        Bytes, Env,
+    };
+
+    let env = Env::default();
+    let contract_id = env.register(SacDeployer, ());
+    let client = SacDeployerClient::new(&env, &contract_id);
+
+    let serialized_asset = Bytes::from_slice(&env, &Asset::Native.to_xdr(Limits::none()).unwrap());
+    let sac_address = client.deploy_sac(&serialized_asset);
+
+    assert_eq!(sac_address, env.deployer().with_stellar_asset(serialized_asset).deployed_address());
 }
 ```
 
 ### Explanation
 
-- `TestEnv::default()`: creates a default testing environment for the deployment.
-- `SacDeployer::default()`: initializes the SacDeployer contract.
-- `deploy_sac(env.clone(), serialized_asset)`: calls the `deploy_sac` function to deploy the SAC and retrieves the address.
-- `println!("SAC Address: {}", sac_address.to_string())`: prints the address of the deployed SAC.
-- `assert!(sac_address.to_string().len() > 0, "SAC address should be non-empty")`: asserts that the SAC address is non-empty, ensuring a successful deployment.
-- `serialized_asset`is the Stellar `Asset` XDR serialized to bytes. Refer to `[soroban_sdk::xdr::Asset]` [XDR](https://docs.rs/stellar-xdr/latest/stellar_xdr/curr/enum.Asset.html)
+- `env.register(SacDeployer, ())`: registers the `SacDeployer` contract in the test environment and returns its contract ID.
+- `SacDeployerClient::new(&env, &contract_id)`: creates a client used to invoke the deployed `SacDeployer` contract's functions.
+- `serialized_asset`: the Stellar `Asset` XDR serialized to bytes. This example serializes the native XLM asset via [`soroban_sdk::xdr::Asset`](https://docs.rs/soroban-sdk/latest/soroban_sdk/xdr/enum.Asset.html); for an issued asset, use `Asset::CreditAlphanum4`/`Asset::CreditAlphanum12` instead.
+- `client.deploy_sac(&serialized_asset)`: invokes the contract, which deploys the SAC and returns its address.
+- The assertion confirms the returned address matches the deterministic address the SDK computes for that same serialized asset.
 
 ### Conclusion
 


### PR DESCRIPTION
### What
Replace the SAC deployment test snippet's made-up`TestEnv`/`SacDeployer::default()`/string-literal `Bytes` calls with the actual test code required to register the contract, serializes a real XDR asset, and deploys it.

### Why
None of the original types or calls exist in the SDK, so the example couldn't be compiled as shown. Unclear where the examples came from, maybe this is from a misfired AI contribution.