### PR TITLE
docs(rpc): add OpenChainBench live RPC benchmark reference

### DIFF
--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -49,4 +49,6 @@ _The "Dedicated Nodes" column represents providers who host full nodes as a serv
 | [Ankr](https://www.ankr.com/rpc/stellar) | Mainnet | Full Archive RPC `https://rpc.ankr.com/stellar_soroban` |
 ## Benchmarks
 
-For live latency comparisons across Stellar RPC providers, see [OpenChainBench](https://openchainbench.com) — an open-source benchmark tracking p50/p90/p99 latency for Stellar RPC providers, probed every minute from 3 global regions (US, EU, Asia).
+For live p50/p90/p99 latency comparisons across Stellar Soroban RPC providers, see the [OpenChainBench Stellar RPC benchmark](https://openchainbench.com/benchmarks/stellar-rpc) — an open-source tracker probing 5 no-key endpoints every 60 seconds from 3 global regions (Virginia, Amsterdam, Singapore).
+
+> **Note:** measurements are best-effort client-side round-trip times from fixed probe origins; actual latency from your application will vary by deployment region and provider routing. p50 is the median (half of requests are faster), p90 means 90% finish within that time, and p99 captures the slowest 1%, useful for spotting tail-latency outliers.

--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -47,3 +47,6 @@ _The "Dedicated Nodes" column represents providers who host full nodes as a serv
 | [Lightsail Network - Quasar](https://quasar.lightsail.network) | Mainnet | RPC `https://rpc.lightsail.network/` |
 |  | Mainnet | Full Archive RPC: `https://archive-rpc.lightsail.network/` |
 | [Ankr](https://www.ankr.com/rpc/stellar) | Mainnet | Full Archive RPC `https://rpc.ankr.com/stellar_soroban` |
+## Benchmarks
+
+For live latency comparisons across Stellar RPC providers, see [OpenChainBench](https://openchainbench.com) — an open-source benchmark tracking p50/p90/p99 latency for Stellar RPC providers, probed every minute from 3 global regions (US, EU, Asia).

--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -47,6 +47,7 @@ _The "Dedicated Nodes" column represents providers who host full nodes as a serv
 | [Lightsail Network - Quasar](https://quasar.lightsail.network) | Mainnet | RPC `https://rpc.lightsail.network/` |
 |  | Mainnet | Full Archive RPC: `https://archive-rpc.lightsail.network/` |
 | [Ankr](https://www.ankr.com/rpc/stellar) | Mainnet | Full Archive RPC `https://rpc.ankr.com/stellar_soroban` |
+
 ## Benchmarks
 
 For live p50/p90/p99 latency comparisons across Stellar Soroban RPC providers, see the [OpenChainBench Stellar RPC benchmark](https://openchainbench.com/benchmarks/stellar-rpc) — an open-source tracker probing 5 no-key endpoints every 60 seconds from 3 global regions (Virginia, Amsterdam, Singapore).

--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -52,4 +52,4 @@ _The "Dedicated Nodes" column represents providers who host full nodes as a serv
 
 For live p50/p90/p99 latency comparisons across Stellar Soroban RPC providers, see the [OpenChainBench Stellar RPC benchmark](https://openchainbench.com/benchmarks/stellar-rpc) — an open-source tracker probing 5 no-key endpoints every 60 seconds from 3 global regions (Virginia, Amsterdam, Singapore).
 
-> **Note:** measurements are best-effort client-side round-trip times from fixed probe origins; actual latency from your application will vary by deployment region and provider routing. p50 is the median (half of requests are faster), p90 means 90% finish within that time, and p99 captures the slowest 1%, useful for spotting tail-latency outliers.
+> **Note:** measurements are best-effort client-side round-trip times from fixed probe origins; actual latency from your application will vary by deployment region and provider routing. p50 is the median (half of requests are faster), p90 means 90% finish within that time, and p99 means 99% finish within that time, useful for spotting tail-latency outliers.


### PR DESCRIPTION
OpenChainBench (https://openchainbench.com) is an open-source benchmark tracking p50/p90/p99 latency for Stellar RPC providers, probed every minute from 3 global regions. Adding a Benchmarks section at the end of the RPC providers page gives developers a live reference when choosing between providers.