### PR TITLE
Fix typo in Hubble visualization overview

### DIFF
--- a/docs/data/analytics/hubble/developer-guide/visualization/overview.mdx
+++ b/docs/data/analytics/hubble/developer-guide/visualization/overview.mdx
@@ -3,4 +3,4 @@ title: "Overview"
 sidebar_position: 0
 ---
 
-There are various ways to visulize data from Hubble. The following section will go through the steps to use [Google's Looker Studio](https://cloud.google.com/looker-studio?hl=en) to help visualize Stellar network data.
+There are various ways to visualize data from Hubble. This section explains how to use [Google's Looker Studio](https://cloud.google.com/looker-studio?hl=en) to visualize Stellar network data.


### PR DESCRIPTION
## Summary

- Fixes the typo `visulize` → `visualize`
- Improves the wording of the Looker Studio introduction
- No technical or functional changes