### PR TITLE
docs: add Soroscan to block explorers

### DIFF
--- a/docs/tools/developer-tools/block-explorers.mdx
+++ b/docs/tools/developer-tools/block-explorers.mdx
@@ -27,7 +27,7 @@ Explore transactions, accounts, assets, contracts, and ledgers, with a built-in 
 
 :::note
 
-Soroscan is a newer explorer under active development. A few things we're still working on:
+Soroscan is a newer explorer under active development. A few things the Soroscan team is still working on:
 
 - Richer analytics and network insights
 - Deeper detail across account, contract, and asset views

--- a/docs/tools/developer-tools/block-explorers.mdx
+++ b/docs/tools/developer-tools/block-explorers.mdx
@@ -20,3 +20,7 @@ Explore transactions and network activity for Stellar’s networks, including Fu
 ### [Stellar Explorer](https://steexp.com)
 
 Check data related to payments, accounts, deployed contracts, and more for Stellar’s Futurenet, Testnet, and Mainnet.
+
+### [Soroscan](https://soroscan.io)
+
+Explore transactions, accounts, assets, contracts, and ledgers, with a built-in AI assistant that answers questions about on-chain data. Available for Mainnet, Testnet, and Futurenet.

--- a/docs/tools/developer-tools/block-explorers.mdx
+++ b/docs/tools/developer-tools/block-explorers.mdx
@@ -24,3 +24,13 @@ Check data related to payments, accounts, deployed contracts, and more for Stell
 ### [Soroscan](https://soroscan.io)
 
 Explore transactions, accounts, assets, contracts, and ledgers, with a built-in AI assistant that answers questions about on-chain data. Available for Mainnet, Testnet, and Futurenet.
+
+:::note
+
+Soroscan is a newer explorer under active development. A few things we're still working on:
+
+- Richer analytics and network insights
+- Deeper detail across account, contract, and asset views
+- Expanding the built-in AI assistant
+
+:::


### PR DESCRIPTION
Adds Soroscan to the block explorers list. Soroscan is a Stellar block explorer covering Mainnet, Testnet, and Futurenet, with a built-in AI assistant for on-chain questions. Live at https://soroscan.io.