### PR TITLE
🔧 Preserve accurate last-update attribution

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          # Docusaurus uses Git history for last-update author and time.
+          fetch-depth: 0
 
       - name: Determine image label
         id: vars


### PR DESCRIPTION
## Why

Docusaurus derives each page's last-update author and timestamp from Git history. The production workflow currently checks out only the triggering commit, so that shallow clone's root commit can be attributed to pages it did not modify.

For example, the deployed SDEX page reports a September 2 update by maz, while the latest commit that actually changed the page is `7a80e82bd` from July 15 by John Wooten.

## What changed

Fetch the complete repository history in the production build-and-push workflow by setting `fetch-depth: 0` on the checkout step. This gives Docusaurus the history it needs without changing page content.

## Verification

`corepack pnpm build` completed successfully with full history. The generated SDEX page rendered:

> Last updated on Jul 15, 2026 by John Wooten