### PR TITLE
Update contract constructor documentation

### DIFF
--- a/docs/build/guides/auth/check-auth-tutorials.mdx
+++ b/docs/build/guides/auth/check-auth-tutorials.mdx
@@ -78,11 +78,13 @@ const TRANSFER_FN: Symbol = symbol_short!("transfer");
 1. Initializes the contract with a list of signers' public keys
 2. Stores the count of signers in the contract's storage
 
+This is done in `__constructor`, which the host invokes once as part of the deployment itself. Setting the signers here rather than in a separate function called after deployment means the account can never exist in a signerless state that someone else could claim by front-running the call.
+
 ```rust
 #[contractimpl]
 impl AccountContract {
 
-    pub fn init(env: Env, signers: Vec<BytesN<32>>) {
+    pub fn __constructor(env: Env, signers: Vec<BytesN<32>>) {
         for signer in signers.iter() {
             env.storage().instance().set(&DataKey::Signer(signer), &());
         }
@@ -298,7 +300,7 @@ const TRANSFER_FN: Symbol = symbol_short!("transfer");
 
 #[contractimpl]
 impl AccountContract {
-    pub fn init(env: Env, signers: Vec<BytesN<32>>) {
+    pub fn __constructor(env: Env, signers: Vec<BytesN<32>>) {
         for signer in signers.iter() {
             env.storage().instance().set(&DataKey::Signer(signer), &());
         }
@@ -464,8 +466,10 @@ fn signer_public_key(e: &Env, signer: &Keypair) -> BytesN<32> {
     signer.public.to_bytes().into_val(e)
 }
 
-fn create_account_contract(e: &Env) -> AccountContractClient {
-    AccountContractClient::new(e, &e.register(AccountContract {}, ()))
+fn create_account_contract(e: &Env, signers: Vec<BytesN<32>>) -> AccountContractClient {
+    // The constructor arguments are passed to `register`, so the account is
+    // deployed with its signers already set.
+    AccountContractClient::new(e, &e.register(AccountContract {}, (signers,)))
 }
 
 fn sign(e: &Env, signer: &Keypair, payload: &BytesN<32>) -> Val {
@@ -492,17 +496,18 @@ fn test_token_auth() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let account_contract = create_account_contract(&env);
-
     let mut signers = [generate_keypair(), generate_keypair()];
     if signers[0].public.as_bytes() > signers[1].public.as_bytes() {
         signers.swap(0, 1);
     }
-    account_contract.init(&vec![
+    let account_contract = create_account_contract(
         &env,
-        signer_public_key(&env, &signers[0]),
-        signer_public_key(&env, &signers[1]),
-    ]);
+        vec![
+            &env,
+            signer_public_key(&env, &signers[0]),
+            signer_public_key(&env, &signers[1]),
+        ],
+    );
 
     let payload = BytesN::random(&env);
     let token = Address::generate(&env);

--- a/docs/build/guides/auth/check-auth-tutorials.mdx
+++ b/docs/build/guides/auth/check-auth-tutorials.mdx
@@ -78,8 +78,6 @@ const TRANSFER_FN: Symbol = symbol_short!("transfer");
 1. Initializes the contract with a list of signers' public keys
 2. Stores the count of signers in the contract's storage
 
-This is done in `__constructor`, which the host invokes once as part of the deployment itself. Setting the signers here rather than in a separate function called after deployment means the account can never exist in a signerless state that someone else could claim by front-running the call.
-
 ```rust
 #[contractimpl]
 impl AccountContract {
@@ -467,8 +465,6 @@ fn signer_public_key(e: &Env, signer: &Keypair) -> BytesN<32> {
 }
 
 fn create_account_contract(e: &Env, signers: Vec<BytesN<32>>) -> AccountContractClient {
-    // The constructor arguments are passed to `register`, so the account is
-    // deployed with its signers already set.
     AccountContractClient::new(e, &e.register(AccountContract {}, (signers,)))
 }
 

--- a/docs/build/guides/auth/contract-authorization.mdx
+++ b/docs/build/guides/auth/contract-authorization.mdx
@@ -350,7 +350,9 @@ fn test_account() {
 
    ...
 
-   account_contract.init(&signer.public.to_bytes().into_val(&env));
+   let public_key: BytesN<32> = signer.public.to_bytes().into_val(&env);
+   let contract_id = env.register(SimpleAccount, SimpleAccountArgs::__constructor(&public_key));
+   let account_contract = SimpleAccountClient::new(&env, &contract_id);
 
    env.try_invoke_contract_check_auth::<Error>(
       &account_contract.address,

--- a/docs/build/guides/storage/choosing-the-right-storage.mdx
+++ b/docs/build/guides/storage/choosing-the-right-storage.mdx
@@ -107,9 +107,7 @@ pub enum DataKey {
 
 #[contractimpl]
 impl LoyaltyPointsContract {
-    // Set the administrator address. `__constructor` is invoked by the host as
-    // part of the deployment itself (since protocol 22), so the admin is set
-    // atomically with the contract's creation and cannot be front-run.
+    // Initialize a contract with the administrator address.
     pub fn __constructor(env: Env, admin: Address) {
         env.storage().instance().set(&DataKey::Admin, &admin);
     }

--- a/docs/build/guides/storage/choosing-the-right-storage.mdx
+++ b/docs/build/guides/storage/choosing-the-right-storage.mdx
@@ -107,9 +107,10 @@ pub enum DataKey {
 
 #[contractimpl]
 impl LoyaltyPointsContract {
-    // Initialize a contract with the administrator address.
-    // Note, that since protocol 22 this should be `__constructor` instead.
-    pub fn init(env: Env, admin: Address) {
+    // Set the administrator address. `__constructor` is invoked by the host as
+    // part of the deployment itself (since protocol 22), so the admin is set
+    // atomically with the contract's creation and cannot be front-run.
+    pub fn __constructor(env: Env, admin: Address) {
         env.storage().instance().set(&DataKey::Admin, &admin);
     }
 

--- a/docs/build/smart-contracts/example-contracts/bls-signature.mdx
+++ b/docs/build/smart-contracts/example-contracts/bls-signature.mdx
@@ -33,7 +33,7 @@ It is good to have an understanding of how a contract account works, so walk thr
 
 [open-in-github-codespaces]: https://github.com/codespaces/new?repo=stellar/soroban-examples&editor=web
 [open-in-code-anywhere]: https://app.codeanywhere.com/#https://github.com/stellar/soroban-examples
-[BLS signature example]: https://github.com/stellar/soroban-examples/tree/v23.0.0/bls_signature
+[BLS signature example]: https://github.com/stellar/soroban-examples/tree/main/bls_signature
 [Complex Account example]: ./complex-account.mdx
 [Simple Account example]: ./simple-account.mdx
 
@@ -84,12 +84,12 @@ Implementing a production-safe signature scheme requires deep understanding of t
 
 ## Run the Example
 
-First go through the [Setup] process to get your development environment configured, then clone the `v23.0.0` tag of `soroban-examples` repository:
+First go through the [Setup] process to get your development environment configured, then clone the `main` branch of `soroban-examples` repository:
 
 [setup]: ../getting-started/setup.mdx
 
 ```
-git clone -b v23.0.0 https://github.com/stellar/soroban-examples
+git clone -b main https://github.com/stellar/soroban-examples
 ```
 
 Or, skip the development environment setup and open this example in [GitHub Codespaces][open-in-github-codespaces] or [Code Anywhere][open-in-code-anywhere].
@@ -137,7 +137,7 @@ pub enum AccError {
 
 #[contractimpl]
 impl IncrementContract {
-    pub fn init(env: Env, agg_pk: BytesN<96>) {
+    pub fn __constructor(env: Env, agg_pk: BytesN<96>) {
         // Initialize the account contract essentials: the aggregated pubkey and
         // the DST. Because the message to be signed (which is
         // the hash of some call stack) is the same for all signers, we can
@@ -160,7 +160,7 @@ impl IncrementContract {
     }
 }
 
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl CustomAccountInterface for IncrementContract {
     type Signature = BytesN<192>;
 
@@ -202,7 +202,7 @@ impl CustomAccountInterface for IncrementContract {
 }
 ```
 
-Ref: https://github.com/stellar/soroban-examples/tree/v23.0.0/bls_signature
+Ref: https://github.com/stellar/soroban-examples/tree/main/bls_signature
 
 ## How it Works
 
@@ -226,7 +226,7 @@ pub enum DataKey {
 
 #[contractimpl]
 impl IncrementContract {
-    pub fn init(env: Env, agg_pk: BytesN<96>) {
+    pub fn __constructor(env: Env, agg_pk: BytesN<96>) {
         // Initialize the account contract essentials: the aggregated pubkey and
         // the DST. Because the message to be signed (which is
         // the hash of some call stack) is the same for all signers, we can
@@ -250,14 +250,14 @@ impl IncrementContract {
 }
 ```
 
-This contract is fairly simple and standard. On `init()`, it initializes the aggregate public key of all the owners, the domain separation tag `DST`, and initializes the counter to 0.
+This contract is fairly simple and standard. On `__constructor()`, which the host invokes at deployment, it initializes the aggregate public key of all the owners, the domain separation tag `DST`, and initializes the counter to 0.
 
 It contains a single function `increment` which calls `require_auth` that will check the authorization condition defined later, and if success, increment and return the counter.
 
 ### BLS Signature verification
 
 ```rust
-#[contractimpl]
+#[contractimpl(contracttrait)]
 impl CustomAccountInterface for IncrementContract {
     type Signature = BytesN<192>;
 
@@ -311,7 +311,7 @@ To perform the signature verification, we construct two vectors `Vec<G1Affine>` 
 
 Open the [`bls_signature/src/test.rs`] file to follow along.
 
-[`bls_signature/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/v23.0.0/bls_signature/src/test.rs
+[`bls_signature/src/test.rs`]: https://github.com/stellar/soroban-examples/tree/main/bls_signature/src/test.rs
 
 ```rust title="bls_signature/src/test.rs"
 #[test]
@@ -320,8 +320,8 @@ fn test() {
     let pk = aggregate_pk_bytes(&env);
     env.mock_all_auths();
 
-    let client = create_client(&env);
-    client.init(&pk);
+    let contract_id = env.register(IncrementContract, IncrementContractArgs::__constructor(&pk));
+    let client = IncrementContractClient::new(&env, &contract_id);
     let payload = BytesN::random(&env);
     let sig_val = sign_and_aggregate(&env, &payload.clone().into()).to_val();
 

--- a/docs/learn/fundamentals/contract-development/contract-interactions/cross-contract.mdx
+++ b/docs/learn/fundamentals/contract-development/contract-interactions/cross-contract.mdx
@@ -4,19 +4,9 @@ title: Cross-Contract
 description: Interact with a Soroban contract from within another Soroban contract.
 ---
 
-A cross-contract invocation is a powerful (yet expensive) kind of contract interaction. A contract invocation is similar to starting a new process because the code that runs will be in a separate address space, meaning that they do not share any data other than what was passed in the invocation. While a contract invocation typically transfers control to a _different_ contract, it is possible to transfer control to the currently running contract. Regardless of whether the contract that receives control is a different contract or the currently running contract, `env.current_contract_address()` inside the invoked function returns the address of the contract that received control, not the address of the contract that made the call. A contract invocation can only access the public methods of a contract.
+A cross-contract invocation is a powerful (yet expensive) kind of contract interaction. A contract invocation is similar to starting a new process because the code that runs will be in a separate address space, meaning that they do not share any data other than what was passed in the invocation. While a contract invocation typically transfers control to a _different_ contract, it is possible to transfer control to the currently running contract. Regardless of whether the contract that receives control is a different contract or the currently running contract, the value returned by `get_invoking_contract` will be the previous value of `get_current_contract`. A contract invocation can only access the public methods of a contract.
 
-## Calling a contract's functions
-
-The `#[contractimpl]` macro generates a `Client` for each contract, and that client is how a contract's public functions are called from another contract. For example, the [liquidity pool example contract] moves tokens by constructing a client for the token contract and calling `transfer` on it:
-
-```rust
-token::Client::new(&e, &get_token_a(&e)).transfer(&to, &e.current_contract_address(), &amount);
-```
-
-## Constructors are not invocations
-
-A contract's `__constructor` is the one public function you do _not_ call this way. The host invokes it exactly once, as part of the deployment itself, so it never appears on a client. The [token example contract] declares one to set its admin and metadata:
+One public function is an exception: a contract's `__constructor` is invoked by the host at deployment, rather than by another contract. For example, the [token example contract] sets its admin and metadata in a constructor:
 
 ```rust
 #[contractimpl]
@@ -24,7 +14,7 @@ impl Token {
     pub fn __constructor(e: Env, admin: Address, decimal: u32, name: String, symbol: String) {
 ```
 
-A contract that deploys a token therefore passes those arguments to `deploy_v2`, which deploys the contract and runs its constructor in the same invocation:
+So instead of being invoked like other functions, its arguments are passed to `deploy_v2`, which deploys the contract and runs its constructor in the same invocation:
 
 ```rust
 e.deployer()
@@ -32,10 +22,13 @@ e.deployer()
     .deploy_v2(token_wasm_hash, (admin, decimal, name, symbol))
 ```
 
-Doing the setup in a constructor rather than in an ordinary `initialize` function called after deployment means there is no window in which a deployed-but-unconfigured contract exists, and so nothing for a third party to front-run.
+In tests, the same arguments are passed to `register`:
 
-For a fuller treatment of calling other contracts, including error handling and importing a contract's Wasm, see [Making cross-contract calls].
+```rust
+e.register(Token {}, (admin, decimal, name, symbol))
+```
 
-[liquidity pool example contract]: ../../../../build/smart-contracts/example-contracts/liquidity-pool.mdx
+For calling a contract's other functions, see [Making cross-contract calls].
+
 [token example contract]: ../../../../build/smart-contracts/example-contracts/tokens.mdx
 [making cross-contract calls]: ../../../../build/guides/conventions/cross-contract.mdx

--- a/docs/learn/fundamentals/contract-development/contract-interactions/cross-contract.mdx
+++ b/docs/learn/fundamentals/contract-development/contract-interactions/cross-contract.mdx
@@ -4,22 +4,38 @@ title: Cross-Contract
 description: Interact with a Soroban contract from within another Soroban contract.
 ---
 
-A cross-contract invocation is a powerful (yet expensive) kind of contract interaction. A contract invocation is similar to starting a new process because the code that runs will be in a separate address space, meaning that they do not share any data other than what was passed in the invocation. While a contract invocation typically transfers control to a _different_ contract, it is possible to transfer control to the currently running contract. Regardless of whether the contract that receives control is a different contract or the currently running contract, the value returned by `get_invoking_contract` will be the previous value of `get_current_contract`. A contract invocation can only access the public methods of a contract.
+A cross-contract invocation is a powerful (yet expensive) kind of contract interaction. A contract invocation is similar to starting a new process because the code that runs will be in a separate address space, meaning that they do not share any data other than what was passed in the invocation. While a contract invocation typically transfers control to a _different_ contract, it is possible to transfer control to the currently running contract. Regardless of whether the contract that receives control is a different contract or the currently running contract, `env.current_contract_address()` inside the invoked function returns the address of the contract that received control, not the address of the contract that made the call. A contract invocation can only access the public methods of a contract.
 
-If a contract contains a public function `f`, then invoking `f` can be done by making a Rust function call to `f::invoke`.
+## Calling a contract's functions
 
-Some contracts, such as the token contract, only export the contract invocation functions. In doing so, they are able to assign those functions friendly names. For example, [initialize](https://github.com/stellar/soroban-token-contract/blob/42380647bb817bf01c739c19286f18be881e0e41/src/contract.rs#L55-L57)
-
-```rust
-#[contractimpl(export_if = "export")]
-impl TokenTrait for Token {
-    fn initialize(e: Env, admin: Identifier, decimal: u32, name: Binary, symbol: Binary) {
-```
-
-is [exported](https://github.com/stellar/soroban-token-contract/blob/42380647bb817bf01c739c19286f18be881e0e41/src/lib.rs#L26) as
+The `#[contractimpl]` macro generates a `Client` for each contract, and that client is how a contract's public functions are called from another contract. For example, the [liquidity pool example contract] moves tokens by constructing a client for the token contract and calling `transfer` on it:
 
 ```rust
-pub use crate::contract::initialize::invoke as initialize;
+token::Client::new(&e, &get_token_a(&e)).transfer(&to, &e.current_contract_address(), &amount);
 ```
 
-This function is then easily [called by the liquidity pool contract](https://github.com/stellar/soroban-examples/blob/4060d3bd5ee7846020b68ee583665a4d4cf4b315/liquidity_pool/src/lib.rs#L164-L171).
+## Constructors are not invocations
+
+A contract's `__constructor` is the one public function you do _not_ call this way. The host invokes it exactly once, as part of the deployment itself, so it never appears on a client. The [token example contract] declares one to set its admin and metadata:
+
+```rust
+#[contractimpl]
+impl Token {
+    pub fn __constructor(e: Env, admin: Address, decimal: u32, name: String, symbol: String) {
+```
+
+A contract that deploys a token therefore passes those arguments to `deploy_v2`, which deploys the contract and runs its constructor in the same invocation:
+
+```rust
+e.deployer()
+    .with_current_contract(salt)
+    .deploy_v2(token_wasm_hash, (admin, decimal, name, symbol))
+```
+
+Doing the setup in a constructor rather than in an ordinary `initialize` function called after deployment means there is no window in which a deployed-but-unconfigured contract exists, and so nothing for a third party to front-run.
+
+For a fuller treatment of calling other contracts, including error handling and importing a contract's Wasm, see [Making cross-contract calls].
+
+[liquidity pool example contract]: ../../../../build/smart-contracts/example-contracts/liquidity-pool.mdx
+[token example contract]: ../../../../build/smart-contracts/example-contracts/tokens.mdx
+[making cross-contract calls]: ../../../../build/guides/conventions/cross-contract.mdx

--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -402,12 +402,10 @@ pub trait VaultTrait {
 struct Vault;
 
 // `__constructor` is an inherent function on the contract type rather than part
-// of `VaultTrait`. The host invokes it once, as part of the deployment itself,
-// so the vault's reserves and share token are set up atomically with its
-// creation — there is no window in which a deployed-but-unconfigured vault
-// exists for someone else to configure.
+// of `VaultTrait`, because the host invokes it directly at deployment.
 #[contractimpl]
 impl Vault {
+    // Sets the token contract addresses for this vault
     pub fn __constructor(e: Env, token_wasm_hash: BytesN<32>, token: Address) {
         // The share token's admin and metadata are passed straight to its
         // `__constructor`, so it is deployed and initialized in a single step.
@@ -501,9 +499,6 @@ fn create_vault_contract<'a>(
     token_wasm_hash: &BytesN<32>,
     token: &Address,
 ) -> VaultClient<'a> {
-    // The constructor arguments are passed to `register`, which invokes
-    // `__constructor` as part of registering the contract — the same way a
-    // deploy does on a real network.
     VaultClient::new(
         e,
         &e.register(crate::Vault {}, (token_wasm_hash.clone(), token.clone())),
@@ -1029,7 +1024,7 @@ stellar contract upload \
 
 <TabItem value="deploy vault" label="deploy_vault.sh">
 
-Everything after the `--` is passed to the vault's `__constructor`, so the vault is deployed and configured in one transaction. Note that this means `upload.sh` must be run first, to get the token Wasm hash.
+Everything after the `--` is passed to the vault's `__constructor`, so `upload.sh` must be run first to get the token Wasm hash.
 
 ```bash
 stellar contract deploy \
@@ -1134,7 +1129,7 @@ We should receive an output with the token contract ID. We will need this ID for
 CBYMG7OPIT67AG4S2FZU7LAYCXUSXEHRGHLDE6H26VCVWNOV7QUQTGNU
 ```
 
-The vault's constructor deploys the share token for us, so before we can deploy the vault we need the Wasm hash of the token contract. We can get it by running the `upload.sh` script.
+Next, we need to get the Wasm hash of the token contract, which is an argument to the vault's constructor. We can do this by running the `upload.sh` script.
 
 ```bash
 stellar contract upload \
@@ -1150,7 +1145,7 @@ We should receive the Wasm hash of the token contract.
 6b7e4bfbf47157a12e24e564efc1f9ac237e7ae6d7056b6c2ab47178b9e7a510
 ```
 
-Now we can deploy the vault contract by running the `deploy_vault.sh` script, passing the token Wasm hash and the token contract address after the `--`. Those are the vault's constructor arguments, so the vault is deployed and configured in a single transaction — there is no separate initialization step, and therefore nothing for anyone else to front-run.
+Now we can deploy the vault contract by running the `deploy_vault.sh` script, passing the token Wasm hash and the token contract address after the `--` as the constructor arguments.
 
 ```bash
 stellar contract deploy \
@@ -1163,7 +1158,7 @@ stellar contract deploy \
     --token <TOKEN_CONTRACT_ADDRESS>
 ```
 
-We should receive an output with the vault contract ID. We will need this ID for the steps that follow.
+We should receive an output with the vault contract ID. We will need this ID for the next step.
 
 ```bash
 CBBPLE6TGYOMO5HUF2AMYLSYYXM2VYZVAVYI5QCCM5OCFRZPBE2XA53F

--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -383,9 +383,6 @@ contractmeta!(
 );
 
 pub trait VaultTrait {
-    // Sets the token contract addresses for this vault
-    fn initialize(e: Env, token_wasm_hash: BytesN<32>, token: Address);
-
     // Returns the token contract address for the vault share token
     fn share_id(e: Env) -> Address;
 
@@ -404,9 +401,14 @@ pub trait VaultTrait {
 #[contract]
 struct Vault;
 
+// `__constructor` is an inherent function on the contract type rather than part
+// of `VaultTrait`. The host invokes it once, as part of the deployment itself,
+// so the vault's reserves and share token are set up atomically with its
+// creation — there is no window in which a deployed-but-unconfigured vault
+// exists for someone else to configure.
 #[contractimpl]
-impl VaultTrait for Vault {
-    fn initialize(e: Env, token_wasm_hash: BytesN<32>, token: Address) {
+impl Vault {
+    pub fn __constructor(e: Env, token_wasm_hash: BytesN<32>, token: Address) {
         // The share token's admin and metadata are passed straight to its
         // `__constructor`, so it is deployed and initialized in a single step.
         let share_contract_id = create_contract(
@@ -424,7 +426,10 @@ impl VaultTrait for Vault {
         put_total_shares(&e, 0);
         put_reserve(&e, 0);
     }
+}
 
+#[contractimpl]
+impl VaultTrait for Vault {
     fn share_id(e: Env) -> Address {
         get_token_share(&e)
     }
@@ -496,9 +501,13 @@ fn create_vault_contract<'a>(
     token_wasm_hash: &BytesN<32>,
     token: &Address,
 ) -> VaultClient<'a> {
-    let vault = VaultClient::new(e, &e.register(crate::Vault {}, ()));
-    vault.initialize(token_wasm_hash, token);
-    vault
+    // The constructor arguments are passed to `register`, which invokes
+    // `__constructor` as part of registering the contract — the same way a
+    // deploy does on a real network.
+    VaultClient::new(
+        e,
+        &e.register(crate::Vault {}, (token_wasm_hash.clone(), token.clone())),
+    )
 }
 
 fn install_token_wasm(e: &Env) -> BytesN<32> {
@@ -1020,26 +1029,15 @@ stellar contract upload \
 
 <TabItem value="deploy vault" label="deploy_vault.sh">
 
+Everything after the `--` is passed to the vault's `__constructor`, so the vault is deployed and configured in one transaction. Note that this means `upload.sh` must be run first, to get the token Wasm hash.
+
 ```bash
 stellar contract deploy \
     --wasm target/wasm32v1-none/release/vault.wasm \
     --source-account <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
-    --network-passphrase 'Test SDF Network ; September 2015'
-```
-
-</TabItem>
-
-<TabItem value="initialize vault" label="initialize_vault.sh">
-
-```bash
-stellar contract invoke \
-    --id <VAULT_CONTRACT_ID> \
-    --source-account <SECRET_KEY> \
-    --rpc-url https://soroban-testnet.stellar.org:443 \
     --network-passphrase 'Test SDF Network ; September 2015' \
     -- \
-    initialize \
     --token_wasm_hash 73593275ee3bcacc2aef8d641a1d5108618064bdfff84a826576b8caff395add \
     --token <TOKEN_CONTRACT_ADDRESS>
 ```
@@ -1136,23 +1134,7 @@ We should receive an output with the token contract ID. We will need this ID for
 CBYMG7OPIT67AG4S2FZU7LAYCXUSXEHRGHLDE6H26VCVWNOV7QUQTGNU
 ```
 
-Next, we need to deploy the vault contract. We can do this by running the `deploy_vault.sh` script.
-
-```bash
-stellar contract deploy \
-    --wasm target/wasm32v1-none/release/vault.wasm \
-    --source-account <SECRET_KEY> \
-    --rpc-url https://soroban-testnet.stellar.org:443 \
-    --network-passphrase 'Test SDF Network ; September 2015'
-```
-
-We should receive an output with the vault contract ID. We will need this ID for the next step.
-
-```bash
-CBBPLE6TGYOMO5HUF2AMYLSYYXM2VYZVAVYI5QCCM5OCFRZPBE2XA53F
-```
-
-Now we need to get the Wasm hash of the token contract. We can do this by running the `upload.sh` script.
+The vault's constructor deploys the share token for us, so before we can deploy the vault we need the Wasm hash of the token contract. We can get it by running the `upload.sh` script.
 
 ```bash
 stellar contract upload \
@@ -1168,21 +1150,26 @@ We should receive the Wasm hash of the token contract.
 6b7e4bfbf47157a12e24e564efc1f9ac237e7ae6d7056b6c2ab47178b9e7a510
 ```
 
-Now we need to initialize the vault contract. We can do this by running the `initialize_vault.sh` script and passing in the token contract ID and token contract Wasm hash.
+Now we can deploy the vault contract by running the `deploy_vault.sh` script, passing the token Wasm hash and the token contract address after the `--`. Those are the vault's constructor arguments, so the vault is deployed and configured in a single transaction — there is no separate initialization step, and therefore nothing for anyone else to front-run.
 
 ```bash
-stellar contract invoke \
-    --id <VAULT_CONTRACT_ID> \
+stellar contract deploy \
+    --wasm target/wasm32v1-none/release/vault.wasm \
     --source-account <SECRET_KEY> \
     --rpc-url https://soroban-testnet.stellar.org:443 \
     --network-passphrase 'Test SDF Network ; September 2015' \
     -- \
-    initialize \
     --token_wasm_hash 6b7e4bfbf47157a12e24e564efc1f9ac237e7ae6d7056b6c2ab47178b9e7a510 \
     --token <TOKEN_CONTRACT_ADDRESS>
 ```
 
-After receiving the transaction has been submitted, we will mint some tokens to **both** our User Account and Vault Contract addresses. We can do this by running the `mint.sh` script.
+We should receive an output with the vault contract ID. We will need this ID for the steps that follow.
+
+```bash
+CBBPLE6TGYOMO5HUF2AMYLSYYXM2VYZVAVYI5QCCM5OCFRZPBE2XA53F
+```
+
+Next, we will mint some tokens to **both** our User Account and Vault Contract addresses. We can do this by running the `mint.sh` script.
 
 ```bash
 stellar contract invoke \

--- a/docs/learn/migrate/evm/smart-contract-deployment.mdx
+++ b/docs/learn/migrate/evm/smart-contract-deployment.mdx
@@ -383,6 +383,10 @@ contractmeta!(
 );
 
 pub trait VaultTrait {
+    // Sets the token contract addresses for this vault. The host invokes
+    // `__constructor` as part of the deployment itself.
+    fn __constructor(e: Env, token_wasm_hash: BytesN<32>, token: Address);
+
     // Returns the token contract address for the vault share token
     fn share_id(e: Env) -> Address;
 
@@ -401,12 +405,9 @@ pub trait VaultTrait {
 #[contract]
 struct Vault;
 
-// `__constructor` is an inherent function on the contract type rather than part
-// of `VaultTrait`, because the host invokes it directly at deployment.
 #[contractimpl]
-impl Vault {
-    // Sets the token contract addresses for this vault
-    pub fn __constructor(e: Env, token_wasm_hash: BytesN<32>, token: Address) {
+impl VaultTrait for Vault {
+    fn __constructor(e: Env, token_wasm_hash: BytesN<32>, token: Address) {
         // The share token's admin and metadata are passed straight to its
         // `__constructor`, so it is deployed and initialized in a single step.
         let share_contract_id = create_contract(
@@ -424,10 +425,7 @@ impl Vault {
         put_total_shares(&e, 0);
         put_reserve(&e, 0);
     }
-}
 
-#[contractimpl]
-impl VaultTrait for Vault {
     fn share_id(e: Env) -> Address {
         get_token_share(&e)
     }


### PR DESCRIPTION
### What
Update Soroban documentation and examples to use `__constructor` deployment arguments and `deploy_v2` or `register` instead of post-deployment initialization.

### Why
The existing examples describe the pre-constructor initialization flow, which no longer matches current practices.

Related https://github.com/stellar/soroban-examples/pull/412