### PR TITLE
Fix syntax error in ledger snapshot testing example

### DIFF
--- a/docs/build/guides/testing/ledger-snapshot-testing.mdx
+++ b/docs/build/guides/testing/ledger-snapshot-testing.mdx
@@ -173,7 +173,7 @@ First, the ledger snapshot data is loaded into the environment:
 fn test() {
     let env = Env::from_ledger_snapshot_file(
         "../../snapshot.json",
-    ;
+    );
 }
 ```
 


### PR DESCRIPTION
### What
Add the missing closing parenthesis in the first `Env::from_ledger_snapshot_file` code sample.

### Why
The snippet as written doesn't compile, which is confusing since the correct version appears later on the same page.