### PR TITLE
Fill in released Smart Contract Rust SDK version for Protocol 27

### DIFF
--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -22,7 +22,7 @@ Release candidates are software releases that are also released to the [Testnet]
 | Rust XDR | `27.0.0` |
 | Smart Contract Host Environment | `27.0.0` |
 | Stellar Core | `27.0.0` |
-| Smart Contract Rust SDK | `TBD` |
+| Smart Contract Rust SDK | `27.0.2` |
 | Poseidon Rust SDK | `TBD` |
 | Stellar CLI | `TBD` |
 | Stellar RPC | `v27.0.0` |


### PR DESCRIPTION
### What
Replace the `TBD` placeholder for the Smart Contract Rust SDK version in the Protocol 27 row with the version that has since shipped.

### Why
The SDK release the row was waiting on has already shipped.