### PR TITLE
Update software versions for p27 (Mainnet) and initial p28

### DIFF
--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -12,6 +12,41 @@ Release candidates are software releases that are also released to the [Testnet]
 
 [testnet]: ./README.mdx
 
+## Protocol 27 (Mainnet, July 8, 2026)
+
+### Software
+
+| Software | Version |
+| --- | --- |
+| XDR | `v27.0` |
+| Rust XDR | `27.0.0` |
+| Smart Contract Host Environment | `27.0.1` |
+| Stellar Core | `27.1.0` |
+| Smart Contract Rust SDK | `27.0.6` |
+| Poseidon Rust SDK | `27.0.0` |
+| Stellar CLI | `27.1.0` |
+| Stellar RPC | `v27.1.1` |
+| Stellar Horizon | `v27.0.1` |
+| Stellar Galexie | `v27.0.0` |
+| Stellar Quickstart | `docker pull stellar/quickstart` |
+| Stellar JS Stellar Base | `N/A` (merged into the JS Stellar SDK) |
+| Stellar JS Stellar SDK | `v16.2.0` |
+| Stellar Horizon Client & TxnBuild | `v0.6.1` |
+| Stellar RPC Client | `v27.0.0` |
+| Freighter |  |
+| Laboratory | `N/A` |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |
+| Testnet Network Passphrase | `Test SDF Network ; September 2015` |
+| Mainnet Network Passphrase | `Public Global Stellar Network ; September 2015` |
+
+### Release notes
+
+New features in Zipper, Protocol 27:
+
+- Release Notes: [v27.1.0](https://github.com/stellar/stellar-core/releases/tag/v27.1.0) (recommended) / [v27.0.0](https://github.com/stellar/stellar-core/releases/tag/v27.0.0) (protocol activation)
+- [Protocol 27 Upgrade Guide](https://stellar.org/blog/foundation-news/stellar-zipper-protocol-27-upgrade-guide)
+- Authentication Delegation and Address-Bound Soroban Credentials: [CAP-71](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071.md)
+
 ## Protocol 27 (Testnet, June 18, 2026)
 
 ### Software
@@ -23,16 +58,16 @@ Release candidates are software releases that are also released to the [Testnet]
 | Smart Contract Host Environment | `27.0.0` |
 | Stellar Core | `27.0.0` |
 | Smart Contract Rust SDK | `27.0.2` |
-| Poseidon Rust SDK | `TBD` |
-| Stellar CLI | `TBD` |
+| Poseidon Rust SDK | `27.0.0` |
+| Stellar CLI | `27.0.0` |
 | Stellar RPC | `v27.0.0` |
 | Stellar Horizon | `v27.0.0` |
-| Stellar Galexie | `TBD` |
-| Stellar Quickstart | `TBD` |
-| Stellar JS Stellar Base | `TBD` |
+| Stellar Galexie | `v27.0.0` |
+| Stellar Quickstart | `docker pull stellar/quickstart` |
+| Stellar JS Stellar Base | `N/A` (merged into the JS Stellar SDK) |
 | Stellar JS Stellar SDK | `v16.0.0-rc.2` |
-| Stellar Horizon Client & TxnBuild | `TBD` |
-| Stellar RPC Client | `TBD` |
+| Stellar Horizon Client & TxnBuild | `v0.6.0` |
+| Stellar RPC Client | `v27.0.0` |
 | Freighter |  |
 | Laboratory | `N/A` |
 | Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |

--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -12,6 +12,41 @@ Release candidates are software releases that are also released to the [Testnet]
 
 [testnet]: ./README.mdx
 
+## Protocol 28 (Testnet, TBD)
+
+### Software
+
+| Software | Version |
+| --- | --- |
+| XDR | `TBD` |
+| Rust XDR | `28.0.0` |
+| Smart Contract Host Environment | `28.0.1` |
+| Stellar Core | `TBD` |
+| Smart Contract Rust SDK | `TBD` |
+| Poseidon Rust SDK | `TBD` |
+| Stellar CLI | `TBD` |
+| Stellar RPC | `TBD` |
+| Stellar Horizon | `TBD` |
+| Stellar Galexie | `TBD` |
+| Stellar Quickstart | `TBD` |
+| Stellar JS Stellar Base | `N/A` (merged into the JS Stellar SDK) |
+| Stellar JS Stellar SDK | `v17.0.0-rc.1` |
+| Stellar Horizon Client & TxnBuild | `TBD` |
+| Stellar RPC Client | `TBD` |
+| Freighter |  |
+| Laboratory | `N/A` |
+| Futurenet Network Passphrase | `Test SDF Future Network ; October 2022` |
+| Testnet Network Passphrase | `Test SDF Network ; September 2015` |
+| Mainnet Network Passphrase | `Public Global Stellar Network ; September 2015` |
+
+### Release notes
+
+New features in Adapter, Protocol 28:
+
+- Allow Validators to Vote to Drop the Transaction Set from the Current Ledger: [CAP-83](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0083.md)
+- Externally Managed Contract Executables: [CAP-85](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0085.md)
+- Host Functions for Sparse Symbol-Keyed Map Creation and Unpacking: [CAP-86](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0086.md)
+
 ## Protocol 27 (Mainnet, July 8, 2026)
 
 ### Software


### PR DESCRIPTION
Protocol 27 has been needed on the [Software Versions](https://developers.stellar.org/docs/networks/software-versions) page for a while. Protocol 28 is upcoming.

This PR adds a mainnet entry for 27, and stubs in a protocol 28 entry for testnet, so it's ready when we are announcing the timeline.