### PR TITLE
Wallet guide: explain the slippage limit on swap and path payment

### DIFF
--- a/docs/build/apps/wallet/stellar.mdx
+++ b/docs/build/apps/wallet/stellar.mdx
@@ -290,6 +290,8 @@ let tx = try txBuilder.removeAssetSupport(asset: asset).build()
 
 Exchange an account's asset for a different asset. The account must have a trustline for the destination asset.
 
+A swap is filled at whatever rate the network can find when the transaction is applied, which may differ from the rate you quoted to the user. The minimum destination amount (`destMin`) is the slippage limit that protects against that: it is the least amount of the destination asset the account is willing to receive for the amount it sends. If the swap cannot deliver at least that much, the transaction fails instead of executing at a worse rate. Derive it from a current quote minus the slippage tolerance you are willing to accept.
+
 <WalletCodeExample>
 
 ```typescript
@@ -300,7 +302,10 @@ const usdcAsset = new IssuedAssetId(
   "USDC",
   "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
 );
-const txn = txBuilder.swap(new NativeAssetId(), usdcAsset, ".1").build();
+// Send 0.1 XLM and accept no less than 0.025 USDC back
+const txn = txBuilder
+  .swap(new NativeAssetId(), usdcAsset, ".1", ".025")
+  .build();
 ```
 
 ```dart
@@ -311,10 +316,12 @@ final usdcAsset = IssuedAssetId(
     issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
 );
 
+// Send 0.1 XLM and accept no less than 0.025 USDC back
 var txn = txBuilder.swap(
     fromAsset: NativeAssetId(),
     toAsset: usdcAsset,
     amount: "0.1",
+    destMin: "0.025",
   ).build();
 ```
 
@@ -325,9 +332,11 @@ let usdcAsset = try IssuedAssetId(
     code: "USDC",
     issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
 
+// Send 0.1 XLM and accept no less than 0.025 USDC back
 let txn = try txBuilder.swap(fromAsset: NativeAssetId(),
                              toAsset: usdcAsset,
-                             amount: 0.1).build()
+                             amount: 0.1,
+                             destinationMinAmount: 0.025).build()
 ```
 
 </WalletCodeExample>
@@ -335,6 +344,13 @@ let txn = try txBuilder.swap(fromAsset: NativeAssetId(),
 #### Path Pay
 
 Send one asset from the source account and receive a different asset in the destination account.
+
+Like a swap, a path payment is filled at the rate available when the transaction is applied, so it takes a slippage limit. Which limit depends on which side of the payment is fixed:
+
+- When you fix the amount to send (`sendAmount`), pass `destMin`: the least amount of the destination asset the recipient must receive.
+- When you fix the amount to deliver (`destAmount`), pass `sendMax`: the most of the send asset the source account is willing to spend.
+
+If the network cannot fill the payment within that limit, the transaction fails instead of executing at a worse rate. Derive the limit from a current quote plus or minus the slippage tolerance you are willing to accept.
 
 <WalletCodeExample>
 
@@ -346,12 +362,14 @@ const usdcAsset = new IssuedAssetId(
   "USDC",
   "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
 );
+// Send 5 XLM; the recipient must receive at least 1.25 USDC
 const txn = txBuilder
   .pathPay({
     destinationAddress: receivingKp.publicKey,
     sendAsset: new NativeAssetId(),
     destAsset: usdcAsset,
     sendAmount: "5",
+    destMin: "1.25",
   })
   .build();
 ```
@@ -364,11 +382,13 @@ final usdcAsset = IssuedAssetId(
     issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
 );
 
+// Send 5 XLM; the recipient must receive at least 1.25 USDC
 var txn = txBuilder.pathPay(
     destinationAddress: receivingKp.address,
     sendAsset: NativeAssetId(),
     destinationAsset: usdcAsset,
     sendAmount: "5",
+    destMin: "1.25",
   ).build();
 ```
 
@@ -379,10 +399,51 @@ let usdcAsset = try IssuedAssetId(
     code: "USDC",
     issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5")
 
+// Send 5 XLM; the recipient must receive at least 1.25 USDC
 let txn = try txBuilder.pathPay(destinationAddress: receivingKp.address,
                                 sendAsset: NativeAssetId(),
                                 destinationAsset: usdcAsset,
-                                sendAmount: 5).build()
+                                sendAmount: 5,
+                                destMin: 1.25).build()
+```
+
+</WalletCodeExample>
+
+To deliver an exact amount of the destination asset instead, pass `destAmount` together with `sendMax`:
+
+<WalletCodeExample>
+
+```typescript
+// Deliver exactly 5 USDC; spend no more than 21 XLM to do it
+const txn = txBuilder
+  .pathPay({
+    destinationAddress: receivingKp.publicKey,
+    sendAsset: new NativeAssetId(),
+    destAsset: usdcAsset,
+    destAmount: "5",
+    sendMax: "21",
+  })
+  .build();
+```
+
+```dart
+// Deliver exactly 5 USDC; spend no more than 21 XLM to do it
+var txn = txBuilder.pathPay(
+    destinationAddress: receivingKp.address,
+    sendAsset: NativeAssetId(),
+    destinationAsset: usdcAsset,
+    destAmount: "5",
+    sendMax: "21",
+  ).build();
+```
+
+```swift
+// Deliver exactly 5 USDC; spend no more than 21 XLM to do it
+let txn = try txBuilder.pathPay(destinationAddress: receivingKp.address,
+                                sendAsset: NativeAssetId(),
+                                destinationAsset: usdcAsset,
+                                destAmount: 5,
+                                sendMax: 21).build()
 ```
 
 </WalletCodeExample>

--- a/docs/build/apps/wallet/stellar.mdx
+++ b/docs/build/apps/wallet/stellar.mdx
@@ -336,7 +336,7 @@ let usdcAsset = try IssuedAssetId(
 let txn = try txBuilder.swap(fromAsset: NativeAssetId(),
                              toAsset: usdcAsset,
                              amount: 0.1,
-                             destinationMinAmount: 0.025).build()
+                             destMin: 0.025).build()
 ```
 
 </WalletCodeExample>
@@ -348,7 +348,7 @@ Send one asset from the source account and receive a different asset in the dest
 Like a swap, a path payment is filled at the rate available when the transaction is applied, so it takes a slippage limit. Which limit depends on which side of the payment is fixed:
 
 - When you fix the amount to send (`sendAmount`), pass `destMin`: the least amount of the destination asset the recipient must receive.
-- When you fix the amount to deliver (`destAmount`), pass `sendMax`: the most of the send asset the source account is willing to spend.
+- When you fix the amount to deliver (`destAmount`), pass `sendMax`: the maximum amount of the send asset the source account is willing to spend.
 
 If the network cannot fill the payment within that limit, the transaction fails instead of executing at a worse rate. Derive the limit from a current quote plus or minus the slippage tolerance you are willing to accept.
 


### PR DESCRIPTION
## TL;DR

The wallet guide's Swap and Path Pay examples called the wallet SDKs without a minimum-received or maximum-spent bound, and never explained what those parameters are for. This adds a short explanation of the slippage limit to both sections — a swap or path payment is filled at whatever rate the network finds when the transaction is applied, and the bound is what makes it fail rather than fill at a worse rate — and passes an explicit bound in every TypeScript, Dart, and Swift snippet. It also adds a strict-receive example (fix the amount delivered, cap the amount spent), which the page did not show before.

Companion change: stellar/typescript-wallet-sdk#252 makes the bound a required argument in the TypeScript wallet SDK. The updated snippets here are valid on the current SDK releases too, since the parameters already exist, so this PR does not need to wait on that one.

<details>
<summary>Implementation details (for agents)</summary>

**What changed** (single file, `docs/build/apps/wallet/stellar.mdx`):

- [Swap section](https://github.com/stellar/stellar-docs/blob/5bafa49b258cf26e4fa0ce659483879b1fe5343e/docs/build/apps/wallet/stellar.mdx#L289-L342) — new paragraph describing `destMin` as the slippage limit and how to derive it (current quote minus tolerance). All three snippets now pass a minimum: TypeScript `swap(..., ".1", ".025")`, Dart `destMin: "0.025"`, Swift `destMin: 0.025`. Parameter names verified against each SDK's current source.
- [Path Pay section](https://github.com/stellar/stellar-docs/blob/5bafa49b258cf26e4fa0ce659483879b1fe5343e/docs/build/apps/wallet/stellar.mdx#L344-L449) — new paragraph explaining which bound applies to which mode (`sendAmount` → `destMin`, `destAmount` → `sendMax`). The existing strict-send snippets gain `destMin: "1.25"` in all three languages. A second `<WalletCodeExample>` block shows the strict-receive form with `destAmount: "5"` / `sendMax: "21"` in all three languages.
- Each snippet carries a one-line comment stating the intent of the numbers, which are illustrative.

**Verification:**

- `prettier --config .prettierrc.js --no-editorconfig -c docs/build/apps/wallet/stellar.mdx` with prettier 3.9.6 and `@stellar/prettier-config`: passes (this is what `ci:mdx` runs).
- `<WalletCodeExample>` open/close tags balance (36/36) after the edit.
- No links added, so `check:links` is unaffected. No frontmatter or heading changes.

**Follow-ups / out of scope:**

- The page still does not show how to obtain a quote (Horizon strict-send/strict-receive paths); a short pointer there would let readers derive the bound rather than hard-code it.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

