### PR TITLE
Wrap @theme-original/Root so the markdown plugin keeps its injection

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,4 +1,5 @@
 import React, { type ReactNode } from 'react';
+import Root from '@theme-original/Root';
 
 import ForAgentsPanel from '@site/src/components/ForAgentsPanel';
 
@@ -10,12 +11,18 @@ interface Props {
  * `Root` wraps the whole app above the router, so anything rendered here
  * survives client-side navigation. That is what the "For agents" panel needs:
  * one instance for the entire site rather than one per page (#2586).
+ *
+ * This must WRAP `@theme-original/Root`, not replace it:
+ * `docusaurus-markdown-source-plugin` ships its own Root, which injects the
+ * "Open Markdown" dropdown and the hash-scroll behavior on docs pages. A
+ * user-land Root shadows it outright, which is exactly the regression that
+ * removed the button site-wide (#2712).
  */
-export default function Root({ children }: Props): ReactNode {
+export default function RootWrapper({ children }: Props): ReactNode {
   return (
-    <>
+    <Root>
       {children}
       <ForAgentsPanel />
-    </>
+    </Root>
   );
 }


### PR DESCRIPTION
Closes #2712.

## Root cause

`docusaurus-markdown-source-plugin` provides its own `theme/Root.js`, which injects the "Open Markdown" dropdown into the article header and smooth-scrolls to URL hashes. The user-land `src/theme/Root.tsx` added in #2698 (cc @oceans404) shadows the plugin's Root completely, so its injection never ran and the button disappeared from every docs page in production. Evidence and build-by-build comparison in #2712.

## Fix

One-file change: `src/theme/Root.tsx` now wraps `@theme-original/Root` instead of replacing it, following the same wrapper pattern the repo already uses for `DocItem/Footer`, `DocCardList`, and `ApiExplorer`. The plugin's Root keeps running and the "For agents" panel still mounts once above the router.

## Verification

Full `pnpm build` passes with the change. Served the build and checked in a real browser:

- `/docs/build/building-with-ai`: exactly one `.markdown-actions-container` (the button is back) and exactly one "For agents" trigger, no console or page errors.
- Hash navigation (`#stellar-skills`) scrolls to the section, confirming the plugin Root's scroll handling is active again.
- API reference pages unchanged (they get their button from #2644, which is separate).