### PR TITLE
🔗 Remove UTM tracking from documentation links

### DIFF
--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -22,7 +22,7 @@ These providers allow access to the Futurenet, Testnet and Mainnet network.
 | [Lightsail Network - Quasar\*](https://quasar.lightsail.network) | ❌ | ❌ | ✅ | ❌ | ✅ |
 | [Uniblock](https://www.uniblock.dev) | ❌ | ✅ | ✅ | ❌ | ❌ |
 | [Exaion](https://crypto.exaion.com) | ❌ | ❌ | ✅ | ✅ | ✅ |
-| [Alchemy](https://dashboard.alchemy.com/?utm_source=chain_partner&utm_medium=referral&utm_campaign=stellar) | ❌ | ✅ | ✅ | ✅ | ❌ |
+| [Alchemy](https://dashboard.alchemy.com) | ❌ | ✅ | ✅ | ✅ | ❌ |
 | [GetBlock](https://getblock.io/nodes/xlm/) | ❌ | ❌ | ✅ | ✅ | ✅ |
 
 \*_RPC Archive is a new option for those looking to retrieve full ledger history. Currently only the [getLedgers](./api-reference/methods/getLedgers.mdx) RPC method supports this feature. You can choose one of the providers above, or create your own getLedgers archive by following [these steps](./admin-guide/data-lake-integration.mdx)._

--- a/docs/tools/developer-tools/asset-tools.mdx
+++ b/docs/tools/developer-tools/asset-tools.mdx
@@ -7,6 +7,6 @@ sidebar_position: 30
 
 # Asset Sandbox
 
-### [Asset Sandbox](https://stellar.cheesecakelabs.com/?utm_source=stellar&utm_medium=landing-page&utm_campaign=stellar-asset-sandbox)
+### [Asset Sandbox](https://stellar.cheesecakelabs.com)
 
 A sandbox supported by SDF and Cheesecake Labs for businesses to experiment with asset issuance on Stellar's test network.


### PR DESCRIPTION
I get the allure of having this tracking. Marketing and tracking all the data can be fun. But the docs are a natural source of community information, not a venue for promoting products and services.

I first experienced this in 2023 when I added tracking to our own regulatory and compliance disclosure site in https://github.com/blocktransfer/issuer-disclosures/commit/b9df49d2a9cf9bba493c17fcf3851c676d338dba. You can even see me tweaking the tags to normalize page refs the next year in https://github.com/blocktransfer/issuer-disclosures/commit/96cf8fc8b7bc45615e5219fcbd36ad97a8202830. But this is bad policy that distracts the editor and reader from the core documentation efforts.

I have no problem with primary commercial sites, like the root domain, highlighting and referring to anything desired. But our source of truth as an information center should not burden visitors with this tracking. They already have to expose their cookies to tracking, which I believe we should keep away from developers in their earliest learning phase.