### PR TITLE
Update Stellar Private Payments section on Privacy docs

### DIFF
--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -19,25 +19,31 @@ Privacy Pools include built-in features that allow operators to implement compli
 
 ### Stellar Private Payments
 
-Nethermind's ZK team has built a proof-of-concept Privacy Pools implementation for Stellar using Circom circuits, Groth16 proofs, and Stellar smart contracts.
+Nethermind has built Stellar Private Payments (SPP), a Privacy Pools implementation for Stellar using Circom circuits, Groth16 proofs, and Stellar smart contracts. SPP gives payments counterparty-level privacy: users hold a private balance in a shared shielded pool and pay each other inside it, while the public ledger records only that the pool was used — never who paid whom or how much.
 
 :::caution
 
-Research prototype, not audited. Do not use in production with real assets.
+Stellar Private Payments is a developer preview. The contracts, SDKs, and demo linked below are unaudited — testnet only, not intended for production use or real assets.
 
 :::
 
-| Component                   | Description                                  |
-| --------------------------- | -------------------------------------------- |
-| Pool contract               | Manages deposits, transfers, and withdrawals |
-| Groth16 verifier            | Onchain ZK proof verification                |
-| ASP membership contract     | Merkle tree of approved addresses            |
-| ASP non-membership contract | Sparse Merkle tree for exclusion proofs      |
+| Component                   | Description                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| Pool contract               | Manages deposits, transfers, and withdrawals                                     |
+| Groth16 verifier            | Onchain ZK proof verification                                                    |
+| ASP membership contract     | Merkle tree of approved keys                                                     |
+| ASP non-membership contract | Sparse Merkle tree for exclusion proofs                                          |
+| Public key registry         | Maps Stellar addresses to pool keys, so users can pay a regular Stellar address |
 
-Proofs are generated client-side in the browser via WebAssembly — user secrets never leave the device.
+SPP implements a key-based association set model: every pool transaction (deposit, transfer, and withdrawal) proves membership or non-membership through a designated Association Set Provider, without revealing the user's history. Proofs are generated client-side in the browser via WebAssembly — user secrets never leave the device.
+
+Learn more in the post [Developer Preview: Stellar Private Payments](https://stellar.org/blog/developers/developer-preview-stellar-private-payments), published during the Testnet preview.
 
 - **Repo**: [NethermindEth/stellar-private-payments](https://github.com/NethermindEth/stellar-private-payments)
 - **Demo**: [nethermindeth.github.io/stellar-private-payments](https://nethermindeth.github.io/stellar-private-payments/)
+- **TS/JS SDK**: [stellar-private-payments on npm](https://www.npmjs.com/package/stellar-private-payments) (alpha) · [source](https://github.com/NethermindEth/stellar-private-payments/tree/main/sdk/web)
+- **Rust SDK**: [sdk/native](https://github.com/NethermindEth/stellar-private-payments/tree/main/sdk/native)
+- **CLI**: install with the one-line command in the [repo README](https://github.com/NethermindEth/stellar-private-payments#install-the-cli)
 
 ## Confidential Tokens
 
@@ -66,7 +72,7 @@ An onchain verifier is a smart contract that accepts a compact zero-knowledge pr
 
 ### RISC Zero (Groth16) Verifier
 
-The Stellar Private Payments prototype includes a deployable verifier contract. The contract verifies Groth16-based proofs created with RISC Zero's zkVM coprocessor (allowing developers to write programs in Rust, rather than domain-specific zero-knowledge languages, and execute them verifiably) or ZK-specific languages like Circom.
+Nethermind also maintains a deployable verifier contract. The contract verifies Groth16-based proofs created with RISC Zero's zkVM coprocessor (allowing developers to write programs in Rust, rather than domain-specific zero-knowledge languages, and execute them verifiably) or ZK-specific languages like Circom.
 
 - **Repo**: [NethermindEth/stellar-risc0-verifier](https://github.com/NethermindEth/stellar-risc0-verifier)
 - **Article**: [Verifying RISC Zero Execution in a Stellar Smart Contract](https://stellar.org/blog/developers/risc-zero-verifier)

--- a/docs/build/apps/privacy.mdx
+++ b/docs/build/apps/privacy.mdx
@@ -27,13 +27,13 @@ Stellar Private Payments is a developer preview. The contracts, SDKs, and demo l
 
 :::
 
-| Component                   | Description                                                                     |
-| --------------------------- | ------------------------------------------------------------------------------- |
-| Pool contract               | Manages deposits, transfers, and withdrawals                                     |
-| Groth16 verifier            | Onchain ZK proof verification                                                    |
-| ASP membership contract     | Merkle tree of approved keys                                                     |
-| ASP non-membership contract | Sparse Merkle tree for exclusion proofs                                          |
-| Public key registry         | Maps Stellar addresses to pool keys, so users can pay a regular Stellar address |
+| Component | Description |
+| --- | --- |
+| Pool contract | Manages deposits, transfers, and withdrawals |
+| Groth16 verifier | Onchain ZK proof verification |
+| ASP membership contract | Merkle tree of approved keys |
+| ASP non-membership contract | Sparse Merkle tree for exclusion proofs |
+| Public key registry | Maps Stellar addresses to pool keys, so users can pay a regular Stellar address |
 
 SPP implements a key-based association set model: every pool transaction (deposit, transfer, and withdrawal) proves membership or non-membership through a designated Association Set Provider, without revealing the user's history. Proofs are generated client-side in the browser via WebAssembly — user secrets never leave the device.
 


### PR DESCRIPTION
Updates the Privacy on Stellar page to reflect SPP's Developer Preview launch ([blog post](https://stellar.org/blog/developers/developer-preview-stellar-private-payments)):

- Status updated from research prototype to developer preview (testnet, unaudited), matching the Confidential Tokens section's treatment
- Adds counterparty-level privacy framing consistent with the announcement post
- Component table: adds the public key registry contract; "approved addresses" → "approved keys" (ASP association is key-based)
- Adds the key-based association set model (membership/non-membership proven on every pool transaction)
- Adds developer resources: TS/JS SDK (npm, alpha), Rust SDK, and the `spp` CLI
- Fixes the RISC Zero verifier section, which attributed that verifier to the SPP prototype; SPP ships its own Circom Groth16 verifier in its repo

Follow-up: the Developer Preview recording link will be added when the stream is released on Aug 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)