### PR TITLE
Sync SAC event doc-comments with CAP-67 fix

### DIFF
--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -170,8 +170,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["set_authorized", id: Address], data =
-    /// [authorize: bool]`
+    /// Emits an event with topics `["set_authorized", id: Address,
+    /// sep0011_asset: String], data = authorize: bool`
     fn set_authorized(env: Env, id: Address, authorize: bool);
 
     /// Returns true if `id` is authorized to use its balance.
@@ -190,8 +190,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["mint", to: Address], data
-    /// = amount: i128`
+    /// Emits an event with topics `["mint", to: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn mint(env: Env, to: Address, amount: i128);
 
     /// Clawback `amount` from `from` account. `amount` is burned in the
@@ -205,8 +205,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["clawback", admin: Address, to: Address],
-    /// data = amount: i128`
+    /// Emits an event with topics `["clawback", from: Address,
+    /// sep0011_asset: String], data = amount: i128`
     fn clawback(env: Env, from: Address, amount: i128);
 
     /// Creates this contract asset's unlimited trustline for the provided


### PR DESCRIPTION
### What
Update the `StellarAssetInterface` event doc-comments for `set_authorized`, `mint`, and `clawback` in `docs/tokens/stellar-asset-contract.mdx` to the corrected CAP-67 event-topic shapes.

### Why
This file carries a verbatim copy of the `StellarAssetInterface` trait from `soroban-sdk/src/token.rs`, and rs-soroban-sdk PR [#1956](https://github.com/stellar/rs-soroban-sdk/pull/1956) just fixed that trait's doc-comments to match CAP-67 (which removed the `admin` topic from these events and added a trailing `sep0011_asset` topic); `clawback`'s comment was additionally wrong before this, naming topics that didn't match its own parameters. Without this change the docs would drift from the SDK again, which is exactly what #2593 flagged. This closes the drift half of that issue; the broader SEP-41-vs-SAC event-schema comparison table it also requests is separate, larger work already assigned to a maintainer, and is out of scope here.