### PR TITLE
Rewrite deploy-contract guide's deployer example for the current constructor-based pattern

### DIFF
--- a/docs/build/guides/conventions/deploy-contract.mdx
+++ b/docs/build/guides/conventions/deploy-contract.mdx
@@ -30,12 +30,12 @@ This guide walks through the process of deploying a smart contract from installe
 
 ### Setup environment
 
-The [deployer example](https://github.com/stellar/soroban-examples/tree/v22.0.1/deployer) demonstrates how to deploy contracts using a contract.
+The [deployer example](https://github.com/stellar/soroban-examples/tree/main/deployer) demonstrates how to deploy contracts using a contract.
 
 1. Clone the Soroban Examples Repository:
 
 ```bash
-git clone -b v22.0.1 https://github.com/stellar/soroban-examples
+git clone -b main https://github.com/stellar/soroban-examples
 ```
 
 2. Navigate to the Deployer Example:
@@ -61,9 +61,8 @@ cargo test
 You should see the output indicating the tests passed:
 
 ```bash
-running 2 tests
-test test::test_deploy_from_contract ... ok
-test test::test_deploy_from_address ... ok
+running 1 test
+test test::test ... ok
 ```
 
 ### Code overview
@@ -72,90 +71,81 @@ test test::test_deploy_from_address ... ok
 #[contract]
 pub struct Deployer;
 
+const ADMIN: Symbol = symbol_short!("admin");
+
 #[contractimpl]
 impl Deployer {
-    /// Deploy the contract Wasm and after deployment invoke the init function
-    /// of the contract with the given arguments.
+    /// Construct the deployer with a provided administrator.
+    pub fn __constructor(env: Env, admin: Address) {
+        env.storage().instance().set(&ADMIN, &admin);
+    }
+
+    /// Deploys the contract on behalf of the `Deployer` contract.
     ///
-    /// This has to be authorized by `deployer` (unless the `Deployer` instance
-    /// itself is used as deployer). This way the whole operation is atomic
-    /// and it's not possible to frontrun the contract initialization.
-    ///
-    /// Returns the contract address and result of the init function.
+    /// This has to be authorized by the `Deployer`s administrator.
     pub fn deploy(
         env: Env,
-        deployer: Address,
         wasm_hash: BytesN<32>,
         salt: BytesN<32>,
-        init_fn: Symbol,
-        init_args: Vec<Val>,
-    ) -> (Address, Val) {
-        // Skip authorization if deployer is the current contract.
-        if deployer != env.current_contract_address() {
-            deployer.require_auth();
-        }
+        constructor_args: Vec<Val>,
+    ) -> Address {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
 
-        // Deploy the contract using the uploaded Wasm with given hash.
+        // Deploy the contract using the uploaded Wasm with given hash on behalf
+        // of the current contract.
+        // Note, that not deploying on behalf of the admin provides more
+        // consistent address space for the deployer contracts - the admin could
+        // change or it could be a completely separate contract with complex
+        // authorization rules, but all the contracts will still be deployed
+        // by the same `Deployer` contract address.
         let deployed_address = env
             .deployer()
-            .with_address(deployer, salt)
-            .deploy(wasm_hash);
+            .with_address(env.current_contract_address(), salt)
+            .deploy_v2(wasm_hash, constructor_args);
 
-        // Invoke the init function with the given arguments.
-        let res: Val = env.invoke_contract(&deployed_address, &init_fn, init_args);
-        // Return the contract ID of the deployed contract and the result of
-        // invoking the init result.
-        (deployed_address, res)
+        deployed_address
     }
 }
 ```
 
 ## How it works
 
-The deployer contract provides a mechanism to deploy other contracts in a secure and deterministic manner. It ensures that the deployment is authorized by the specified deployer address and supports atomic initialization of the newly deployed contract. This guarantees that the contract is properly initialized immediately after deployment, preventing any potential issues with uninitialized contracts.
+The deployer contract provides a mechanism to deploy other contracts in a secure and deterministic manner. It stores an administrator address at construction time and requires that administrator's authorization for every deployment. It also supports atomic initialization of the newly deployed contract via constructor arguments. This guarantees that the contract is properly initialized immediately after deployment, preventing any potential issues with uninitialized contracts.
 
 ### Function breakdown
 
 - `env: Env`: The Env object represents the current contract execution environment. It provides methods to interact with the blockchain and other contracts, as well as perform various operations.
-- `deployer: Address`: The Address of the entity that is requesting the contract deployment. This address will be used to authorize the deployment.
+- `admin: Address`: The Address of the administrator, provided to the `__constructor` function and stored for later use. Only this address can authorize deployments.
 - `wasm_hash: BytesN<32>`: The hash of the Wasm bytecode of the contract to be deployed and must already be installed and on the ledger. This hash is used to uniquely identify the contract's code.
-- `salt: BytesN<32>`: A unique value used to derive the address of the deployed contract. The same combination of deployer address and salt will always produce the same deployed contract address, ensuring deterministic contract addresses.
-- `init_fn: Symbol`: The name of the initialization function to be called on the newly deployed contract.
-- `init_args: Vec<Val>`: A vector of arguments, specified as `{type: value}` objects, to be passed to the initialization function of the deployed contract.
+- `salt: BytesN<32>`: A unique value used to derive the address of the deployed contract. The same combination of the `Deployer` contract's address and salt will always produce the same deployed contract address, ensuring deterministic contract addresses.
+- `constructor_args: Vec<Val>`: A vector of arguments, specified as `{type: value}` objects, to be passed to the constructor of the deployed contract.
 
 ### Function steps
 
 ```rust
-if deployer != env.current_contract_address() {
-   deployer.require_auth();
-}
+let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+admin.require_auth();
 ```
 
-The function checks if the `deployer` address is the same as the current contract’s address. If it is not, it requires authorization from the deployer address to ensure that the deployer has permitted this deployment.
+The function loads the administrator address that was stored during construction and requires its authorization, ensuring that only the administrator can trigger a deployment.
 
 ```rust
 let deployed_address = env
    .deployer()
-   .with_address(deployer, salt)
-   .deploy(wasm_hash);
+   .with_address(env.current_contract_address(), salt)
+   .deploy_v2(wasm_hash, constructor_args);
 ```
 
 - Uses the `env.deployer()` method to create a deployer object.
-- `with_address(deployer, salt)` specifies the deployer address and the salt to derive the new contract’s address.
-- `deploy(wasm_hash)` deploys the contract using the provided Wasm bytecode hash and returns the address of the newly deployed contract.
+- `with_address(env.current_contract_address(), salt)` specifies that the deployed contract's address is derived from the `Deployer` contract's own address and the given salt.
+- `deploy_v2(wasm_hash, constructor_args)` deploys the contract using the provided Wasm bytecode hash, invokes its constructor with `constructor_args`, and returns the address of the newly deployed contract.
 
 ```rust
-let res: Val = env.invoke_contract(&deployed_address, &init_fn, init_args);
+deployed_address
 ```
 
-- Invokes the specified initialization function (`init_fn`) on the newly deployed contract (`deployed_address`), passing the provided initialization arguments (`init_args`).
-- The result of this function call is stored in `res`.
-
-```rust
-(deployed_address, res)
-```
-
-Returns a tuple containing the address of the newly deployed contract and the result of the initialization function.
+Returns the address of the newly deployed contract.
 
 ### Build the contracts
 
@@ -177,7 +167,7 @@ target/wasm32v1-none/release/soroban_deployer_test_contract.wasm
 
 ## Run the contract
 
-Before deploying the test contract with the deployer, install the test contract Wasm using the `install` command. The `install` command will print out the hash derived from the Wasm file which should be used by the deployer.
+Before deploying the test contract with the deployer, install the test contract Wasm using the `upload` command. The `upload` command will print out the hash derived from the Wasm file which should be used by the deployer.
 
 ```sh
 stellar contract upload \
@@ -192,18 +182,19 @@ When deploying a smart contract to the network, you must specify an identity tha
 
 The command prints out the hash as hex. It will look something like `6bc6d975ef99c057231481c40f69f4c2a8a89ac56e8826ef0378f8e5c6abc4be`.
 
-We also need to deploy the `Deployer` contract:
+We also need to deploy the `Deployer` contract. Since the `Deployer` contract's `__constructor` function requires an administrator address, we provide the `alice` [identity] as the `--admin` argument. Create and provide your own identity, where necessary.
 
 ```sh
 stellar contract deploy \
   --wasm deployer/target/wasm32v1-none/release/soroban_deployer_contract.wasm \
   --source-account alice  \
-  --network testnet
+  --network testnet \
+  -- --admin alice
 ```
 
 This will return the deployer address. For example: `CDKYZMA3OXR54YAHOQ5D4EWDFDT3ZNKKRYKQT7MGPWH22ZVD2DX2BJID`.
 
-Then the deployer contract may be invoked with the Wasm hash value above.
+Then the deployer contract may be invoked with the Wasm hash value above. The `constructor_args` are passed through to the constructor of the deployed contract, so they are used here to set the initial `value` to `8`.
 
 ```sh
 stellar contract invoke \
@@ -212,11 +203,9 @@ stellar contract invoke \
   --network testnet \
   -- \
   deploy \
-  --deployer CDKYZMA3OXR54YAHOQ5D4EWDFDT3ZNKKRYKQT7MGPWH22ZVD2DX2BJID \
   --salt 123 \
   --wasm_hash 6bc6d975ef99c057231481c40f69f4c2a8a89ac56e8826ef0378f8e5c6abc4be \
-  --init_fn init \
-  --init_args '[{"u32":8}]'
+  --constructor_args '[{"u32":8}]'
 ```
 
 The deployer contract invocation will return the Contract address (For example: `CCTVFX6BFTQHTGAHA5TY4YZQJRUKRE2RRNUTGVBNKE3PJF5C7CI53APY`) of the newly deployed test contract.


### PR DESCRIPTION
### What
Update the deployer guide's contract code, CLI commands, and example link to match the current constructor-based deployer contract instead of the old init-function pattern.

### Why
The docs page is out of date. The deployer contract's actual current implementation takes an administrator at construction time and uses `deploy_v2`, so the old `init_fn`/`init_args` example and CLI flags shown here no longer match what a reader would find in the real example or be able to run.
https://github.com/stellar/soroban-examples/blob/main/deployer