### PR TITLE
Day one updates on /launch/usdt0

### DIFF
--- a/static/launch/usdt0.html
+++ b/static/launch/usdt0.html
@@ -688,19 +688,19 @@ gtag('js',new Date());gtag('config','G-ZCT4GYX8KN',{anonymize_ip:true});</script
 
       <div class="venues">
         <div class="venue">
-          <h3>Exchange</h3>
-          <ul><li>Kraken</li><li>SushiSwap</li><li>BiLira</li></ul>
-          <p>Buy, sell, and swap USDT0 on Stellar.</p>
+          <h3>Exchanges, DEXs &amp; Lending Protocols</h3>
+          <ul><li>Kraken</li><li>SushiSwap</li><li>BiLira</li><li>Kinetic (K2)</li></ul>
+          <p>Buy, sell, swap, and borrow against USDT0 on Stellar.</p>
         </div>
         <div class="venue">
           <h3>Wallets</h3>
-          <ul><li>Freighter</li><li>Lobstr</li><li>Meru</li><li>Bitget Wallet</li></ul>
+          <ul><li>Freighter</li><li>Lobstr</li><li>Meru</li><li>Bitget Wallet</li><li>Exodus</li></ul>
           <p>Hold and send USDT0 on Stellar.</p>
         </div>
         <div class="venue">
-          <h3>Custody &amp; infra</h3>
-          <ul><li>Fireblocks</li><li>WalletConnect</li></ul>
-          <p>Institutional custody and treasury ops; wallet connection across the aggregator.</p>
+          <h3>Custody</h3>
+          <ul><li>Fireblocks</li></ul>
+          <p>Institutional custody and treasury operations for USDT0 on Stellar.</p>
         </div>
         <div class="venue">
           <h3>Fintechs &amp; ramps</h3>
@@ -708,6 +708,9 @@ gtag('js',new Date());gtag('config','G-ZCT4GYX8KN',{anonymize_ip:true});</script
           <p>Ramp services and fintech products using USDT0 in production, including cross-border payments across Africa.</p>
         </div>
       </div>
+
+      <a class="dep-link" href="https://usdt0.to/transfer" target="_blank" rel="noopener noreferrer">
+        Transfer USDT0 to Stellar &rarr;</a>
 
     </div>
     <div class="dep-note">Balances move into and out of Stellar without a custodial bridge or a
@@ -835,7 +838,7 @@ gtag('js',new Date());gtag('config','G-ZCT4GYX8KN',{anonymize_ip:true});</script
     <span>Stellar Development Foundation</span>
     <span class="foot-r">
       <span class="foot-icons">
-      <button class="themetog" id="themetog" type="button" aria-pressed="false" aria-label="Toggle color theme" title="Toggle color theme">
+      <button class="themetog" id="themetog" type="button" aria-pressed="false">
         <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
              stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/>


### PR DESCRIPTION
Follow-up to #2807, updating the Day one section on `/launch/usdt0`.

**Removes WalletConnect.** It was listed as a partner, but it is a connection transport rather than an integration. Freighter's own docs describe it as how Freighter Mobile reaches a dapp — it relays `stellar_signXDR` and is asset-agnostic, so it would carry an XLM payment identically. Nothing about it integrated USDT0, which is what this section claims of everything in it. That also empties "& infra" of meaning, so the card is now just **Custody**, and its caption drops "wallet connection across the aggregator", which did not refer to anything identifiable.

**Adds Kinetic (K2).** A money market, so "Exchange" no longer described a card holding a CEX, a DEX, a regional exchange and a lending protocol. Retitled **Exchanges, DEXs & Lending Protocols**.

**Adds Exodus** back to Wallets.

**Adds a transfer link.** Day one said where USDT0 already is and never said how to get any. `usdt0.to/transfer` now sits under the cards, styled like the stellar.expert link in Deploy so both sections use one grammar for the next step.

One file changed, no new assets. All four cards still measure the same height, so the row is unaffected.
