### PR TITLE
Correct Partition Field(s) in the Hubble data dictionary

### DIFF
--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/account-signers-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/account-signers-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | account_id, signer, closed_at |
-| Partition Field(s) | batch_run_date (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | account_id, signer, last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.account_signers_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/accounts-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/accounts-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | account_id, closed_at |
-| Partition Field(s) | batch_run_date (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | account_id, last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.accounts_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/claimable-balances-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/claimable-balances-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | balance_id, closed_at |
-| Partition Field(s) | batch_run_date (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | asset_id, last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.claimable_balances_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/config-settings-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/config-settings-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | config_setting_id, closed_at |
-| Partition Field(s) | closed_at (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.config_settings_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/contract-code-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/contract-code-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | contract_code_hash, closed_at |
-| Partition Field(s) | closed_at (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | last_modified_ledger, contract_code_hash |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.contract_code_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/contract-data-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/contract-data-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | ledger_key_hash, closed_at |
-| Partition Field(s) | closed_at (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | last_modified_ledger, contract_id |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.contract_data_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/enriched-history-operations-soroban.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/enriched-history-operations-soroban.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | op_id |
-| Partition Field(s) | closed_at (MONTH partition) |
+| Partition Field(s) | closed_at (DAY partition) |
 | Clustered Field(s) | ledger_sequence, transaction_id, op_account_id, type |
 | Documentation | [dbt_docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.enriched_history_operations_soroban) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/enriched-history-operations.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/enriched-history-operations.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | op_id |
-| Partition Field(s) | closed_at (MONTH partition) |
+| Partition Field(s) | closed_at (DAY partition) |
 | Clustered Field(s) | ledger_sequence, transaction_id, op_account_id, type |
 | Documentation | [dbt_docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.enriched_history_operations) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/liquidity-pools-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/liquidity-pools-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | liquidity_pool_id, closed_at |
-| Partition Field(s) | batch_run_date (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | liquidity_pool_id, asset_a_id, asset_b_id, last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.liquidity_pools_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/offers-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/offers-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | offer_id, closed_at |
-| Partition Field(s) | batch_run_date (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | selling_asset_id, buying_asset_id, last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.offers_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/trustlines-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/trustlines-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | account_id, asset_type, asset_issuer, asset_code, liquidity_pool_id, closed_at |
-| Partition Field(s) | batch_run_date (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | account_id, asset_id, liquidity_pool_id, last_modified_ledger |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.trust_lines_current) |
 

--- a/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/ttl-current.mdx
+++ b/docs/data/analytics/hubble/data-catalog/data-dictionary/silver/ttl-current.mdx
@@ -11,7 +11,7 @@ description: ""
 | Property | Configuration |
 | --- | --- |
 | Natural Key(s) | key_hash, closed_at |
-| Partition Field(s) | closed_at (MONTH partition) |
+| Partition Field(s) | N/A |
 | Clustered Field(s) | last_modified_ledger, key_hash |
 | Documentation | [dbt docs](http://www.stellar-dbt-docs.com/#!/model/model.stellar_dbt_public.ttl_current) |
 


### PR DESCRIPTION
### What

Corrects 12 `Partition Field(s)` entries in the Hubble data dictionary that don't match the tables in BigQuery.

### How this was verified

Every `Partition Field(s)` entry in `bronze/`, `silver/` and `gold/` was checked against BigQuery — `INFORMATION_SCHEMA.TABLES.ddl` across `crypto-stellar.crypto_stellar`, `crypto_stellar_dbt`, `crypto_stellar_raw` and `snapshots`, plus `bq show` on the tables whose partitioning changed. Each page was resolved to its table via the dbt-docs link the page itself declares, not by guessing from the filename — that matters, e.g. `bronze/history-assets` documents `history_assets_staging` (correctly `batch_run_date` MONTH), not `history_assets`.

**29 of the 41 entries are correct and are left untouched.**

### The 12 corrections

**Ten `*_current` tables are not partitioned at all** — documented as MONTH-partitioned on `batch_run_date` or `closed_at`:

`accounts-current`, `account-signers-current`, `claimable-balances-current`, `config-settings-current`, `contract-code-current`, `contract-data-current`, `liquidity-pools-current`, `offers-current`, `trustlines-current`, `ttl-current`

Two independent signals agree: the dbt models declare no `partition_by`, and BigQuery reports no partitioning on any of the ten. This one has a real cost consequence — anyone adding `where batch_run_date >= ...` to bound spend on these tables was getting no partition pruning from it.

**Two tables were repartitioned MONTH → DAY** on `closed_at` on 2026-07-29, making the existing entries stale:

`enriched-history-operations`, `enriched-history-operations-soroban`

### Scope

Partitioning only, as a single-cell change per page.

While verifying, I also noticed the `Clustered Field(s)` entries on the `*_current` pages are out of date — `accounts-current` lists `account_id, last_modified_ledger` for a table with no clustering, and `trustlines-current` lists four columns where BigQuery has `asset_code, asset_issuer`. I've deliberately left those alone so this PR stays reviewable against a single question. Happy to follow up if useful.

### Note for reviewers

The DAY repartitioning landed the same day this was written, and `enriched_history_operations_day_partitioned` / `enriched_history_operations_soroban_day_partitioned` clones are still sitting in `crypto_stellar_dbt`, so that migration may still be in progress. Worth a sanity check that DAY is the intended end state for both tables before merging.
