### PR TITLE
Add a promotional and third-party content policy to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ A husky pre-commit hook runs the prettier check; if it fails, run `pnpm format:m
 ### Promotional and third-party content
 
 - **We don't accept promotional contributions.** PRs that add payment addresses, donation appeals, referral links, or marketing copy for a contributor's own product will be closed without review. This includes rewriting an existing page to center a specific project.
-- **Third-party tools and services belong on the pages built for them.** Several pages exist to list ecosystem tooling and providers. Entries there are descriptive rather than promotional: what the thing does and how it works with Stellar, not why a reader should choose it. If you think your project belongs in one of those sections, open an issue proposing it before opening a PR.
+- **Third-party tools and services belong on the pages built for them.** Several pages exist to list ecosystem tooling and providers. Entries there are descriptive rather than promotional: what the thing does and how it works with Stellar, not why a reader should choose it. If your project clearly fits into one of these list pages, feel free to directly open a PR. If you're uncertain where or if your project fits, feel free to open an issue proposing it.
 
 ## Site Code and Infrastructure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Before diving in, please read the org-wide [Stellar Contribution Guide](https://
     - [Images](#images)
     - [Code examples](#code-examples)
     - [Terminology and style](#terminology-and-style)
+    - [Promotional and third-party content](#promotional-and-third-party-content)
   - [Site Code and Infrastructure](#site-code-and-infrastructure)
     - [API reference pages are generated](#api-reference-pages-are-generated)
     - [URLs are forever](#urls-are-forever)
@@ -84,6 +85,11 @@ A husky pre-commit hook runs the prettier check; if it fails, run `pnpm format:m
 - "Stellar network" — lowercase *network*. Likewise *asset* and *anchor* are not capitalized.
 - Write SEP and CAP references without zero-padding (for example, `SEP-1` and `CAP-1`, not `SEP-0001` and `CAP-0001`). Keep canonical filenames and URLs unchanged (for example, `sep-0001.md` and `cap-0001.md`).
 - Meeting notes (in `meetings/`) use the date as the title (`2026-05-07`), uniformly across the series.
+
+### Promotional and third-party content
+
+- **We don't accept promotional contributions.** PRs that add payment addresses, donation appeals, referral links, or marketing copy for a contributor's own product will be closed without review. This includes rewriting an existing page to center a specific project.
+- **Third-party tools and services belong on the pages built for them.** Several pages exist to list ecosystem tooling and providers. Entries there are descriptive rather than promotional: what the thing does and how it works with Stellar, not why a reader should choose it. If you think your project belongs in one of those sections, open an issue proposing it before opening a PR.
 
 ## Site Code and Infrastructure
 


### PR DESCRIPTION
## What

Adds a `Promotional and third-party content` subsection under Content Conventions in `CONTRIBUTING.md`, along with its table of contents entry. Two bullets, no other changes.

## Why

We get a steady trickle of PRs that add payment addresses, donation appeals, referral links, or marketing copy for the contributor's own project. Each one currently gets handled ad hoc, which means re-explaining the same standard every time and leaving the decision looking like a personal judgment call rather than a repo policy.

Writing it down does two things:

- Gives reviewers something to point at when closing one of these, instead of relitigating it per PR.
- Gives the good-faith version of the question a clear path. Some contributors genuinely aren't sure whether their project belongs in one of our ecosystem listing pages, and "open an issue proposing it first" is a much better answer than a case-by-case verdict after they've already done the work.

The second bullet matters as much as the first. There are open PRs right now proposing third-party tooling in good faith, and pointing at a process beats improvising a decision.

## Notes

- Content only. No site, build, or dependency changes.
- `CONTRIBUTING.md` sits outside the `check:mdx` glob (`{docs,src/pages,meetings}`), so the prettier hook doesn't cover it. It does have pre-existing formatting warnings under the repo prettier config. I left those alone to keep this diff scoped to the one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)