### PR TITLE
📝 Simplify README `MethodTable` introductions

### DIFF
--- a/docs/data/apis/horizon/api-reference/errors/README.mdx
+++ b/docs/data/apis/horizon/api-reference/errors/README.mdx
@@ -7,7 +7,7 @@ import { MethodTable } from "@site/src/components/MethodTable";
 
 After processing a request, Horizon returns a success or error response to the client. A success response will return a Status Code of 200, and an error response will return a Status Code in the range of 4XX - 5XX along with additional information about why the request could not complete successfully.
 
-There are two categories of errors: [HTTP Status Codes](./http-status-codes/README.mdx) and [Result Codes](./result-codes/README.mdx). Result Codes only follow a Transaction Failed (400) HTTP Status Code.
+There are two categories of errors:
 
 <MethodTable title="Error Categories">
 
@@ -17,3 +17,5 @@ There are two categories of errors: [HTTP Status Codes](./http-status-codes/READ
 | [Result Codes](./result-codes/README.mdx) | Errors that occur at the Stellar Core level. |
 
 </MethodTable>
+
+Result Codes only follow a Transaction Failed (400) HTTP Status Code.

--- a/docs/data/apis/horizon/api-reference/errors/http-status-codes/README.mdx
+++ b/docs/data/apis/horizon/api-reference/errors/http-status-codes/README.mdx
@@ -13,7 +13,7 @@ Stellar uses conventional HTTP response codes to indicate the success or failure
 - Codes in the 4xx range indicate an error that failed given the information provided
 - Codes in the 5xx range indicate an error with the Horizon server.
 
-There are two types of Status Codes: [Standard Status Codes](./standard.mdx) and [Horizon-Specific Status Codes](./horizon-specific/README.mdx).
+There are two types of Status Codes:
 
 <MethodTable title="HTTP Status Code Types">
 

--- a/docs/data/apis/horizon/api-reference/errors/result-codes/README.mdx
+++ b/docs/data/apis/horizon/api-reference/errors/result-codes/README.mdx
@@ -9,7 +9,7 @@ Result Codes describe why a transaction or operation failed in Stellar Core and 
 
 In the “extras” field, the errors returned are referred to as “Result Codes” and are Horizon’s abstraction of “Stellar Protocol Codes”, which are more specific codes available in the XDR. Result Codes are Horizon’s way of normalizing Stellar Protocol Codes.
 
-There are three types of Result Codes: [Transaction Result Codes](./transactions.mdx), [Operation Result Codes](./operations.mdx), and [Operation-Specific Result Codes](./operation-specific/README.mdx).
+There are three types of Result Codes:
 
 <MethodTable title="Result Code Types">
 

--- a/docs/platforms/anchor-platform/api-reference/platform/README.mdx
+++ b/docs/platforms/anchor-platform/api-reference/platform/README.mdx
@@ -5,7 +5,7 @@ sidebar_position: 10
 
 import { MethodTable } from "@site/src/components/MethodTable";
 
-Data on the Anchor Platform is available through two different APIs: A REST API and a JSON-RPC API. Each of these APIs has associated documentation here.
+Data on the Anchor Platform is available through two different APIs:
 
 <MethodTable title="API Types">
 


### PR DESCRIPTION
From https://github.com/stellar/stellar-docs/pull/2672#discussion_r3633503673

There are a few (mostly API) pages that introduce MethodTables which contain functions. In introducing these lists of cards, they repeat the exact information and links in the actual table. This is redundant.