### PR TITLE
fix: markdown preview mojibake, admonitions, and lost code blocks

### DIFF
--- a/docs/build/smart-contracts/example-contracts/workspace.mdx
+++ b/docs/build/smart-contracts/example-contracts/workspace.mdx
@@ -179,7 +179,7 @@ Now that we've created a trait in `contract_a_interface`, and implemented it in 
 
 We're creating and implementing an entirely new contract, `ContractB`. We're skipping the trait, and getting right to the contract itself.
 
-::: info
+:::info
 
 Defining the contract interface with a `trait` separately is optional. It's a great way to share the interface of a contract, and a contract client, with multiple contracts in a multi-contract workspace.
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -86,6 +86,9 @@ const config: Config = {
     './src/plugins/route-export/index.ts',
     './src/plugins/analytics-module/index.ts',
     'docusaurus-markdown-source-plugin',
+    // Dumps the .md-twin → source-file map consumed by the postbuild step
+    // that restores <CodeExample> content (scripts/rewrite_md_code_examples.mjs).
+    './src/plugins/markdown-source-map/index.ts',
     [
       "docusaurus-plugin-llms",
       {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,6 +3,11 @@ events { }
 http {
   include mime.types;
 
+  # Serve text responses (notably the raw .md markdown-source copies) with an
+  # explicit charset; without it browsers fall back to Windows-1252 and render
+  # UTF-8 punctuation (em dashes, arrows) as mojibake.
+  charset utf-8;
+
   server {
     root /usr/share/nginx/html;
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "postbuild": "node scripts/rewrite_md_links.mjs && node scripts/rewrite_md_admonitions.mjs",
+    "postbuild": "node scripts/rewrite_md_code_examples.mjs && node scripts/rewrite_md_titles.mjs && node scripts/rewrite_md_links.mjs && node scripts/rewrite_md_admonitions.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "postbuild": "node scripts/rewrite_md_links.mjs",
+    "postbuild": "node scripts/rewrite_md_links.mjs && node scripts/rewrite_md_admonitions.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/rewrite_md_admonitions.mjs
+++ b/scripts/rewrite_md_admonitions.mjs
@@ -1,0 +1,131 @@
+// @ts-check
+/**
+ * Post-build step for the markdown-source feature (see rewrite_md_links.mjs).
+ *
+ * The docusaurus-markdown-source-plugin emits a `.md` twin of every docs page
+ * but passes Docusaurus admonitions (`:::info[Title]` ... `:::`) through
+ * verbatim. That syntax is not standard Markdown, so markdown previews render
+ * the `:::` lines literally.
+ *
+ * This script rewrites admonitions INSIDE the generated `build/**\/*.md` files
+ * to GitHub-style alerts (https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts):
+ *
+ *     :::info[Title]          > [!NOTE]
+ *     Body.           --->    > **Title**
+ *     :::                     > Body.
+ *
+ * which render as colored callouts on GitHub and in common markdown viewers,
+ * and degrade to plain blockquotes elsewhere. Docusaurus admonition types map
+ * to the closest of GitHub's five alert types. Nested admonitions become
+ * nested quotes; admonitions indented inside list items keep their indent.
+ * Lines inside code fences are left untouched so documented admonition syntax
+ * survives.
+ *
+ * It does NOT touch any source file in the repo and does NOT affect the HTML
+ * site — it only post-processes generated build artifacts. It is idempotent:
+ * a converted file contains no admonition lines for a re-run to match.
+ *
+ * Runs automatically via the `postbuild` npm lifecycle hook, so it applies in
+ * CI and the production Docker build alike.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const BUILD_DIR = 'build';
+
+const FENCE_RE = /^\s*(```|~~~)/;
+// ":::type" or ":::type[Title]" (3+ colons for nesting, optional indentation).
+const OPEN_RE = /^([ \t]*):{3,}([a-zA-Z]+)(?:\[(.*)\])?[ \t]*$/;
+// Bare ":::" closing line (3+ colons, optional indentation).
+const CLOSE_RE = /^[ \t]*:{3,}[ \t]*$/;
+
+// Docusaurus admonition type -> closest GitHub alert type.
+const ALERT_TYPE = {
+  note: 'NOTE',
+  info: 'NOTE',
+  tip: 'TIP',
+  important: 'IMPORTANT',
+  warning: 'WARNING',
+  caution: 'CAUTION',
+  danger: 'CAUTION',
+};
+
+/** Convert admonition blocks to GitHub alerts; returns null when unchanged. */
+function convertAdmonitions(content) {
+  let changed = 0;
+  let inFence = false;
+  /** @type {{ indent: string }[]} */
+  const stack = [];
+  const out = [];
+
+  const prefix = () => (stack[0]?.indent ?? '') + '> '.repeat(stack.length);
+
+  for (const line of content.split('\n')) {
+    if (FENCE_RE.test(line)) inFence = !inFence;
+
+    if (!inFence) {
+      const open = line.match(OPEN_RE);
+      if (open) {
+        const [, indent, type, title] = open;
+        stack.push({ indent });
+        out.push(`${prefix()}[!${ALERT_TYPE[type.toLowerCase()] ?? 'NOTE'}]`);
+        if (title) out.push(`${prefix()}**${title}**`);
+        changed++;
+        continue;
+      }
+      if (stack.length > 0 && CLOSE_RE.test(line)) {
+        stack.pop();
+        changed++;
+        continue; // drop the closing line entirely
+      }
+    }
+
+    if (stack.length > 0) {
+      // Blockquote the admonition body (fenced lines included — fences are
+      // valid inside blockquotes). Strip the opener's indent so the body
+      // aligns under the quote marker; blank lines become bare ">".
+      const { indent } = stack[stack.length - 1];
+      const rest = line.startsWith(indent)
+        ? line.slice(indent.length)
+        : line.trimStart();
+      out.push(rest === '' ? prefix().trimEnd() : prefix() + rest);
+      continue;
+    }
+
+    out.push(line);
+  }
+
+  return changed > 0 ? out.join('\n') : null;
+}
+
+/** Recursively collect every *.md file under dir. */
+function collectMd(dir) {
+  return readdirSync(dir, { recursive: true })
+    .map((p) => join(dir, String(p)))
+    .filter((p) => p.endsWith('.md'));
+}
+
+function main() {
+  if (!existsSync(BUILD_DIR)) {
+    console.warn(`[rewrite-md-admonitions] "${BUILD_DIR}/" not found — skipping.`);
+    return;
+  }
+
+  const files = collectMd(BUILD_DIR);
+  let touchedFiles = 0;
+
+  for (const file of files) {
+    const out = convertAdmonitions(readFileSync(file, 'utf8'));
+    if (out !== null) {
+      writeFileSync(file, out);
+      touchedFiles++;
+    }
+  }
+
+  console.log(
+    `[rewrite-md-admonitions] Converted admonitions in ${touchedFiles} of ${files.length} generated markdown file(s).`,
+  );
+}
+
+main();

--- a/scripts/rewrite_md_admonitions.mjs
+++ b/scripts/rewrite_md_admonitions.mjs
@@ -16,8 +16,11 @@
  *
  * which render as colored callouts on GitHub and in common markdown viewers,
  * and degrade to plain blockquotes elsewhere. Docusaurus admonition types map
- * to the closest of GitHub's five alert types. Nested admonitions become
- * nested quotes; admonitions indented inside list items keep their indent.
+ * to the closest of GitHub's five alert types. A synthesized title gets an
+ * empty quote line after it so it doesn't lazily merge into the first body
+ * paragraph. GitHub only renders alerts at the top level, so nested
+ * admonitions and ones indented inside list items become plain blockquotes
+ * with a bold "Type: Title" label instead of a literal "[!TYPE]" marker.
  * Lines inside code fences are left untouched so documented admonition syntax
  * survives.
  *
@@ -34,7 +37,10 @@ import { join } from 'node:path';
 
 const BUILD_DIR = 'build';
 
-const FENCE_RE = /^\s*(```|~~~)/;
+// Code-fence delimiter: 3+ backticks or tildes, optionally indented.
+const FENCE_OPEN_RE = /^\s*(`{3,}|~{3,})/;
+// A closing fence is the delimiter alone — no info string after it.
+const FENCE_CLOSE_RE = /^\s*(`{3,}|~{3,})[ \t]*$/;
 // ":::type" or ":::type[Title]" (3+ colons for nesting, optional indentation).
 const OPEN_RE = /^([ \t]*):{3,}([a-zA-Z]+)(?:\[(.*)\])?[ \t]*$/;
 // Bare ":::" closing line (3+ colons, optional indentation).
@@ -51,10 +57,26 @@ const ALERT_TYPE = {
   danger: 'CAUTION',
 };
 
+// Emoji stand-ins for the admonition icons, used where GitHub alert syntax
+// doesn't render (nested / list-indented admonitions).
+const TYPE_EMOJI = {
+  note: 'ℹ️',
+  info: 'ℹ️',
+  tip: '💡',
+  important: '❗',
+  warning: '⚠️',
+  caution: '⚠️',
+  danger: '🔥',
+};
+
 /** Convert admonition blocks to GitHub alerts; returns null when unchanged. */
 function convertAdmonitions(content) {
   let changed = 0;
-  let inFence = false;
+  /** Delimiter of the code fence we're inside (e.g. "````"), or null. */
+  let fence = null;
+  /** Separate a synthesized title from the next body line with an empty
+   * quote line, so the two don't lazily merge into one paragraph. */
+  let needBlank = false;
   /** @type {{ indent: string }[]} */
   const stack = [];
   const out = [];
@@ -62,20 +84,58 @@ function convertAdmonitions(content) {
   const prefix = () => (stack[0]?.indent ?? '') + '> '.repeat(stack.length);
 
   for (const line of content.split('\n')) {
-    if (FENCE_RE.test(line)) inFence = !inFence;
+    if (fence) {
+      // Per CommonMark, only a bare delimiter of the same character and at
+      // least the opening length closes the fence; anything else (an inner
+      // fence of the other character, a shorter run, or a line with an info
+      // string) is fenced content.
+      const close = line.match(FENCE_CLOSE_RE);
+      if (close && close[1][0] === fence[0] && close[1].length >= fence.length) {
+        fence = null;
+      }
+    } else {
+      const open = line.match(FENCE_OPEN_RE);
+      if (open) fence = open[1];
+    }
 
-    if (!inFence) {
+    if (!fence) {
       const open = line.match(OPEN_RE);
       if (open) {
         const [, indent, type, title] = open;
+        const alert = ALERT_TYPE[type.toLowerCase()] ?? 'NOTE';
+        const topLevel = stack.length === 0 && indent === '';
+        if (needBlank) {
+          out.push(prefix().trimEnd());
+          needBlank = false;
+        }
         stack.push({ indent });
-        out.push(`${prefix()}[!${ALERT_TYPE[type.toLowerCase()] ?? 'NOTE'}]`);
-        if (title) out.push(`${prefix()}**${title}**`);
+        if (topLevel) {
+          out.push(`${prefix()}[!${alert}]`);
+          if (title) {
+            out.push(`${prefix()}**${title}**`);
+            needBlank = true;
+          }
+        } else {
+          // GitHub only renders alerts at the top level; a nested or
+          // list-indented "[!TYPE]" shows up as literal text, so degrade to
+          // a blockquote led by the type's emoji icon and a bold label. The
+          // label keeps the original Docusaurus type name (e.g. "Danger"),
+          // matching the HTML page, since this path isn't limited to
+          // GitHub's alert set.
+          const t = type.toLowerCase();
+          const label = t[0].toUpperCase() + t.slice(1);
+          const emoji = TYPE_EMOJI[t] ?? 'ℹ️';
+          out.push(
+            `${prefix()}${emoji} **${title ? `${label}: ${title}` : label}**`,
+          );
+          needBlank = true;
+        }
         changed++;
         continue;
       }
       if (stack.length > 0 && CLOSE_RE.test(line)) {
         stack.pop();
+        needBlank = false;
         changed++;
         continue; // drop the closing line entirely
       }
@@ -89,7 +149,13 @@ function convertAdmonitions(content) {
       const rest = line.startsWith(indent)
         ? line.slice(indent.length)
         : line.trimStart();
-      out.push(rest === '' ? prefix().trimEnd() : prefix() + rest);
+      if (rest === '') {
+        out.push(prefix().trimEnd());
+      } else {
+        if (needBlank) out.push(prefix().trimEnd());
+        out.push(prefix() + rest);
+      }
+      needBlank = false;
       continue;
     }
 

--- a/scripts/rewrite_md_code_examples.mjs
+++ b/scripts/rewrite_md_code_examples.mjs
@@ -1,0 +1,92 @@
+// @ts-check
+/**
+ * Post-build step for the markdown-source feature (see rewrite_md_links.mjs).
+ *
+ * The docusaurus-markdown-source-plugin cleaner removes unknown paired MDX
+ * components together with their inner content, so the `.md` twin of any
+ * page using <CodeExample> loses its code blocks entirely.
+ *
+ * This script regenerates the twin of every routed source that uses
+ * <CodeExample>: the wrapper tags are unwrapped first — preserving the
+ * fenced code, and turning a `title` attribute into a bold label — and the
+ * result is passed through the upstream plugin's own cleaner, so everything
+ * else is processed identically to the plugin's output.
+ *
+ * The twin-to-source mapping comes from build/.md-source-map.json, written
+ * by src/plugins/markdown-source-map during the build (route metadata is
+ * only available inside Docusaurus). rewrite_md_titles.mjs deletes the map
+ * once it has run.
+ *
+ * MUST run before the other rewrite_md_* steps — the regenerated twins
+ * still need the title, link, and admonition rewrites applied.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  cleanMarkdownForDisplay,
+} = require('docusaurus-markdown-source-plugin/lib/clean-markdown');
+const {
+  transformOutsideCodeFences,
+} = require('docusaurus-markdown-source-plugin/lib/fence-transform');
+
+const SITE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_DIR = join(SITE_DIR, 'build');
+const MAP_PATH = join(BUILD_DIR, '.md-source-map.json');
+
+const CODE_EXAMPLE_RE = /<CodeExample\b([^>]*)>([\s\S]*?)<\/CodeExample>/g;
+const TITLE_ATTR_RE = /\btitle\s*=\s*["']([^"']*)["']/;
+
+function unwrapCodeExamples(content) {
+  // Unwrap outside code fences only, so documentation ABOUT the component
+  // (a literal <CodeExample> inside a fence) is untouched.
+  return transformOutsideCodeFences(content, (segment) =>
+    segment.replace(CODE_EXAMPLE_RE, (_match, attrs, inner) => {
+      const title = attrs.match(TITLE_ATTR_RE);
+      const body = inner.replace(/^\s*\n/, '').replace(/\s+$/, '');
+      return title ? `**${title[1]}:**\n\n${body}` : body;
+    }),
+  );
+}
+
+function main() {
+  if (!existsSync(MAP_PATH)) {
+    console.warn(
+      '[rewrite-md-code-examples] build/.md-source-map.json not found — skipping.',
+    );
+    return;
+  }
+
+  const entries = JSON.parse(readFileSync(MAP_PATH, 'utf8'));
+  let touchedFiles = 0;
+
+  for (const { routePath, sourceFilePath, twinRelPath } of entries) {
+    let content;
+    try {
+      content = readFileSync(join(SITE_DIR, sourceFilePath), 'utf8');
+    } catch {
+      continue;
+    }
+    if (!/<CodeExample\b/.test(content)) continue;
+
+    const routeDir = routePath.endsWith('/')
+      ? routePath
+      : routePath.replace(/[^/]+$/, '');
+    writeFileSync(
+      join(BUILD_DIR, twinRelPath),
+      cleanMarkdownForDisplay(unwrapCodeExamples(content), routeDir),
+      'utf8',
+    );
+    touchedFiles++;
+  }
+
+  console.log(
+    `[rewrite-md-code-examples] Regenerated ${touchedFiles} of ${entries.length} generated markdown file(s) with <CodeExample> content preserved.`,
+  );
+}
+
+main();

--- a/scripts/rewrite_md_titles.mjs
+++ b/scripts/rewrite_md_titles.mjs
@@ -1,0 +1,86 @@
+// @ts-check
+/**
+ * Post-build step for the markdown-source feature (see rewrite_md_links.mjs).
+ *
+ * The docusaurus-markdown-source-plugin strips YAML front matter from the
+ * generated `.md` twins but never re-injects the page title, so every twin
+ * starts abruptly with the first body paragraph while its HTML counterpart
+ * shows the title as an H1.
+ *
+ * This script prepends `# {front matter title}` to each twin, using the
+ * twin-to-source map written by src/plugins/markdown-source-map. Pages
+ * without a front matter `title`, with `hide_title: true`, or whose body
+ * already starts with an H1 are left alone. The map file is deleted
+ * afterwards (this is the last step that consumes it) so it is not deployed.
+ *
+ * MUST run after rewrite_md_code_examples.mjs (which regenerates some twins
+ * from source, discarding earlier edits) and before rewrite_md_links.mjs /
+ * rewrite_md_admonitions.mjs is fine either way — the injected line is plain
+ * markdown that neither step touches.
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  unlinkSync,
+  existsSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SITE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_DIR = join(SITE_DIR, 'build');
+const MAP_PATH = join(BUILD_DIR, '.md-source-map.json');
+
+/** Extract the `title` from a source file's YAML front matter, if any. */
+function frontMatterTitle(source) {
+  const fm = source.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!fm) return null;
+  if (/^hide_title:\s*true\b/m.test(fm[1])) return null;
+  const title = fm[1].match(/^title:[ \t]*(.+?)[ \t]*$/m);
+  if (!title) return null;
+  // Strip surrounding quotes if present.
+  return title[1].replace(/^(["'])(.*)\1$/, '$2');
+}
+
+function main() {
+  if (!existsSync(MAP_PATH)) {
+    console.warn(
+      '[rewrite-md-titles] build/.md-source-map.json not found — skipping.',
+    );
+    return;
+  }
+
+  const entries = JSON.parse(readFileSync(MAP_PATH, 'utf8'));
+  let touchedFiles = 0;
+
+  for (const { sourceFilePath, twinRelPath } of entries) {
+    let source;
+    try {
+      source = readFileSync(join(SITE_DIR, sourceFilePath), 'utf8');
+    } catch {
+      continue;
+    }
+    const title = frontMatterTitle(source);
+    if (!title) continue;
+
+    const twinPath = join(BUILD_DIR, twinRelPath);
+    let twin;
+    try {
+      twin = readFileSync(twinPath, 'utf8');
+    } catch {
+      continue;
+    }
+    if (twin.startsWith('# ')) continue;
+
+    writeFileSync(twinPath, `# ${title}\n\n${twin}`, 'utf8');
+    touchedFiles++;
+  }
+
+  unlinkSync(MAP_PATH);
+  console.log(
+    `[rewrite-md-titles] Injected the page title into ${touchedFiles} of ${entries.length} generated markdown file(s).`,
+  );
+}
+
+main();

--- a/src/plugins/markdown-source-map/index.ts
+++ b/src/plugins/markdown-source-map/index.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { LoadContext, Plugin } from '@docusaurus/types';
+
+// Flatten nested Docusaurus route tree into a flat array
+function flattenRoutes(routes: any[]): any[] {
+  return routes.flatMap((route) => [
+    route,
+    ...(route.routes ? flattenRoutes(route.routes) : []),
+  ]);
+}
+
+// Strip baseUrl prefix from a URL path to get build-relative path
+function stripBaseUrl(urlPath: string, baseUrl: string): string {
+  if (baseUrl !== '/' && urlPath.startsWith(baseUrl)) {
+    return urlPath.slice(baseUrl.length);
+  }
+  return urlPath.startsWith('/') ? urlPath.slice(1) : urlPath;
+}
+
+/**
+ * Companion to docusaurus-markdown-source-plugin: dumps the mapping from
+ * each generated `.md` twin back to its source file, for
+ * scripts/rewrite_md_code_examples.mjs (the `postbuild` npm hook) to consume.
+ *
+ * The regeneration itself cannot live in this plugin: Docusaurus runs all
+ * plugins' postBuild hooks concurrently, so there is no way to reliably run
+ * after docusaurus-markdown-source-plugin has written the twins. Writing the
+ * map is order-independent; the npm `postbuild` hook is guaranteed to run
+ * after the whole build.
+ *
+ * @param context site context, provided by Docusaurus
+ * @returns plugin instance that writes the twin-to-source map
+ */
+export default function markdownSourceMapPlugin(context: LoadContext): Plugin {
+  return {
+    name: 'stellar-docs-markdown-source-map-plugin',
+
+    async postBuild({ outDir, routes, baseUrl }) {
+      const entries = flattenRoutes(routes)
+        .filter((route) => {
+          const src = route.metadata?.sourceFilePath;
+          return src && (src.endsWith('.md') || src.endsWith('.mdx'));
+        })
+        .map((route) => {
+          const markdownUrl = route.path.endsWith('/')
+            ? route.path + 'index.md'
+            : route.path + '.md';
+          return {
+            routePath: route.path,
+            sourceFilePath: route.metadata.sourceFilePath,
+            twinRelPath: stripBaseUrl(markdownUrl, baseUrl),
+          };
+        });
+
+      const outputPath = path.join(outDir, '.md-source-map.json');
+      fs.writeFileSync(outputPath, JSON.stringify(entries, null, 2));
+      console.log(
+        `[markdown-source-map] Wrote ${entries.length} twin-to-source entries to ${path.relative(context.siteDir, outputPath)}`,
+      );
+    },
+  };
+}


### PR DESCRIPTION
### What

- Serve text responses with an explicit `charset=utf-8` so `.md` previews no longer render UTF-8 punctuation (em dashes, arrows, emoji) as mojibake
- 3 new `postbuild` scripts added:
    - `scripts/rewrite_md_admonitions.mjs` rewrites Docusaurus admonitions in the generated `.md` twins to GitHub-style alerts (`:::info[Title]` → `> [!NOTE]` + blockquoted body); nested and list-indented admonitions were also handled.
    - `scripts/rewrite_md_code_examples.mjs` regenerates `.md` twins from their MDX sources, converting `<CodeExample>` blocks to fenced code blocks with bold labels for `title` attributes
    - `scripts/rewrite_md_titles.mjs` prepends the front-matter title as an H1 to `.md` twins that lack one, skipping `hide_title: true` pages
- Add a small local Docusaurus plugin (`src/plugins/markdown-source-map`) that dumps a route → source-file map at build time, since the twin-regeneration scripts need it and plugin `postBuild` hooks run concurrently with no reliable ordering

### Why

The raw `.md` being served had several issues:
- UTF-8 punctuation (em dashes, arrows, emoji) rendered as mojibake
- CodeExample blocks were completely stripped.
- Front-matter titles were missing from some `.md` twins.
- Admonitions were not being rendered