### PR TITLE
Fix undefined variable in stellar-asset-contract guide example

### DIFF
--- a/docs/build/guides/tokens/stellar-asset-contract.mdx
+++ b/docs/build/guides/tokens/stellar-asset-contract.mdx
@@ -22,7 +22,7 @@ impl MyContract {
     pub fn token_fn(e: Env, id: Address) {
         // Create a client instance for the provided token identifier. If the id
         // value corresponds to an SAC contract, then SAC implementation is used.
-        let client = token::TokenClient::new(&env, &id);
+        let client = token::TokenClient::new(&e, &id);
         // Call token functions part of the Stellar SEP-41 token interface
         client.transfer(...);
     }


### PR DESCRIPTION
### What
Make the example function's body reference the parameter it actually declared.

### Why
The snippet referenced a variable name that was never declared, so it wouldn't compile as shown.