### PR TITLE
Fix Address constructor and stale SDK version in EVM basics migration guide

### DIFF
--- a/docs/learn/migrate/evm/solidity-and-rust-basics.mdx
+++ b/docs/learn/migrate/evm/solidity-and-rust-basics.mdx
@@ -181,7 +181,7 @@ let vec = vec![&env, 0, 1, 2, 3];
 let map = map![&env, (2, 20), (1, 10)];
 
 // Address
-let address = Address::generate(&env);
+let address = Address::from_str(&env, "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI");
 
 // Struct (named fields)
 pub struct State {

--- a/docs/learn/migrate/evm/solidity-and-rust-basics.mdx
+++ b/docs/learn/migrate/evm/solidity-and-rust-basics.mdx
@@ -181,7 +181,7 @@ let vec = vec![&env, 0, 1, 2, 3];
 let map = map![&env, (2, 20), (1, 10)];
 
 // Address
-let address = Address::new([0u8; 32]);
+let address = Address::generate(&env);
 
 // Struct (named fields)
 pub struct State {
@@ -573,10 +573,10 @@ crate-type = ["cdylib"]
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = "26"
+soroban-sdk = "27"
 
 [dev-dependencies]
-soroban-sdk = { version = "26", features = ["testutils"] }
+soroban-sdk = { version = "27", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/docs/learn/migrate/evm/solidity-and-rust-basics.mdx
+++ b/docs/learn/migrate/evm/solidity-and-rust-basics.mdx
@@ -181,7 +181,7 @@ let vec = vec![&env, 0, 1, 2, 3];
 let map = map![&env, (2, 20), (1, 10)];
 
 // Address
-let address = Address::from_str(&env, "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI");
+let address = Address::from_str(&env, "G...");
 
 // Struct (named fields)
 pub struct State {


### PR DESCRIPTION
### What
Replace the non-existent `Address::new(...)` call with the SDK's function to get an address in this context, and bump the pinned soroban-sdk version.

### Why
`Address` has no public byte-array constructor, so the example as written can't compile, and the pinned SDK version was behind current.