### PR TITLE
Document account-address fuzzing prototype

### DIFF
--- a/docs/build/smart-contracts/example-contracts/fuzzing.mdx
+++ b/docs/build/smart-contracts/example-contracts/fuzzing.mdx
@@ -640,10 +640,12 @@ Types that implement `SorobanArbitrary` include:
 
 All user-defined contract types, those with the [`contracttype`] attribute, automatically derive `SorobanArbitrary`. Note that `SorobanArbitrary` is only derived when the "testutils" Cargo feature is active. This implies that, in general, to make a Soroban contract fuzzable, the contract crate must define a "testutils" Cargo feature, that feature should turn on the "soroban-sdk/testutils" feature, and the fuzz test, which is its own crate, must turn that feature on.
 
-### Generating Account vs. Contract Addresses
+## Generating Account vs. Contract Addresses
 
-By default, [`Address`]'s prototype, `<Address as SorobanArbitrary>::Prototype`, only ever generates contract (`C...`) addresses. To generate account (`G...`) addresses instead, use [`ArbitraryAddressAccount`] as the prototype type. This is useful when a fuzz or property test needs to exercise the account-address code path of a contract.
+By default, [`Address`]'s prototype, `<Address as SorobanArbitrary>::Prototype`, is [`ArbitraryAddressContract`], also named [`ArbitraryAddress`], which only ever generates contract (`C...`) addresses. To generate account (`G...`) addresses instead, use [`ArbitraryAddressAccount`] as the prototype type. This is useful when a fuzz or property test needs to exercise the account-address code path of a contract.
 
+[`arbitraryaddresscontract`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/arbitrary/struct.ArbitraryAddressContract.html
+[`arbitraryaddress`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/arbitrary/type.ArbitraryAddress.html
 [`arbitraryaddressaccount`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/arbitrary/struct.ArbitraryAddressAccount.html
 
 ```rust
@@ -655,7 +657,7 @@ struct Input {
 
 fuzz_target!(|input: Input| {
     let env = Env::default();
-    let from: Address = input.from.into_val(&env);
+    let from = Address::from_val(&env, &input.from);
     // ... do fuzzing here ...
 });
 ```

--- a/docs/build/smart-contracts/example-contracts/fuzzing.mdx
+++ b/docs/build/smart-contracts/example-contracts/fuzzing.mdx
@@ -640,6 +640,26 @@ Types that implement `SorobanArbitrary` include:
 
 All user-defined contract types, those with the [`contracttype`] attribute, automatically derive `SorobanArbitrary`. Note that `SorobanArbitrary` is only derived when the "testutils" Cargo feature is active. This implies that, in general, to make a Soroban contract fuzzable, the contract crate must define a "testutils" Cargo feature, that feature should turn on the "soroban-sdk/testutils" feature, and the fuzz test, which is its own crate, must turn that feature on.
 
+### Generating Account vs. Contract Addresses
+
+By default, [`Address`]'s prototype, `<Address as SorobanArbitrary>::Prototype`, only ever generates contract (`C...`) addresses. To generate account (`G...`) addresses instead, use [`ArbitraryAddressAccount`] as the prototype type. This is useful when a fuzz or property test needs to exercise the account-address code path of a contract.
+
+[`arbitraryaddressaccount`]: https://docs.rs/soroban-sdk/latest/soroban_sdk/testutils/arbitrary/struct.ArbitraryAddressAccount.html
+
+```rust
+#[derive(Arbitrary, Debug)]
+struct Input {
+    // Always an account address.
+    from: ArbitraryAddressAccount,
+}
+
+fuzz_target!(|input: Input| {
+    let env = Env::default();
+    let from: Address = input.from.into_val(&env);
+    // ... do fuzzing here ...
+});
+```
+
 ## A More Complex Fuzz Test
 
 The [`fuzz_target_2.rs`] example, demonstrates the use of `SorobanArbitrary`, the advancement of time, and more advanced fuzzing techniques.


### PR DESCRIPTION
### What
Add a section to the fuzzing guide explaining how to generate account addresses instead of the default contract addresses when fuzz or property testing.

### Why
The `Address` fuzzing prototype only ever produced contract (`C...`) addresses, so a test could never exercise a contract's account-address code path; `rs-soroban-sdk` [#2024](https://github.com/stellar/rs-soroban-sdk/pull/2024) added an `ArbitraryAddressAccount` prototype to fix that, and the docs described neither the old limitation nor the new option.