### PR TITLE
Update simple-account example to the constructor-based init pattern

### DIFF
--- a/docs/build/smart-contracts/example-contracts/simple-account.mdx
+++ b/docs/build/smart-contracts/example-contracts/simple-account.mdx
@@ -42,10 +42,10 @@ While contract accounts are supported by the Stellar protocol and Soroban SDK, t
 ## Run the Example
 
 1. Finish the [Setup] checklist to install the Stellar CLI, Rust target, and required environment variables.
-2. Clone the `soroban-examples` repository at the `v23.0.0` tag:
+2. Clone the `soroban-examples` repository at the `main` branch:
 
 ```sh
-git clone -b v23.0.0 https://github.com/stellar/soroban-examples
+git clone -b main https://github.com/stellar/soroban-examples
 ```
 
 3. If you prefer not to install anything locally, launch the repo in [GitHub Codespaces][open-in-github-codespaces] or [Codeanywhere][open-in-code-anywhere].
@@ -81,7 +81,7 @@ pub enum DataKey {
 
 #[contractimpl]
 impl SimpleAccount {
-    pub fn init(env: Env, public_key: BytesN<32>) {
+    pub fn __constructor(env: Env, public_key: BytesN<32>) {
         if env.storage().instance().has(&DataKey::Owner) {
             panic!("owner is already set");
         }
@@ -89,7 +89,7 @@ impl SimpleAccount {
     }
 ```
 
-Call `init` once to persist the owner's public key. Subsequent calls panic to prevent replacement of the key.
+`__constructor` runs once, at deployment, to persist the owner's public key.
 
 ### Implement `__check_auth`
 
@@ -122,10 +122,11 @@ Open `simple_account/src/test.rs`. `__check_auth` is not exposed as a regular en
 #[test]
 fn test_account() {
     let env = Env::default();
-    let account_contract = SimpleAccountClient::new(&env, &env.register(SimpleAccount, ()));
 
     let signer = Keypair::generate(&mut thread_rng());
-    account_contract.init(&signer.public.to_bytes().into_val(&env));
+    let public_key: BytesN<32> = signer.public.to_bytes().into_val(&env);
+    let contract_id = env.register(SimpleAccount, SimpleAccountArgs::__constructor(&public_key));
+    let account_contract = SimpleAccountClient::new(&env, &contract_id);
 
     let payload = BytesN::random(&env);
     env.try_invoke_contract_check_auth::<Error>(
@@ -151,7 +152,7 @@ fn test_account() {
 
 Follow the same structure for any account:
 
-- create a keypair and store the expected signer (for example, with `init`)
+- create a keypair and store the expected signer (for example, via `__constructor`)
 - call `try_invoke_contract_check_auth` with a valid signature and assert it succeeds
 - call it again with an invalid signature or payload and assert it fails
 
@@ -172,4 +173,4 @@ The compiled file appears at `target/wasm32v1-none/release/simple_account.wasm` 
 - [BLS signature contract](./bls-signature.mdx) – demonstrates custom signature schemes inside `__check_auth`.
 
 [Complex account example]: ./complex-account.mdx
-[simple account example]: https://github.com/stellar/soroban-examples/tree/v23.0.0/simple_account
+[simple account example]: https://github.com/stellar/soroban-examples/tree/main/simple_account


### PR DESCRIPTION
### What
Replace the example's separate `init` call with the `__constructor` pattern the real current example actually uses, and point the example link at the current version.

### Why
The doc is out-of-date with the example contract in the soroban-examples repo (https://github.com/stellar/soroban-examples/blob/main/simple_account/src/test.rs) and demonstrates an old way to do contract initiatilisation that we should not be promoting.