### PR TITLE
docs(tokens): cite CAP-0067 as the source for the SAC event shapes

### DIFF
--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -198,6 +198,8 @@ The event shapes in the interface above are the ones a SEP-41 contract token emi
 
 Code written against the shapes above will therefore mis-parse an event emitted by a Stellar Asset Contract, reading the asset identifier as a missing field or ignoring it entirely.
 
+[CAP-0067](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md) is the normative source for the Stellar Asset Contract shapes below, and for the unification of classic events described further down.
+
 | Event | SEP-41 contract token | Stellar Asset Contract |
 | --- | --- | --- |
 | `approve` | `["approve", from, spender]` | `["approve", from, spender, sep0011_asset]` |


### PR DESCRIPTION
Follow-up to #2720, prompted by the deployment recheck in [stellar-experimental/stellar-raven#6](https://github.com/stellar-experimental/stellar-raven/issues/6).

Three of the four markers that finding tracked went from 0 to present on the page. `CAP-67` stayed at 0.

I had left it off on the reasoning that the section links [Tracking the movement of value](../learn/fundamentals/stellar-data-structures/events.mdx) rather than restating protocol-23 emission on a page about the generic interface. Checking it, that reasoning does not hold: **the linked page has zero `CAP-0067` occurrences of its own**, so a reader wanting to check the table against the spec has no path from either page.

Half the original reasoning does stand, which is why this is one sentence rather than a section. Restating classic-op emission mechanics belongs in the events reference, not here. Citing CAP-0067 as the normative source *for the table itself* is a different thing, and sd-018's recommendation names it that way — "CAP-0067 is the normative source for the SAC `transfer`/`burn` shapes and Classic unification."

## Verification

- `prettier -c`: clean
- `scripts/check-relative-links.sh --range`: "All links check out"
- `docusaurus build`: succeeds, page processed, no warnings against it
- Marker count on the page: `sep0011_asset` 7, `clawback` 3, `set_authorized` 3, `CAP-0067` 0 → 1
- No routes added or removed
