### PR TITLE
Document contractevent sparse map default

### DIFF
--- a/docs/build/guides/events/publish.mdx
+++ b/docs/build/guides/events/publish.mdx
@@ -65,6 +65,12 @@ pub fn events_function(env: Env, invoker: Address, token: Address) {
 }
 ```
 
+:::info[SDK v28 Changes]
+
+As of SDK v28, a data field of an event whose value is void — such as an `Option` field that is `None` — is omitted from the published map when `data_format` is `"map"`, the default, instead of being written with a void value. For example, publishing `Borrow` above with a `None` optional field would produce a map missing that field's key entirely. An event that must keep publishing every field, including ones with a void value, opts out with `#[contractevent(sparse = false)]`. The `sparse` argument only applies to `data_format = "map"`; it is a compile error with `single-value` or `vec`. See the [Rust SDK v28 migration guide] for more detail.
+
+:::
+
 A more realistic example can be found in the way the [token interface] works. For example, the interface requires an event to be published every time the `transfer` function is invoked, with the following information:
 
 ```rust
@@ -85,3 +91,4 @@ pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
 
 [token interface]: ../../../tokens/token-interface.mdx
 [Rust SDK documentation]: https://docs.rs/soroban-sdk/latest/soroban_sdk/_migrating/v23_contractevent/index.html
+[Rust SDK v28 migration guide]: https://docs.rs/soroban-sdk/latest/soroban_sdk/_migrating/v28_contractevent_packing/index.html

--- a/docs/build/smart-contracts/example-contracts/events.mdx
+++ b/docs/build/smart-contracts/example-contracts/events.mdx
@@ -35,6 +35,7 @@ With the release of Whisk, Protocol 23, the syntax for publishing smart contract
 [events example]: https://github.com/stellar/soroban-examples/tree/main/events
 [storing data example]: ../getting-started/storing-data.mdx
 [Rust SDK documentation]: https://docs.rs/soroban-sdk/latest/soroban_sdk/_migrating/v23_contractevent/index.html
+[Publish events from a Rust contract]: ../../guides/events/publish.mdx
 
 ## Run the Example
 
@@ -159,6 +160,8 @@ An event also contains a data object of any value or type including types define
 ```
 
 Event data will, by default, conform to the data structure in the defined `struct`. The `data_format` can also be specified as `vec` or `single-value`. Again, please refer to the [Rust SDK documentation] for more details.
+
+As of SDK v28, a field of the default `map` format whose value is void, such as an `Option` field that is `None`, is omitted from the published map. See [Publish events from a Rust contract] for how to opt out.
 
 ### Publishing
 

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -93,6 +93,9 @@ pub trait TokenInterface {
     /// * topics `["transfer", from: Address, to: Address]`
     /// * data `{ to_muxed_id: Option<u64>, amount: i128 }: Map`
     ///
+    /// As of SDK v28, the `to_muxed_id` key is omitted from the map when it
+    /// is `None`, instead of being present with a void value.
+    ///
     /// Legacy implementations may emit an event with:
     /// * topics `["transfer", from: Address, to: Address]`
     /// * data `amount: i128`


### PR DESCRIPTION
### What
Document that `#[contractevent]` events using the default `map` data format now omit fields with a void value, such as a `None` `Option` field, and how to opt out with `#[contractevent(sparse = false)]`.

### Why
Rust SDK v28 changes this packing behavior as a breaking change (CAP-86, stellar/rs-soroban-sdk#2008), and the events guide, the example-contracts walkthrough, and the SEP-41 token interface spec all described the old behavior of always writing every field.