### PR TITLE
Fix type mismatch and stale tag in example-contract template

### DIFF
--- a/docs/build/smart-contracts/example-contracts/TEMPLATE.mdx
+++ b/docs/build/smart-contracts/example-contracts/TEMPLATE.mdx
@@ -23,15 +23,15 @@ Place each link definition at the bottom of the section it first is used in.
 
 [open-in-github-codespaces]: https://github.com/codespaces/new?repo=stellar/soroban-examples&editor=web
 [open-in-code-anywhere]: https://app.codeanywhere.com/#https://github.com/stellar/soroban-examples
-[example demonstrates]: https://github.com/stellar/soroban-examples/tree/v23.0.0/hello_world
+[example demonstrates]: https://github.com/stellar/soroban-examples/tree/main/hello_world
 [other example]: ../getting-started/setup.mdx
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v23.0.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `main` branch of `soroban-examples` repository:
 
 ```sh
-git clone -b v23.0.0 https://github.com/stellar/soroban-examples
+git clone -b main https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [GitHub Codespaces][open-in-github-codespaces] or [Code Anywhere][open-in-code-anywhere]
@@ -56,21 +56,21 @@ test test::test ... ok
 
 ```rust title="hello_world/src/lib.rs"
 #![no_std]
-use soroban_sdk::{contractimpl, vec, Env, Symbol, Vec};
+use soroban_sdk::{contractimpl, vec, Env, String, Vec};
 
 pub struct HelloContract;
 
 #[contractimpl]
 impl HelloContract {
-    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
-        vec![&env, Symbol::short("Hello"), to]
+    pub fn hello(env: Env, to: String) -> Vec<String> {
+        vec![&env, String::from_str(&env, "Hello"), to]
     }
 }
 
 mod test;
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v23.0.0/hello_world
+Ref: https://github.com/stellar/soroban-examples/tree/main/hello_world
 
 ## How it Works
 
@@ -88,7 +88,7 @@ Underneath each of those headings is a brief discussion of how that concept ties
 
 ## Tests
 
-Open the [`/hello_world/src/test.rs`](https://github.com/stellar/soroban-examples/tree/v23.0.0/hello_world/src/test.rs) file to follow along.
+Open the [`/hello_world/src/test.rs`](https://github.com/stellar/soroban-examples/tree/main/hello_world/src/test.rs) file to follow along.
 
 ```rust title="hello_world/src/test.rs"
 #[test]

--- a/docs/build/smart-contracts/example-contracts/TEMPLATE.mdx
+++ b/docs/build/smart-contracts/example-contracts/TEMPLATE.mdx
@@ -28,7 +28,7 @@ Place each link definition at the bottom of the section it first is used in.
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `main` branch of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `main` branch of the `soroban-examples` repository:
 
 ```sh
 git clone -b main https://github.com/stellar/soroban-examples
@@ -56,8 +56,9 @@ test test::test ... ok
 
 ```rust title="hello_world/src/lib.rs"
 #![no_std]
-use soroban_sdk::{contractimpl, vec, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
+#[contract]
 pub struct HelloContract;
 
 #[contractimpl]


### PR DESCRIPTION
### What
Make the template's example contract and test code use the same type consistently, and update its placeholder example-repo reference to the current version.

### Why
The docs page about the example is out of date with the actual example at:
https://github.com/stellar/soroban-examples/tree/main/hello_world