### PR TITLE
Fix: stale references in the x402 quickstart

### DIFF
--- a/docs/build/agentic-payments/x402/quickstart-guide.mdx
+++ b/docs/build/agentic-payments/x402/quickstart-guide.mdx
@@ -198,7 +198,7 @@ When integrating x402 into your own client, handle the key response states:
 const response = await fetch(protectedUrl, { headers: paymentHeaders });
 
 if (response.status === 402) {
-  const paymentRequired = response.headers.get("X-Payment");
+  const paymentRequired = response.headers.get("PAYMENT-REQUIRED");
   console.error("Payment required:", paymentRequired);
   // Re-initiate payment flow
 } else if (response.status === 200) {
@@ -249,7 +249,7 @@ A trustline tells Stellar your account accepts USDC. Without it, you cannot rece
 
 #### Using Stellar Lab
 
-1. Go to [Transaction Builder](https://laboratory.stellar.org/#txbuilder?network=test)
+1. Go to [Transaction Builder](https://lab.stellar.org/transaction/build)
 2. Enter your public key as source account
 3. Click "Fetch next sequence number"
 4. Add Operation → "Change Trust"
@@ -318,6 +318,7 @@ The server is set up as an MVP for machine-to-machine payments. If you want to e
 - [x402 on Stellar (Blog)](https://stellar.org/blog/foundation-news/x402-on-stellar) - Foundation news and announcement
 - [x402 protocol (Coinbase Developer Platform)](https://docs.cdp.coinbase.com/x402) - Official x402 protocol overview and spec
 - [x402 protocol specification](https://www.x402.org) - x402 Specification and Whitepaper
-- [Coinbase x402 GitHub](https://github.com/coinbase/x402) - Official x402 Protocol GitHub Repo
-- [x402-stellar (npm)](https://www.npmjs.com/package/x402-stellar) - npm package for x402 on Stellar
+- [x402 GitHub](https://github.com/x402-foundation/x402) - Official x402 Protocol GitHub Repo
+- [@x402/stellar (npm)](https://www.npmjs.com/package/@x402/stellar) - npm package for x402 on Stellar
+- [x402-stellar (repo)](https://github.com/stellar/x402-stellar) - Tools, examples, and references for x402 on Stellar
 - [Signing Soroban invocations](../../guides/transactions/signing-soroban-invocations.mdx) - Auth-entry signing and transaction signing on Stellar


### PR DESCRIPTION
Several stale references in the x402 quickstart guide, found while working through it.

**npm package link.** "Learn more" links to [`npmjs.com/package/x402-stellar`](https://www.npmjs.com/package/x402-stellar), an independent third-party package (repo [`mertkaradayi/stellar-x402`](https://github.com/mertkaradayi/stellar-x402), v0.2.0, last published ~8 months ago). The official package is [`@x402/stellar`](https://www.npmjs.com/package/@x402/stellar) — which is what this guide's own install command uses. The [Built on Stellar facilitator page](https://developers.stellar.org/docs/build/agentic-payments/x402/built-on-stellar) already lists the npm package and the repo as separate entries; this applies the same pattern:

```markdown
- [@x402/stellar (npm)](https://www.npmjs.com/package/@x402/stellar) - npm package for x402 on Stellar
- [x402-stellar (repo)](https://github.com/stellar/x402-stellar) - Tools, examples, and references for x402 on Stellar
```

**v1 header in the response-handling example.** The snippet reads `response.headers.get("X-Payment")`. That's the v1 header, renamed `PAYMENT-SIGNATURE` in v2 — and it was a request header, not something present on a 402 response. In v2 the 402 carries `PAYMENT-REQUIRED`, which is what the guide's own client code uses via `getPaymentRequiredResponse`.

**Protocol repo link.** `coinbase/x402` now self-describes as a development fork; the canonical repo is `x402-foundation/x402` under the x402 Foundation.

**Legacy Lab URL.** The trustline step links `laboratory.stellar.org`; the rest of the guide uses `lab.stellar.org`. Updated to `https://lab.stellar.org/transaction/build`.