### PR TITLE
Sync SAC event doc-comments to CAP-67 shapes

### DIFF
--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -170,8 +170,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["set_authorized", id: Address], data =
-    /// [authorize: bool]`
+    /// Emits an event with topics `["set_authorized", id: Address,
+    /// sep0011_asset: String], data = authorize: bool`
     fn set_authorized(env: Env, id: Address, authorize: bool);
 
     /// Returns true if `id` is authorized to use its balance.
@@ -190,8 +190,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["mint", to: Address], data
-    /// = amount: i128`
+    /// Emits an event with topics `["mint", to: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn mint(env: Env, to: Address, amount: i128);
 
     /// Clawback `amount` from `from` account. `amount` is burned in the
@@ -205,8 +205,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["clawback", admin: Address, to: Address],
-    /// data = amount: i128`
+    /// Emits an event with topics `["clawback", from: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn clawback(env: Env, from: Address, amount: i128);
 
     /// Creates this contract asset's unlimited trustline for the provided


### PR DESCRIPTION
### What

Update the `set_authorized`, `mint`, and `clawback` event doc-comments in the embedded `StellarAssetInterface` code block on the Stellar Asset Contract page to the CAP-67 event shapes.

### Why

CAP-0067 removed the `admin` topic from these SAC events and appended a trailing SEP-11 asset topic, but this page's embedded copy of the interface still showed the pre-CAP-67 shapes. https://github.com/stellar/rs-soroban-sdk/pull/1956 fixed this in the soroban-sdk. This change syncs the docs to match the sdk.

Close https://github.com/stellar/stellar-docs/issues/2593