### PR TITLE
make the git sha a link in slack notifications

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -60,7 +60,7 @@ jobs:
           payload: |
             {
               "channel": "${{ env.SLACK_CHANNEL }}",
-              "text": "Docs build complete for [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})."
+              "text": "Docs build complete for <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>."
             }
 
       - name: Slack notification — failure
@@ -72,5 +72,5 @@ jobs:
           payload: |
             {
               "channel": "${{ env.SLACK_CHANNEL }}",
-              "text": "Docs build failed for [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})."
+              "text": "Docs build failed for <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>."
             }

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -60,7 +60,7 @@ jobs:
           payload: |
             {
               "channel": "${{ env.SLACK_CHANNEL }}",
-              "text": "Docs build complete for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+              "text": "Docs build complete for [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})."
             }
 
       - name: Slack notification — failure
@@ -72,5 +72,5 @@ jobs:
           payload: |
             {
               "channel": "${{ env.SLACK_CHANNEL }}",
-              "text": "Docs build failed for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+              "text": "Docs build failed for [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})."
             }


### PR DESCRIPTION
this is a totally superficial change, but it should render the slack notifications in the `#docs-builds` channel a little nicer 🤞🏻 