### PR TITLE
Fix vertical alignment in audits tables

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -256,7 +256,7 @@ select[data-testid="example-pairing-select"] {
   }
 }
 
-/* Audits tables: stripe by audit group, tighten sub-audit rows */
+/* Audits tables: group sub-audit rows with their parent audit row */
 .audits-table {
   tr:nth-child(2n) {
     background-color: var(--ifm-table-background);
@@ -266,25 +266,12 @@ select[data-testid="example-pairing-select"] {
     background-color: var(--ifm-table-stripe-background);
   }
 
-  tbody td {
-    padding-bottom: 0.15rem;
-  }
-
-  tbody tr:last-child td {
-    padding-bottom: var(--ifm-table-cell-padding);
-  }
-
   tbody tr:not(:last-child) td {
     border-bottom: 0;
   }
 
-  tr.sub {
-    border-top: 0;
-  }
-
   tr.sub td {
     border-top: 0;
-    padding-top: 0.15rem;
   }
 
   tr.sub td:first-child {
@@ -297,5 +284,13 @@ select[data-testid="example-pairing-select"] {
       left: var(--ifm-table-cell-padding);
       line-height: inherit;
     }
+  }
+
+  /* Prettier wraps long hrefs across source lines, which makes MDX render
+     the link text as a <p>. Keep such cells single-line so their content
+     aligns with the rest of the row. */
+  a > p {
+    display: inline;
+    margin: 0;
   }
 }


### PR DESCRIPTION
Follow-up to #2737. On the audits pages, every "Report" link sat ~10px above its version badge and the rows had uneven heights.

**Root causes**

1. In `soroban-sdk.mdx` the `Report` text sits on its own line inside the `<a>`, so MDX renders it as a block `<p>`. The `<p>`'s 20px bottom margin inflated every row and top-anchored the link text, while the version `<code>` badge (Infima's default `vertical-align: middle`) sat centered in the row.
2. The `.audits-table` vertical padding overrides were asymmetric (main row 12px top / 2.4px bottom, sub rows 2.4/2.4, last row 2.4/12), which with centered cells produced uneven row heights (61.8 / 51.2 / 51.2 / 51.2 / 61.3px) and off-center content in the first and last rows.

The mdx can't be "fixed" by putting the link text on one line — Prettier (`printWidth: 80`) re-splits the long hrefs, re-triggering the `<p>`. So this is a CSS-only change.

**Changes** (`src/css/custom.scss`)

- `.audits-table a > p { display: inline; margin: 0 }` — neutralizes the MDX-injected `<p>` so link cells behave like plain inline links, whatever the source formatting is.
- Removed the asymmetric `padding-top` / `padding-bottom` overrides; all body rows now use the symmetric Infima default (12px).
- Kept the grouping rules (no borders inside a group, ↳ arrow, stripes); dropped the no-op `tr.sub { border-top: 0 }`.

**Verified**

Rendered the page on the local dev server and measured the table geometry in-browser: rows are now uniform (51.9 / 51.4 / 51.4 / 51.4 / 51.4px, previously 61.8 / 51.2 / 51.2 / 51.2 / 61.3px) and the badge, auditor, and report link are vertically centered in every row. Checked light and dark themes; the audits page passes the Prettier check.
