### PR TITLE
docs(tokens): distinguish SEP-41 from Stellar Asset Contract events

### DIFF
--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -151,8 +151,8 @@ pub trait StellarAssetInterface {
     ///
     /// # Events
     ///
-    /// Emits an event with topics `["set_admin", admin: Address], data =
-    /// [new_admin: Address]`
+    /// Emits an event with topics `["set_admin", admin: Address,
+    /// sep0011_asset: String], data = new_admin: Address`
     fn set_admin(env: Env, new_admin: Address);
 
     /// Returns the admin of the contract.

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -194,7 +194,7 @@ The `approve` function overwrites the previous value with `amount`, so it is pos
 
 ### Events: SEP-41 Tokens vs. Stellar Asset Contracts
 
-The event shapes in the interface above are the ones a SEP-41 contract token emits. A [Stellar Asset Contract](./stellar-asset-contract.mdx) — the built-in contract every Stellar asset has — emits the same event names with **one extra topic**: the asset's SEP-11 identifier, always last.
+The event shapes in the interface above are the ones a SEP-41 contract token emits. A [Stellar Asset Contract](./stellar-asset-contract.mdx) — the built-in contract every Stellar asset has — emits the same event names with **one extra topic**: the asset's [SEP-11](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md) identifier, always last.
 
 Code written against the shapes above will therefore mis-parse an event emitted by a Stellar Asset Contract, reading the asset identifier as a missing field or ignoring it entirely.
 
@@ -208,9 +208,11 @@ Code written against the shapes above will therefore mis-parse an event emitted 
 | `set_authorized` | not part of this interface | `["set_authorized", id, sep0011_asset]` |
 | `set_admin` | not part of this interface | `["set_admin", admin, sep0011_asset]` |
 
-The extra topic does not change the data payload: `amount: i128` for `transfer`, `mint`, `burn`, and `clawback`; `[amount: i128, live_until_ledger: u32]` for `approve`; `authorize: bool` for `set_authorized`; and `new_admin: Address` for `set_admin`. When the destination of a `transfer` or `mint` carries a multiplexing id, the data becomes `{ amount: i128, to_muxed_id }: Map` instead — see [Monitoring Payments as event stream](../build/guides/transactions/send-and-receive-payments.mdx#monitoring-payments-as-event-stream) for a worked example.
+On the Stellar Asset Contract side, the extra topic does not change the data payload: `amount: i128` for `transfer`, `mint`, `burn`, and `clawback`; `[amount: i128, live_until_ledger: u32]` for `approve`; `authorize: bool` for `set_authorized`; and `new_admin: Address` for `set_admin`. When the destination of a Stellar Asset Contract `transfer` or `mint` carries a multiplexing id, the data becomes `{ amount: i128, to_muxed_id }: Map` instead — see [Monitoring Payments as event stream](../build/guides/transactions/send-and-receive-payments.mdx#monitoring-payments-as-event-stream) for a worked example.
 
-:::caution[A STELLAR ASSET CONTRACT TRANSFER DOES NOT ALWAYS EMIT A TRANSFER EVENT]
+A SEP-41 contract token keeps whatever payload the interface above documents for it, so do not carry these payload shapes back across the table.
+
+:::caution[A Stellar Asset Contract transfer does not always emit a transfer event]
 
 When the asset issuer is one side of the transfer, the contract emits a different event: `mint` if `from` is the issuer, `burn` if `to` is the issuer — and the `burn` drops any multiplexing id. You only get a `transfer` event when neither side is the issuer, or when both are. See [Interacting with classic Stellar assets](./stellar-asset-contract.mdx#interacting-with-classic-stellar-assets).
 
@@ -219,6 +221,8 @@ When the asset issuer is one side of the transfer, the contract emits a differen
 #### Telling a classic operation from a contract invocation
 
 Since protocol 23, classic operations emit these same events, published under the asset's Stellar Asset Contract address whether or not that contract has been deployed — see [Tracking the movement of value](../learn/fundamentals/stellar-data-structures/events.mdx#tracking-the-movement-of-value).
+
+Not all of them, though. `approve` and `set_admin` are never emitted by a classic operation, because no classic operation is equivalent to them: allowances and contract administration exist only on the contract side. So those two always come from a contract invocation, and the rest — `transfer`, `mint`, `burn`, `clawback`, and `set_authorized` — can come from either path.
 
 The two paths produce byte-identical events, so nothing inside an event distinguishes them. To tell them apart, join the event back to its operation using `txHash` and `operationIndex`, then read the operation's type. Note that this separates a classic operation from a contract invocation, not a direct call to the asset contract from one made by another contract on a user's behalf — both of those are `InvokeHostFunction` operations emitting the same event.
 

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -192,6 +192,40 @@ The `approve` function overwrites the previous value with `amount`, so it is pos
 
 :::
 
+### Events: SEP-41 Tokens vs. Stellar Asset Contracts
+
+The event shapes in the interface above are the ones a SEP-41 contract token emits. A [Stellar Asset Contract](./stellar-asset-contract.mdx) — the built-in contract every Stellar asset has — emits the same event names with **one extra topic**: the asset's SEP-11 identifier, always last.
+
+Code written against the shapes above will therefore mis-parse an event emitted by a Stellar Asset Contract, reading the asset identifier as a missing field or ignoring it entirely.
+
+| Event | SEP-41 contract token | Stellar Asset Contract |
+| --- | --- | --- |
+| `approve` | `["approve", from, spender]` | `["approve", from, spender, sep0011_asset]` |
+| `transfer` | `["transfer", from, to]` | `["transfer", from, to, sep0011_asset]` |
+| `burn` | `["burn", from]` | `["burn", from, sep0011_asset]` |
+| `mint` | not part of this interface | `["mint", to, sep0011_asset]` |
+| `clawback` | not part of this interface | `["clawback", from, sep0011_asset]` |
+| `set_authorized` | not part of this interface | `["set_authorized", id, sep0011_asset]` |
+| `set_admin` | not part of this interface | `["set_admin", admin, sep0011_asset]` |
+
+The extra topic does not change the data payload: `amount: i128` for `transfer`, `mint`, `burn`, and `clawback`; `[amount: i128, live_until_ledger: u32]` for `approve`; `authorize: bool` for `set_authorized`; and `new_admin: Address` for `set_admin`. When the destination of a `transfer` or `mint` carries a multiplexing id, the data becomes `{ amount: i128, to_muxed_id }: Map` instead — see [Monitoring Payments as event stream](../build/guides/transactions/send-and-receive-payments.mdx#monitoring-payments-as-event-stream) for a worked example.
+
+:::caution[A STELLAR ASSET CONTRACT TRANSFER DOES NOT ALWAYS EMIT A TRANSFER EVENT]
+
+When the asset issuer is one side of the transfer, the contract emits a different event: `mint` if `from` is the issuer, `burn` if `to` is the issuer — and the `burn` drops any multiplexing id. You only get a `transfer` event when neither side is the issuer, or when both are. See [Interacting with classic Stellar assets](./stellar-asset-contract.mdx#interacting-with-classic-stellar-assets).
+
+:::
+
+#### Telling a classic operation from a contract invocation
+
+Since protocol 23, classic operations emit these same events, published under the asset's Stellar Asset Contract address whether or not that contract has been deployed — see [Tracking the movement of value](../learn/fundamentals/stellar-data-structures/events.mdx#tracking-the-movement-of-value).
+
+The two paths produce byte-identical events, so nothing inside an event distinguishes them. To tell them apart, join the event back to its operation using `txHash` and `operationIndex`, then read the operation's type. Note that this separates a classic operation from a contract invocation, not a direct call to the asset contract from one made by another contract on a user's behalf — both of those are `InvokeHostFunction` operations emitting the same event.
+
+If you would rather not do that join yourself, the [Token Transfer Processor](../data/indexers/build-your-own/processors/token-transfer-processor/README.mdx) normalizes both paths into a single stream of typed events.
+
+One event in the unified set has no counterpart here: `fee` is transaction-level, carries only two topics and no asset identifier, and is never emitted by a contract function.
+
 ### Metadata
 
 Another requirement for complying with the token interface is to write the standard metadata (`decimal`, `name`, and `symbol`) for the token in a specific format. This format allows users to directly read constant data from the ledger instead of invoking a Wasm function. The [token example](https://github.com/stellar/soroban-examples/blob/main/token/src/metadata.rs) demonstrates how to use the Rust [soroban-token-sdk](https://github.com/stellar/rs-soroban-sdk/blob/main/soroban-token-sdk/src/lib.rs) to write the metadata, and we strongly encourage token implementations to follow this approach.


### PR DESCRIPTION
Closes #2715.

The token interface page embeds the generic SEP-41 trait, whose event shapes are correct for a contract token and wrong for a Stellar Asset Contract. Nothing on the page said so, so a reader following it alone decodes a SAC event with the generic schema and mis-parses it. Every SAC topic vector carries a trailing `sep0011_asset` identifier.

## What this adds

A new `### Events: SEP-41 Tokens vs. Stellar Asset Contracts` section covering the seven SAC events, the issuer dispatch, and how to separate a classic operation from a contract invocation.

Three things it deliberately does not restate, linking instead:

- the `transfer` topic breakdown and the muxed data map, already in the payments guide;
- protocol-23 classic event emission, already in the events reference;
- `mint`, `clawback`, and `set_authorized`, already correct in the Stellar Asset Contract page's own trait.

The token interface page had no outbound link to the Stellar Asset Contract page at all, so the relationship was documented in one direction only.

## Two wording choices worth reviewing

**"Contract invocation", not "direct SAC".** The issue asks to distinguish direct SAC events from classic ones. The section says "contract invocation" instead, because a contract calling the asset contract on a user's behalf emits an identical event and is the same `InvokeHostFunction` operation. Operation type cannot separate those two, so the claim is scoped to what the metadata actually supports.

**`fee` gets a one-line caveat rather than a table row**, since it is transaction-level, carries no asset topic, and no contract function emits it.

## Second file

This also corrects `set_admin`'s event in `docs/tokens/stellar-asset-contract.mdx`, which omits the `sep0011_asset` topic and renders the data as a vec where the host emits a bare `Address`. Verified against `soroban-env-host` 27.0.1 `builtin_contracts/stellar_asset_contract/event.rs`, where all seven SAC topic constructors end their topic vec in `read_name(e)?`.

That is arguably a second concern. It is here because the new table states the correct shape and the neighbouring page would otherwise state a different one. Happy to split it out if you would rather keep this to one page.

## Verification

- `prettier --config .prettierrc.js -c` on both files: clean
- `docusaurus build`: succeeds, both pages processed, no warnings against either
- `scripts/check-relative-links.sh --range`: "All links check out"
- No routes added or removed
