### PR TITLE
docs: add payments infrastructure page with stellartools

### DIFF
--- a/docs/tools/developer-tools/payments-infrastructure.mdx
+++ b/docs/tools/developer-tools/payments-infrastructure.mdx
@@ -1,0 +1,26 @@
+---
+title: Payments Infrastructure
+description: Tools and platforms for accepting payments, running subscriptions, and paying out on Stellar.
+sidebar_label: Payments Infrastructure
+sidebar_position: 110
+---
+
+# Payments Infrastructure
+
+Payments infrastructure tools help developers accept payments, run recurring billing, and pay out funds on Stellar without building the money-movement layer from scratch. These platforms sit on top of the network and expose higher-level primitives like checkout, subscriptions, and payouts.
+
+### [StellarTools](https://stellartools.dev)
+
+StellarTools is an open-source, Stripe-like payments platform built on Stellar. It lets developers accept crypto payments, run subscriptions, charge by usage, and pay out to local currencies, with payments settling in seconds for fractions of a cent.
+
+Features include:
+
+- One-time and recurring checkout pages, hosted with your own branding
+- Subscription billing with trials, pause, resume, and cancel-at-period-end
+- Customer portal where users manage their own subscriptions and invoices
+- Global payouts to local currencies (NGN, KES, GHS, and more)
+- Real-time webhooks for payment, subscription, and customer events
+- A TypeScript-first SDK (`@stellartools/core`) for React and vanilla JavaScript
+- An MCP server so AI agents can manage customers, payments, and subscriptions
+
+StellarTools is free and [open source](https://github.com/payrouteshq/stellartools). Learn more in the [documentation](https://docs.stellartools.dev).

--- a/docs/tools/developer-tools/payments-infrastructure.mdx
+++ b/docs/tools/developer-tools/payments-infrastructure.mdx
@@ -23,4 +23,4 @@ Features include:
 - A TypeScript-first SDK (`@stellartools/core`) for React and vanilla JavaScript
 - An MCP server so AI agents can manage customers, payments, and subscriptions
 
-StellarTools is free and [open source](https://github.com/payrouteshq/stellartools). Learn more in the [documentation](https://docs.stellartools.dev).
+StellarTools is free and [open source](https://github.com/payrouteshq/stellartools). Learn more in the [StellarTools documentation](https://docs.stellartools.dev).

--- a/routes.txt
+++ b/routes.txt
@@ -768,6 +768,7 @@
 /docs/tools/developer-tools/network-status
 /docs/tools/developer-tools/node-operator-tools
 /docs/tools/developer-tools/online-ide
+/docs/tools/developer-tools/payments-infrastructure
 /docs/tools/developer-tools/security-tools
 /docs/tools/developer-tools/wallets
 /docs/tools/infra-tools


### PR DESCRIPTION
## What

Adds a new **Payments Infrastructure** category page under **Tools → Developer Tools → More Developer Tools**, and lists **StellarTools** as the first entry.

## Why

The docs currently have no home for community-built payments/billing tooling. StellarTools is an open-source, Stripe-like payments platform built on Stellar (checkout, subscriptions, usage-based billing, payouts to local currencies, webhooks, a TypeScript SDK, and an MCP server). It doesn't fit the existing categories 
It isn't a wallet, explorer, anchor tool, or node tool, so this adds a dedicated category in the same spirit as "Payments Infrastructure" that can also house future community payment tools.

## Changes

- New page: `docs/tools/developer-tools/payments-infrastructure.mdx`
- Added a category card to `docs/tools/developer-tools/README.mdx`

## Notes

Happy to adjust the category name or placement 🙌🏽  flagging @leighmcculloch  as the maintainer of the Developer Tools pages for a steer on naming and sidebar ordering.
Also open to cross-linking from the Agentic Payments section given the MCP server, if that's useful.
