### PR TITLE
Add a USDT0 (LayerZero OFT) page to the tokens section

### DIFF
--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -327,7 +327,7 @@ const tokens: NavbarItem = {
     },
     {
       to: '/docs/tokens/usdt0-layerzero',
-      label: 'Cross-Chain USDT0 Transfers with LayerZero',
+      label: 'USDT0',
     },
   ],
 }

--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -325,6 +325,10 @@ const tokens: NavbarItem = {
       to: '/docs/tokens/cross-chain-transfers',
       label: 'CCTP',
     },
+    {
+      to: '/docs/tokens/usdt0-layerzero',
+      label: 'Cross-Chain USDT0 Transfers with LayerZero',
+    },
   ],
 }
 

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -1,0 +1,153 @@
+---
+sidebar_position: 100
+title: "Cross-Chain USDT0 Transfers with LayerZero"
+sidebar_label: USDT0
+description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, on Stellar. Mainnet addresses, how LayerZero fits, integration pointers, constraints to check before listing, and a read-only pre-listing check."
+---
+
+# Cross-Chain USDT0 Transfers with LayerZero
+
+[USDT0](https://usdt0.to) brings Tether's USDT to other chains over LayerZero's [Omnichain Fungible Token (OFT) standard](https://docs.layerzero.network/v2/concepts/applications/oft-standard). Everdawn Labs builds and operates USDT0. USDT is locked in an adapter contract on Ethereum, and the same amount of USDT0 is minted on the destination chain. Sending USDT0 out of a chain burns it there and unlocks or mints it on the destination, so total supply stays constant across chains.
+
+On Stellar, USDT0 is a **classic asset with a SAC**, not a contract-only token. Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
+
+:::info[Full documentation]
+
+USDT0 is documented and maintained by Everdawn Labs. For the architecture, the OFT interface, supported chains, and the transfer UI:
+
+- [USDT0 developer guide](https://docs.usdt0.to/technical-documentation/developer)
+- [USDT0 contract deployments](https://docs.usdt0.to/technical-documentation/deployments)
+- [How to transfer USDT0](https://docs.usdt0.to/tutorial/how-to-transfer) and the [transfer UI](https://usdt0.to/transfer)
+
+:::
+
+## Mainnet addresses
+
+| Surface | Address |
+| --- | --- |
+| Classic asset | `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` |
+| Stellar Asset Contract (SAC) | `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` |
+| OFT contract (LayerZero messaging) | `CBOWOLFSDM5PZXNFIVDMP5NZ7U2GSIHED6H6R446QOHF266XINKUMMF6` |
+
+Many Stellar assets share the code `USDT` or `USDT0`. An asset's identity is its code **and** its issuer. Always pin the issuer above, and confirm that the SAC you derive from it matches the SAC address above. The [pre-listing check](#pre-listing-check) below does both.
+
+## How LayerZero fits
+
+[LayerZero V2](https://docs.layerzero.network/v2) is a cross-chain messaging protocol. Every connected chain runs an endpoint contract, identified by an endpoint ID (EID). An OFT is an application built on that endpoint: one token contract per chain, each configured with the address of its peer on every other chain.
+
+| LayerZero on Stellar mainnet | Value |
+| --- | --- |
+| Endpoint ID (EID) | `30600` |
+| EndpointV2 contract | `CCQLLRE5JBAWYCW3KTWOIWLMFDUOKROQVZNSALQMGOSXNW3ERUOWTZGK` |
+
+Endpoint, message library, and executor addresses are published on LayerZero's [Stellar deployment page](https://docs.layerzero.network/v2/deployments/chains/stellar) and in the [deployed contracts list](https://docs.layerzero.network/v2/deployments/deployed-contracts).
+
+A transfer works like this:
+
+1. On the source chain, the OFT debits the sender (burn, or lock on Ethereum) and hands a message to the LayerZero endpoint.
+2. The decentralized verifier networks (DVNs) configured for that pathway wait for the source chain to reach the finality they require, then verify the message.
+3. An executor delivers the verified message to the destination endpoint, which calls `lz_receive` on the destination OFT.
+4. The destination OFT credits the recipient. On Stellar, the OFT contract mints through a mint/burn adapter contract that holds the SAC admin role, and the USDT0 lands in the recipient's trustline or contract balance.
+
+Transfer time depends on the source chain's finality and on DVN verification, not on Stellar's ledger close. Expect minutes for a transfer into Stellar. A transfer out of Stellar is a single Stellar transaction on the sending side, and arrival depends on the destination chain. Track a transfer by its transaction hash on [LayerZero Scan](https://layerzeroscan.com).
+
+## Integrate USDT0
+
+USDT0 needs no special integration code on Stellar. Use the same paths as for any other Stellar asset with a SAC:
+
+- **Classic accounts and wallets.** The recipient opens a trustline to `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` once. No issuer approval is needed because the issuer does not set `auth_required`. After that, any account holding USDT0 can send it with a payment operation. See [Send and Receive Payments](../build/guides/transactions/send-and-receive-payments.mdx) and [Verify Trustlines](../build/guides/basics/verify-trustlines.mdx).
+- **Smart contracts.** Call the SAC at `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` through the [token interface](./token-interface.mdx), the same way as any other token. See [Use Issued Assets in Smart Contracts with the SAC](./stellar-asset-contract.mdx). A contract balance in USDT0 lives in the SAC, separate from account trustlines.
+- **Bridging in or out.** End users move USDT0 with the [transfer UI](https://usdt0.to/transfer). Programmatic sends from Stellar go through the OFT contract's `quote_send` and `send` functions, with fees paid in XLM. The [USDT0 developer guide](https://docs.usdt0.to/technical-documentation/developer) documents the OFT interface and the message flow. Query `quote_send` for the current fee rather than relying on a documented number.
+
+### Amount precision
+
+Stellar assets have 7 decimal places, so the SAC's `decimals()` returns `7`. The USDT0 OFT uses 6 shared decimals across all chains: the OFT contract's `shared_decimals()` returns `6` and its `decimal_conversion_rate()` returns `10`. A cross-chain send drops anything below 6 decimals before the amount leaves Stellar. Quoting a send of `1.0000001` USDT0 returns an `amount_sent_ld` of `1.0000000`.
+
+Inside Stellar, payments and SAC transfers use all 7 decimals. If your protocol holds balances that users will later bridge out, round to 6 decimals so no dust gets stranded.
+
+## What to check before you list USDT0
+
+A DeFi protocol, wallet, or exchange should confirm these facts on mainnet before it accepts USDT0 as collateral or lists it. The values below were read from the network on 2026-08-25. The [pre-listing check](#pre-listing-check) reads them again at any time.
+
+**Issuer flags.** The issuer sets `auth_revocable` and `auth_clawback_enabled`. It does not set `auth_required` or `auth_immutable`. In practice:
+
+- Anyone can hold USDT0. No approval is needed to open a trustline or receive a payment.
+- The asset admin can freeze a trustline or a contract balance with `set_authorized`, and can claw back balances with `clawback`. Compared with USDC on Stellar, which sets `auth_revocable` only, USDT0 adds clawback. Read [Controlling access to an asset with flags](./control-asset-access.mdx#controlling-access-to-an-asset-with-flags) and [Clawbacks](../build/guides/transactions/clawbacks.mdx) for how these controls behave.
+- `auth_immutable` is not set, but the flags cannot change in practice. Only a `SetOptions` operation from the issuer account can change them, and that account can no longer sign (see below).
+
+**Who controls the asset.** The issuer account's master key has weight `0` and the account has no other signers, so the issuer account cannot sign any transaction. Administrative control sits with the SAC admin, which is a contract, not an account. It is the mint/burn adapter that the OFT contract calls when a transfer arrives. Its interface exposes `mint`, `set_authorized`, `clawback`, `set_admin`, and `upgrade`, gated by roles. Treat that contract and the holders of its roles as the trust anchor for the asset. Query `admin()` on the SAC to read its current address.
+
+**No `home_domain`, so no `stellar.toml`.** The issuer account has no home domain, and a locked account cannot set one. There is no [SEP-1 asset entry](./publishing-asset-info.mdx) for USDT0. What that breaks:
+
+- Any asset validation keyed on `home_domain` or on a `[[CURRENCIES]]` entry fails or reports the asset as unverified. This includes wallet asset lists, explorers, and anchor asset pickers that rely on `stellar.toml`.
+- Display metadata does not come from a TOML file. The SAC's `name()` returns the `CODE:ISSUER` string, and `symbol()` returns `USDT0`. Supply a display name and icon in your own application.
+- You cannot confirm the issuer through its domain. Confirm it against the USDT0 [deployments page](https://docs.usdt0.to/technical-documentation/deployments) and the SAC derivation instead.
+
+**OFT controls.** The OFT contract can be paused (`is_paused`). It supports per-pathway rate limits and fees (`rate_limit_config`, `effective_fee_bps`). These affect bridging in and out. They do not affect payments or SAC transfers inside Stellar. Read the live values from the contract. Do not rely on documented numbers.
+
+## Pre-listing check
+
+This script is read-only. It uses no keypair, signs nothing, and moves no funds. Every value comes from [Stellar RPC](../data/apis/rpc/README.mdx): account and contract state through `getLedgerEntries`, and contract reads through `simulateTransaction`. It needs `jq`, a current [Stellar CLI](../tools/cli/install-cli.mdx), and a mainnet RPC endpoint from the [RPC providers list](../data/apis/rpc/providers.mdx) in `STELLAR_RPC_URL`. Run it before you list the asset, and again whenever you review the listing.
+
+```bash
+#!/usr/bin/env bash
+# Read-only checks to run before listing USDT0 on Stellar mainnet.
+# No keypair, no signing, no funds. Requires: jq and a current Stellar CLI.
+set -euo pipefail
+
+CODE=USDT0
+ISSUER=GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q
+EXPECTED_SAC=CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF
+OFT=CBOWOLFSDM5PZXNFIVDMP5NZ7U2GSIHED6H6R446QOHF266XINKUMMF6
+ENDPOINT=CCQLLRE5JBAWYCW3KTWOIWLMFDUOKROQVZNSALQMGOSXNW3ERUOWTZGK
+RPC_URL="${STELLAR_RPC_URL:?set STELLAR_RPC_URL to a mainnet RPC endpoint}"
+PASSPHRASE="Public Global Stellar Network ; September 2015"
+NET=(--rpc-url "$RPC_URL" --network-passphrase "$PASSPHRASE")
+
+echo "## 1. Issuer account: flags, home_domain, thresholds, signers"
+# flags is a bitmask: 1 auth_required, 2 auth_revocable, 4 auth_immutable, 8 auth_clawback_enabled.
+# thresholds is hex: master key weight, low, medium, high.
+stellar ledger entry fetch account --account "$ISSUER" "${NET[@]}" --output json |
+  jq '.entries[0].val.account | {
+    auth_required: (.flags % 2 == 1),
+    auth_revocable: ((.flags / 2 | floor) % 2 == 1),
+    auth_immutable: ((.flags / 4 | floor) % 2 == 1),
+    auth_clawback_enabled: ((.flags / 8 | floor) % 2 == 1),
+    home_domain, thresholds, signers }'
+
+echo "## 2. SAC derivation must match the published address"
+DERIVED_SAC=$(stellar contract id asset --asset "$CODE:$ISSUER" "${NET[@]}")
+echo "derived: $DERIVED_SAC"
+[ "$DERIVED_SAC" = "$EXPECTED_SAC" ] || { echo "SAC mismatch, stop here"; exit 1; }
+
+# Simulate a read-only contract call. The source account only seeds the
+# simulation; any existing mainnet account works. Nothing is signed or sent.
+read_only() {
+  stellar contract invoke --id "$1" "${NET[@]}" --source-account "$ISSUER" -- "${@:2}" 2>/dev/null
+}
+
+echo "## 3. SAC metadata and admin"
+for fn in decimals name symbol admin; do
+  printf '%s: ' "$fn"
+  read_only "$EXPECTED_SAC" "$fn"
+done
+
+echo "## 4. OFT wiring: token must equal the SAC, endpoint must be LayerZero EID 30600"
+for fn in token shared_decimals decimal_conversion_rate oft_type endpoint is_paused; do
+  printf '%s: ' "$fn"
+  read_only "$OFT" "$fn"
+done
+printf 'endpoint eid: '
+read_only "$ENDPOINT" eid
+```
+
+Expected results, as of 2026-08-25:
+
+- Step 1: `auth_revocable` and `auth_clawback_enabled` are `true`, the other two flags are `false`, `home_domain` is empty, `thresholds` is `00000000` (master key weight `0`), and `signers` is empty.
+- Step 2: the derived SAC equals `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF`.
+- Step 3: `decimals` is `7`, `symbol` is `"USDT0"`, `admin` is a `C...` contract address.
+- Step 4: `token` equals the SAC, `shared_decimals` is `6`, `oft_type` is `MintBurn` with the admin contract's address, `endpoint` is `CCQLLRE5JBAWYCW3KTWOIWLMFDUOKROQVZNSALQMGOSXNW3ERUOWTZGK`, and the endpoint's `eid` is `30600`.
+
+If any value differs, stop and investigate before you list the asset.
+
+RPC does not aggregate across trustlines. For holder counts and total balance, use Horizon's `/assets` endpoint or an indexer. Those numbers are useful context, but the checks above do not need them.

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -55,7 +55,7 @@ Transfer time depends on the source chain's finality and on DVN verification, no
 
 USDT0 needs no special integration code on Stellar. Use the same paths as for any other Stellar asset with a SAC:
 
-- **Classic accounts and wallets.** The recipient opens a trustline to `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` once. After that, any account holding USDT0 can send it with a payment operation. See [Send and Receive Payments](../build/guides/transactions/send-and-receive-payments.mdx) and [Verify Trustlines](../build/guides/basics/verify-trustlines.mdx).
+- **Classic accounts and wallets.** The recipient opens a trustline to `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` once. After that, any account holding USDT0 can send it to the recipient with a payment operation. See [Send and Receive Payments](../build/guides/transactions/send-and-receive-payments.mdx) and [Verify Trustlines](../build/guides/basics/verify-trustlines.mdx).
 - **Smart contracts.** Call the SAC at `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` through the [token interface](./token-interface.mdx), the same way as any other token. See [Use Issued Assets in Smart Contracts with the SAC](./stellar-asset-contract.mdx). A contract balance in USDT0 lives in the SAC, separate from account trustlines.
 - **Bridging in or out.** End users move USDT0 with the [transfer UI](https://usdt0.to/transfer). Programmatic sends from Stellar go through the OFT contract's `quote_send` and `send` functions, with fees paid in XLM. The [USDT0 developer guide](https://docs.usdt0.to/technical-documentation/developer) documents the OFT interface and the message flow. Query `quote_send` for the current fee rather than relying on a documented number.
 

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -7,13 +7,13 @@ description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, 
 
 # Cross-Chain USDT0 Transfers with LayerZero
 
-[USDT0](https://usdt0.to) brings Tether's USDT to other chains over LayerZero's [Omnichain Fungible Token (OFT) standard](https://docs.layerzero.network/v2/concepts/applications/oft-standard). Everdawn Labs builds and operates USDT0. USDT is locked in an adapter contract on Ethereum, and the same amount of USDT0 is minted on the destination chain. Sending USDT0 out of a chain burns it there and unlocks or mints it on the destination, so total supply stays constant across chains.
+[USDT0](https://usdt0.to) brings Tether's USDT to other chains over LayerZero's [Omnichain Fungible Token (OFT) standard](https://docs.layerzero.network/v2/concepts/applications/oft-standard). USDT is locked in an adapter contract on Ethereum, and the same amount of USDT0 is minted on the destination chain. Sending USDT0 out of a chain burns it there and unlocks or mints it on the destination, so total supply stays constant across chains.
 
-On Stellar, USDT0 is a **classic asset with a SAC**, not a contract-only token. Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
+On Stellar, USDT0 is a **classic asset with a SAC** . Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
 
 :::info[Full documentation]
 
-USDT0 is documented and maintained by Everdawn Labs. For the architecture, the OFT interface, supported chains, and the transfer UI:
+For the architecture, the OFT interface, supported chains, and the transfer UI:
 
 - [USDT0 developer guide](https://docs.usdt0.to/technical-documentation/developer)
 - [USDT0 contract deployments](https://docs.usdt0.to/technical-documentation/deployments)
@@ -44,18 +44,18 @@ Endpoint, message library, and executor addresses are published on LayerZero's [
 
 A transfer works like this:
 
-1. On the source chain, the OFT debits the sender (burn, or lock on Ethereum) and hands a message to the LayerZero endpoint.
+1. On the source chain, the OFT debits the sender and hands a message to the LayerZero endpoint.
 2. The decentralized verifier networks (DVNs) configured for that pathway wait for the source chain to reach the finality they require, then verify the message.
 3. An executor delivers the verified message to the destination endpoint, which calls `lz_receive` on the destination OFT.
 4. The destination OFT credits the recipient. On Stellar, the OFT contract mints through a mint/burn adapter contract that holds the SAC admin role, and the USDT0 lands in the recipient's trustline or contract balance.
 
-Transfer time depends on the source chain's finality and on DVN verification, not on Stellar's ledger close. Expect minutes for a transfer into Stellar. A transfer out of Stellar is a single Stellar transaction on the sending side, and arrival depends on the destination chain. Track a transfer by its transaction hash on [LayerZero Scan](https://layerzeroscan.com).
+Transfer time depends on the source chain's finality and on DVN verification, not on Stellar's ledger close. A transfer out of Stellar is a single Stellar transaction on the sending side, and arrival depends on the destination chain. Track a transfer by its transaction hash on [LayerZero Scan](https://layerzeroscan.com).
 
 ## Integrate USDT0
 
 USDT0 needs no special integration code on Stellar. Use the same paths as for any other Stellar asset with a SAC:
 
-- **Classic accounts and wallets.** The recipient opens a trustline to `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` once. No issuer approval is needed because the issuer does not set `auth_required`. After that, any account holding USDT0 can send it with a payment operation. See [Send and Receive Payments](../build/guides/transactions/send-and-receive-payments.mdx) and [Verify Trustlines](../build/guides/basics/verify-trustlines.mdx).
+- **Classic accounts and wallets.** The recipient opens a trustline to `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` once. After that, any account holding USDT0 can send it with a payment operation. See [Send and Receive Payments](../build/guides/transactions/send-and-receive-payments.mdx) and [Verify Trustlines](../build/guides/basics/verify-trustlines.mdx).
 - **Smart contracts.** Call the SAC at `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` through the [token interface](./token-interface.mdx), the same way as any other token. See [Use Issued Assets in Smart Contracts with the SAC](./stellar-asset-contract.mdx). A contract balance in USDT0 lives in the SAC, separate from account trustlines.
 - **Bridging in or out.** End users move USDT0 with the [transfer UI](https://usdt0.to/transfer). Programmatic sends from Stellar go through the OFT contract's `quote_send` and `send` functions, with fees paid in XLM. The [USDT0 developer guide](https://docs.usdt0.to/technical-documentation/developer) documents the OFT interface and the message flow. Query `quote_send` for the current fee rather than relying on a documented number.
 
@@ -64,90 +64,3 @@ USDT0 needs no special integration code on Stellar. Use the same paths as for an
 Stellar assets have 7 decimal places, so the SAC's `decimals()` returns `7`. The USDT0 OFT uses 6 shared decimals across all chains: the OFT contract's `shared_decimals()` returns `6` and its `decimal_conversion_rate()` returns `10`. A cross-chain send drops anything below 6 decimals before the amount leaves Stellar. Quoting a send of `1.0000001` USDT0 returns an `amount_sent_ld` of `1.0000000`.
 
 Inside Stellar, payments and SAC transfers use all 7 decimals. If your protocol holds balances that users will later bridge out, round to 6 decimals so no dust gets stranded.
-
-## What to check before you list USDT0
-
-A DeFi protocol, wallet, or exchange should confirm these facts on mainnet before it accepts USDT0 as collateral or lists it. The values below were read from the network on 2026-08-25. The [pre-listing check](#pre-listing-check) reads them again at any time.
-
-**Issuer flags.** The issuer sets `auth_revocable` and `auth_clawback_enabled`. It does not set `auth_required` or `auth_immutable`. In practice:
-
-- Anyone can hold USDT0. No approval is needed to open a trustline or receive a payment.
-- The asset admin can freeze a trustline or a contract balance with `set_authorized`, and can claw back balances with `clawback`. Compared with USDC on Stellar, which sets `auth_revocable` only, USDT0 adds clawback. Read [Controlling access to an asset with flags](./control-asset-access.mdx#controlling-access-to-an-asset-with-flags) and [Clawbacks](../build/guides/transactions/clawbacks.mdx) for how these controls behave.
-- `auth_immutable` is not set, but the flags cannot change in practice. Only a `SetOptions` operation from the issuer account can change them, and that account can no longer sign (see below).
-
-**Who controls the asset.** The issuer account's master key has weight `0` and the account has no other signers, so the issuer account cannot sign any transaction. Administrative control sits with the SAC admin, which is a contract, not an account. It is the mint/burn adapter that the OFT contract calls when a transfer arrives. Its interface exposes `mint`, `set_authorized`, `clawback`, `set_admin`, and `upgrade`, gated by roles. Treat that contract and the holders of its roles as the trust anchor for the asset. Query `admin()` on the SAC to read its current address.
-
-**No `home_domain`, so no `stellar.toml`.** The issuer account has no home domain, and a locked account cannot set one. There is no [SEP-1 asset entry](./publishing-asset-info.mdx) for USDT0. What that breaks:
-
-- Any asset validation keyed on `home_domain` or on a `[[CURRENCIES]]` entry fails or reports the asset as unverified. This includes wallet asset lists, explorers, and anchor asset pickers that rely on `stellar.toml`.
-- Display metadata does not come from a TOML file. The SAC's `name()` returns the `CODE:ISSUER` string, and `symbol()` returns `USDT0`. Supply a display name and icon in your own application.
-- You cannot confirm the issuer through its domain. Confirm it against the USDT0 [deployments page](https://docs.usdt0.to/technical-documentation/deployments) and the SAC derivation instead.
-
-**OFT controls.** The OFT contract can be paused (`is_paused`). It supports per-pathway rate limits and fees (`rate_limit_config`, `effective_fee_bps`). These affect bridging in and out. They do not affect payments or SAC transfers inside Stellar. Read the live values from the contract. Do not rely on documented numbers.
-
-## Pre-listing check
-
-This script is read-only. It uses no keypair, signs nothing, and moves no funds. Every value comes from [Stellar RPC](../data/apis/rpc/README.mdx): account and contract state through `getLedgerEntries`, and contract reads through `simulateTransaction`. It needs `jq`, a current [Stellar CLI](../tools/cli/install-cli.mdx), and a mainnet RPC endpoint from the [RPC providers list](../data/apis/rpc/providers.mdx) in `STELLAR_RPC_URL`. Run it before you list the asset, and again whenever you review the listing.
-
-```bash
-#!/usr/bin/env bash
-# Read-only checks to run before listing USDT0 on Stellar mainnet.
-# No keypair, no signing, no funds. Requires: jq and a current Stellar CLI.
-set -euo pipefail
-
-CODE=USDT0
-ISSUER=GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q
-EXPECTED_SAC=CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF
-OFT=CBOWOLFSDM5PZXNFIVDMP5NZ7U2GSIHED6H6R446QOHF266XINKUMMF6
-ENDPOINT=CCQLLRE5JBAWYCW3KTWOIWLMFDUOKROQVZNSALQMGOSXNW3ERUOWTZGK
-RPC_URL="${STELLAR_RPC_URL:?set STELLAR_RPC_URL to a mainnet RPC endpoint}"
-PASSPHRASE="Public Global Stellar Network ; September 2015"
-NET=(--rpc-url "$RPC_URL" --network-passphrase "$PASSPHRASE")
-
-echo "## 1. Issuer account: flags, home_domain, thresholds, signers"
-# flags is a bitmask: 1 auth_required, 2 auth_revocable, 4 auth_immutable, 8 auth_clawback_enabled.
-# thresholds is hex: master key weight, low, medium, high.
-stellar ledger entry fetch account --account "$ISSUER" "${NET[@]}" --output json |
-  jq '.entries[0].val.account | {
-    auth_required: (.flags % 2 == 1),
-    auth_revocable: ((.flags / 2 | floor) % 2 == 1),
-    auth_immutable: ((.flags / 4 | floor) % 2 == 1),
-    auth_clawback_enabled: ((.flags / 8 | floor) % 2 == 1),
-    home_domain, thresholds, signers }'
-
-echo "## 2. SAC derivation must match the published address"
-DERIVED_SAC=$(stellar contract id asset --asset "$CODE:$ISSUER" "${NET[@]}")
-echo "derived: $DERIVED_SAC"
-[ "$DERIVED_SAC" = "$EXPECTED_SAC" ] || { echo "SAC mismatch, stop here"; exit 1; }
-
-# Simulate a read-only contract call. The source account only seeds the
-# simulation; any existing mainnet account works. Nothing is signed or sent.
-read_only() {
-  stellar contract invoke --id "$1" "${NET[@]}" --source-account "$ISSUER" -- "${@:2}" 2>/dev/null
-}
-
-echo "## 3. SAC metadata and admin"
-for fn in decimals name symbol admin; do
-  printf '%s: ' "$fn"
-  read_only "$EXPECTED_SAC" "$fn"
-done
-
-echo "## 4. OFT wiring: token must equal the SAC, endpoint must be LayerZero EID 30600"
-for fn in token shared_decimals decimal_conversion_rate oft_type endpoint is_paused; do
-  printf '%s: ' "$fn"
-  read_only "$OFT" "$fn"
-done
-printf 'endpoint eid: '
-read_only "$ENDPOINT" eid
-```
-
-Expected results, as of 2026-08-25:
-
-- Step 1: `auth_revocable` and `auth_clawback_enabled` are `true`, the other two flags are `false`, `home_domain` is empty, `thresholds` is `00000000` (master key weight `0`), and `signers` is empty.
-- Step 2: the derived SAC equals `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF`.
-- Step 3: `decimals` is `7`, `symbol` is `"USDT0"`, `admin` is a `C...` contract address.
-- Step 4: `token` equals the SAC, `shared_decimals` is `6`, `oft_type` is `MintBurn` with the admin contract's address, `endpoint` is `CCQLLRE5JBAWYCW3KTWOIWLMFDUOKROQVZNSALQMGOSXNW3ERUOWTZGK`, and the endpoint's `eid` is `30600`.
-
-If any value differs, stop and investigate before you list the asset.
-
-RPC does not aggregate across trustlines. For holder counts and total balance, use Horizon's `/assets` endpoint or an indexer. Those numbers are useful context, but the checks above do not need them.

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -2,14 +2,14 @@
 sidebar_position: 100
 title: "Cross-Chain USDT0 Transfers with LayerZero"
 sidebar_label: Cross-Chain USDT0 Transfers with LayerZero
-description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, on Stellar. Mainnet addresses, how LayerZero fits, integration pointers, constraints to check before listing, and a read-only pre-listing check."
+description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, on Stellar. Mainnet addresses, how LayerZero fits, integration pointers, and amount precision."
 ---
 
 # Cross-Chain USDT0 Transfers with LayerZero
 
 [USDT0](https://usdt0.to) brings Tether's USDT to other chains over LayerZero's [Omnichain Fungible Token (OFT) standard](https://docs.layerzero.network/v2/concepts/applications/oft-standard). USDT is locked in an adapter contract on Ethereum, and the same amount of USDT0 is minted on the destination chain. Sending USDT0 out of a chain burns it there and unlocks or mints it on the destination, so total supply stays constant across chains.
 
-On Stellar, USDT0 is a **classic asset with a SAC** . Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
+On Stellar, USDT0 is a **classic asset with a SAC**. Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
 
 :::info[Full documentation]
 
@@ -29,7 +29,7 @@ For the architecture, the OFT interface, supported chains, and the transfer UI:
 | Stellar Asset Contract (SAC) | `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` |
 | OFT contract (LayerZero messaging) | `CBOWOLFSDM5PZXNFIVDMP5NZ7U2GSIHED6H6R446QOHF266XINKUMMF6` |
 
-Many Stellar assets share the code `USDT` or `USDT0`. An asset's identity is its code **and** its issuer. Always pin the issuer above, and confirm that the SAC you derive from it matches the SAC address above. The [pre-listing check](#pre-listing-check) below does both.
+Many Stellar assets share the code `USDT` or `USDT0`. An asset's identity is its code **and** its issuer. Always pin the issuer above, and confirm that the SAC you derive from it matches the SAC address above.
 
 ## How LayerZero fits
 

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -61,6 +61,6 @@ USDT0 needs no special integration code on Stellar. Use the same paths as for an
 
 ### Amount precision
 
-Stellar assets have 7 decimal places, so the SAC's `decimals()` returns `7`. The USDT0 OFT uses 6 shared decimals across all chains: the OFT contract's `shared_decimals()` returns `6` and its `decimal_conversion_rate()` returns `10`. A cross-chain send drops anything below 6 decimals before the amount leaves Stellar. Quoting a send of `1.0000001` USDT0 returns an `amount_sent_ld` of `1.0000000`.
+Stellar assets have 7 decimal places, so the SAC's `decimals()` returns `7`. The USDT0 OFT uses 6 shared decimals across all chains: the OFT contract's `shared_decimals()` returns `6` and its `decimal_conversion_rate()` returns `10`. Amounts transmitted cross-chain are normalized to 6 shared decimals. On a no-fee route, calling `quote_oft` with `amount_ld` set to `10000001` returns `amount_sent_ld` as `10000000` (equivalent to `1.0000000` USDT0); `quote_send` returns the messaging fee instead.
 
 Inside Stellar, payments and SAC transfers use all 7 decimals. If your protocol holds balances that users will later bridge out, round to 6 decimals so no dust gets stranded.

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -56,7 +56,7 @@ Transfer time depends on the source chain's finality and on DVN verification, no
 USDT0 needs no special integration code on Stellar. Use the same paths as for any other Stellar asset with a SAC:
 
 - **Classic accounts and wallets.** The recipient opens a trustline to `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` once. After that, any account holding USDT0 can send it to the recipient with a payment operation. See [Send and Receive Payments](../build/guides/transactions/send-and-receive-payments.mdx) and [Verify Trustlines](../build/guides/basics/verify-trustlines.mdx).
-- **Smart contracts.** Call the SAC at `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` through the [token interface](./token-interface.mdx), the same way as any other token. See [Use Issued Assets in Smart Contracts with the SAC](./stellar-asset-contract.mdx). A contract balance in USDT0 lives in the SAC, separate from account trustlines.
+- **Smart contracts.** Call the SAC at `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` through the [token interface](./token-interface.mdx), the same way as any other token. See [Use Issued Assets in Smart Contracts with the SAC](./stellar-asset-contract.mdx). A contract balance in USDT0 lives in the SAC storage entries, separate from account trustlines.
 - **Bridging in or out.** End users move USDT0 with the [transfer UI](https://usdt0.to/transfer). Programmatic sends from Stellar go through the OFT contract's `quote_send` and `send` functions, with fees paid in XLM. The [USDT0 developer guide](https://docs.usdt0.to/technical-documentation/developer) documents the OFT interface and the message flow. Query `quote_send` for the current fee rather than relying on a documented number.
 
 ### Amount precision

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 100
 title: "Cross-Chain USDT0 Transfers with LayerZero"
-sidebar_label: USDT0
+sidebar_label: Cross-Chain USDT0 Transfers with LayerZero
 description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, on Stellar. Mainnet addresses, how LayerZero fits, integration pointers, constraints to check before listing, and a read-only pre-listing check."
 ---
 

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 100
-title: "Cross-Chain USDT0 Transfers with LayerZero"
-sidebar_label: Cross-Chain USDT0 Transfers with LayerZero
+title: "USDT0 Transfers with LayerZero"
+sidebar_label: USDT0 Transfers with LayerZero
 description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, on Stellar. Mainnet addresses, how LayerZero fits, integration pointers, and amount precision."
 ---
 
-# Cross-Chain USDT0 Transfers with LayerZero
+# USDT0 Transfers with LayerZero
 
 [USDT0](https://usdt0.to) brings Tether's USDT to other chains over LayerZero's [Omnichain Fungible Token (OFT) standard](https://docs.layerzero.network/v2/concepts/applications/oft-standard). USDT is locked in an adapter contract on Ethereum, and the same amount of USDT0 is minted on the destination chain. Sending USDT0 out of a chain burns it there and unlocks or mints it on the destination, so total supply stays constant across chains.
 

--- a/routes.txt
+++ b/routes.txt
@@ -738,6 +738,7 @@
 /docs/tokens/quickstart
 /docs/tokens/stellar-asset-contract
 /docs/tokens/token-interface
+/docs/tokens/usdt0-layerzero
 /docs/tools
 /docs/tools/cli
 /docs/tools/cli/cookbook

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -79,6 +79,7 @@ https://github.com/stellar-experimental/stellar-raven — try it: https://raven.
 - [Token Interface](https://developers.stellar.org/docs/tokens/token-interface.md)
 - [Tutorial: Issue an Asset](https://developers.stellar.org/docs/tokens/how-to-issue-an-asset.md)
 - [Publish Asset Information](https://developers.stellar.org/docs/tokens/publishing-asset-info.md)
+- [Cross-Chain USDT0 Transfers with LayerZero](https://developers.stellar.org/docs/tokens/usdt0-layerzero.md)
 
 [Data](https://developers.stellar.org/docs/data.md)
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -79,7 +79,7 @@ https://github.com/stellar-experimental/stellar-raven — try it: https://raven.
 - [Token Interface](https://developers.stellar.org/docs/tokens/token-interface.md)
 - [Tutorial: Issue an Asset](https://developers.stellar.org/docs/tokens/how-to-issue-an-asset.md)
 - [Publish Asset Information](https://developers.stellar.org/docs/tokens/publishing-asset-info.md)
-- [Cross-Chain USDT0 Transfers with LayerZero](https://developers.stellar.org/docs/tokens/usdt0-layerzero.md)
+- [USDT0 Transfers with LayerZero](https://developers.stellar.org/docs/tokens/usdt0-layerzero.md)
 
 [Data](https://developers.stellar.org/docs/data.md)
 


### PR DESCRIPTION
Closes #2793

## What changed

- New page `docs/tokens/usdt0-layerzero.mdx`, placed right after the CCTP page in the sidebar (`sidebar_position: 100`).
- The CCTP page is unchanged.
- The page covers: what USDT0 is, mainnet addresses, how LayerZero fits (Stellar EID 30600), integration pointers that link the official USDT0 docs, and amount precision.
- `config/theme/navbar.ts` lists the page in the Tokens dropdown, after CCTP.
- `routes.txt` gains the new route (regenerated by `pnpm build`).
- `static/llms.txt` lists the new page under Tokens.
