### PR TITLE
Update the Horizon-to-RPC guide for CAP-67 events that already shipped

### DIFF
--- a/docs/data/apis/migrate-from-horizon-to-rpc.mdx
+++ b/docs/data/apis/migrate-from-horizon-to-rpc.mdx
@@ -27,8 +27,8 @@ Endpoints without mappings do not have a direct replacement in the RPC API. To b
 | [`GET /ledgers/{seq}`] | [`getLedgers`] (with filter for sequence) | Use a [`getLedgers`] view with full history, filtered by ledger sequence | [Ledgers](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#ledgers) |
 | [`GET /ledgers/{seq}/transactions`] | [`getTransactions`] (with filter for ledger sequence) | Use [`getTransactions`] with ledger sequence filtering to retrieve transactions for a specific ledger | [Transactions](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#transactions) |
 | [`GET /ledgers/{seq}/operations`] | [`getTransactions`] | Use [`getTransactions`] for the given ledger, then parse the transaction's XDR for individual operations. | [Operations](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#operations) |
-| [`GET /ledgers/{seq}/payments`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (specifically CAP-67 events when available) and parse [`getTransactions`] meta XDR to identify payment-like operations. | [Payments](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#payments) |
-| [`GET /ledgers/{seq}/effects`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (when expanded to cover all effects with CAP-67) and parse [`getTransactions`] meta XDR for relevant data. | [Effects](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#effects) |
+| [`GET /ledgers/{seq}/payments`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (CAP-67 asset events, emitted since Protocol 23) and parse [`getTransactions`] meta XDR to tie those events back to individual operations. | [Payments](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#payments) |
+| [`GET /ledgers/{seq}/effects`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] for the effects CAP-67 models (asset movement and trustline authorization), and parse [`getTransactions`] meta XDR for every other effect type. | [Effects](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#effects) |
 | [`POST /transactions`] | [`sendTransaction`] | Not applicable | Not applicable |
 | [`POST /transactions_async`] | [`sendTransaction`] | Not applicable | Not applicable |
 | [`GET /transactions`] | [`getTransactions`] | Use [`getTransactions`] to build a historical transaction list | [Transactions](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#transactions) |
@@ -55,8 +55,8 @@ Endpoints without mappings do not have a direct replacement in the RPC API. To b
 | [`GET /offers`] | No direct RPC equivalent | Ingest all ledger history via [`getLedgers`] to build and maintain a complete list of offers. | [Offers](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#offers) |
 | [`GET /offers/{id}`] | [`getLedgerEntries`] | Use [`getLedgerEntries`] to retrieve a specific offer by ID. | [Offers](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#offers) |
 | [`GET /offers/{id}/trades`] | No direct RPC equivalent | Infer trades related to the specific offer ID from historical ledger data (e.g., from [`getEvents`] and [`getTransactions`] metadata). | [Offers](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#offers) |
-| [`GET /payments`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (CAP-67 events) and process [`getTransactions`] metadata for payment-like operations across all history. | [Payments](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#payments) |
-| [`GET /effects`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (when expanded) and process [`getTransactions`] metadata to derive effects across all history. | [Effects](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#effects) |
+| [`GET /payments`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (CAP-67 asset events) and process [`getTransactions`] metadata for payment-like operations across all history. | [Payments](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#payments) |
+| [`GET /effects`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] for the effects CAP-67 models, and process [`getTransactions`] metadata to derive the remaining effect types across all history. | [Effects](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#effects) |
 | [`GET /trades`] | [`getEvents`] [`getTransactions`] ⚠️ | Infer trades from [`getEvents`] and [`getTransactions`] metadata across all history, as there is no direct "trade event" in RPC. | [Trades](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#trades) |
 
 :::tip
@@ -69,9 +69,9 @@ The [`getTransactions`] method can be used to retrieve events batched by transac
 
 The [`getEvents`] method is not a direct replacement for Horizon's endpoints.
 
-The method returns a stream of events that in the current protocol only include events from contracts. In the near future as a result of [CAP-67] this method will be expanded to include events from non-contract operations.
+Since [CAP-67] shipped in Protocol 23, the method returns events from classic operations as well as from contracts. Those unified asset events are emitted as `transfer`, `mint`, `burn`, `clawback`, `fee`, and `set_authorized`, so a single stream now covers the movement of assets and changes to trustline authorization.
 
-In the interim the [`getTransactions`] method can be used to retrieve the meta XDR of transactions containing non-contract operations to determine what movements of value have occurred. The meta XDR also contains events from contracts.
+That is still narrower than Horizon's effects. Anything CAP-67 does not model, such as signer updates, data entry changes, sequence number bumps, and offer management, has to come from the meta XDR of the transaction. The [`getTransactions`] method returns that meta XDR (field `resultMetaXdr`), which also contains events from contracts.
 
 :::
 

--- a/docs/data/apis/migrate-from-horizon-to-rpc.mdx
+++ b/docs/data/apis/migrate-from-horizon-to-rpc.mdx
@@ -71,7 +71,7 @@ The [`getEvents`] method is not a direct replacement for Horizon's endpoints.
 
 Since [CAP-67] shipped in Protocol 23, the method can return events from classic operations as well as from contracts. Those unified asset events are emitted as `transfer`, `mint`, `burn`, `clawback`, `fee`, and `set_authorized`, so a single stream can cover the movement of assets and changes to trustline authorization.
 
-Classic events are not on by default. They are only present if the Stellar Core instance backing the RPC runs with `EMIT_CLASSIC_EVENTS=true`, and covering ledgers from Protocol 22 and earlier also requires `BACKFILL_STELLAR_ASSET_EVENTS=true`. If you run your own RPC, set both before relying on this mapping. If you use a provider, confirm with them. See [Events](../../learn/fundamentals/stellar-data-structures/events.mdx) for more detail.
+Classic events are not on by default. They are only present if the Stellar Core instance backing the RPC runs with `EMIT_CLASSIC_EVENTS=true`. If you also need to cover ledgers from Protocol 22 and earlier, that additionally requires `BACKFILL_STELLAR_ASSET_EVENTS=true`. If you run your own RPC, set what your history range needs before relying on this mapping. If you use a provider, confirm with them. See [Events](../../learn/fundamentals/stellar-data-structures/events.mdx) for more detail.
 
 That is still narrower than Horizon's effects. Anything CAP-67 does not model, such as signer updates, data entry changes, sequence number bumps, and offer management, has to come from the meta XDR of the transaction. The [`getTransactions`] method returns that meta XDR (field `resultMetaXdr`), which also contains events from contracts.
 

--- a/docs/data/apis/migrate-from-horizon-to-rpc.mdx
+++ b/docs/data/apis/migrate-from-horizon-to-rpc.mdx
@@ -27,7 +27,7 @@ Endpoints without mappings do not have a direct replacement in the RPC API. To b
 | [`GET /ledgers/{seq}`] | [`getLedgers`] (with filter for sequence) | Use a [`getLedgers`] view with full history, filtered by ledger sequence | [Ledgers](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#ledgers) |
 | [`GET /ledgers/{seq}/transactions`] | [`getTransactions`] (with filter for ledger sequence) | Use [`getTransactions`] with ledger sequence filtering to retrieve transactions for a specific ledger | [Transactions](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#transactions) |
 | [`GET /ledgers/{seq}/operations`] | [`getTransactions`] | Use [`getTransactions`] for the given ledger, then parse the transaction's XDR for individual operations. | [Operations](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#operations) |
-| [`GET /ledgers/{seq}/payments`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (CAP-67 asset events, emitted since Protocol 23) and parse [`getTransactions`] meta XDR to tie those events back to individual operations. | [Payments](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#payments) |
+| [`GET /ledgers/{seq}/payments`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] (CAP-67 asset events, available since Protocol 23 on nodes that emit classic events) and parse [`getTransactions`] meta XDR to tie those events back to individual operations. | [Payments](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#payments) |
 | [`GET /ledgers/{seq}/effects`] | [`getEvents`] [`getTransactions`] ⚠️ | Use [`getEvents`] for the effects CAP-67 models (asset movement and trustline authorization), and parse [`getTransactions`] meta XDR for every other effect type. | [Effects](../analytics/hubble/analyst-guide/queries-for-horizon-like-data.mdx#effects) |
 | [`POST /transactions`] | [`sendTransaction`] | Not applicable | Not applicable |
 | [`POST /transactions_async`] | [`sendTransaction`] | Not applicable | Not applicable |
@@ -69,7 +69,9 @@ The [`getTransactions`] method can be used to retrieve events batched by transac
 
 The [`getEvents`] method is not a direct replacement for Horizon's endpoints.
 
-Since [CAP-67] shipped in Protocol 23, the method returns events from classic operations as well as from contracts. Those unified asset events are emitted as `transfer`, `mint`, `burn`, `clawback`, `fee`, and `set_authorized`, so a single stream now covers the movement of assets and changes to trustline authorization.
+Since [CAP-67] shipped in Protocol 23, the method can return events from classic operations as well as from contracts. Those unified asset events are emitted as `transfer`, `mint`, `burn`, `clawback`, `fee`, and `set_authorized`, so a single stream can cover the movement of assets and changes to trustline authorization.
+
+Classic events are not on by default. They are only present if the Stellar Core instance backing the RPC runs with `EMIT_CLASSIC_EVENTS=true`, and covering ledgers from Protocol 22 and earlier also requires `BACKFILL_STELLAR_ASSET_EVENTS=true`. If you run your own RPC, set both before relying on this mapping. If you use a provider, confirm with them. See [Events](../../learn/fundamentals/stellar-data-structures/events.mdx) for more detail.
 
 That is still narrower than Horizon's effects. Anything CAP-67 does not model, such as signer updates, data entry changes, sequence number bumps, and offer management, has to come from the meta XDR of the transaction. The [`getTransactions`] method returns that meta XDR (field `resultMetaXdr`), which also contains events from contracts.
 


### PR DESCRIPTION
The endpoint table and the `getEvents` warning still described CAP-67 unified asset events as future work ("when available", "when expanded", "in the near future"). CAP-0067 has been Final since Protocol 23 and the networks are on Protocol 27, so readers were told to plan around something they already have.

Puts those spots in the present tense and names what CAP-67 actually covers (`transfer`, `mint`, `burn`, `clawback`, `fee`, `set_authorized`). Keeps the meta XDR path for the effect types it does not model, such as signer updates, data entry changes, and offer management, so this does not overcorrect into implying `getEvents` fully replaces Horizon effects.

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)