### PR TITLE
Document cargo-afl fuzzing support

### DIFF
--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -265,9 +265,9 @@ To measure code coverage of regular Rust tests, see [Code Coverage].
 [unit tests]: ./unit-tests.mdx
 [stellar/rs-soroban-sdk#1360]: https://github.com/stellar/rs-soroban-sdk/issues/1360
 [fuzzing example]: ../../smart-contracts/example-contracts/fuzzing.mdx
+[Rust Fuzz Book]: https://rust-fuzz.github.io/book
 [Code Coverage]: code-coverage.mdx
 [Coverage Gutters]: https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters
 [`cargo-afl`]: https://github.com/rust-fuzz/afl.rs
 [AFL++]: https://aflplus.plus
 [`afl::fuzz!`]: https://docs.rs/afl/latest/afl/macro.fuzz.html
-[Rust Fuzz Book]: https://rust-fuzz.github.io/book

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -116,9 +116,98 @@ For a full detailed example, see the [fuzzing example].
 
 :::
 
-:::info
+## How to Write Fuzz Tests with `cargo-afl`
 
-There is another tool for fuzzing Rust code, `cargo-afl`. See the [Rust Fuzz book] for a tutorial for how to use it.
+_Available since soroban-sdk v28.0.0._
+
+[`cargo-afl`] drives [AFL++] and, unlike `cargo-fuzz`, runs on stable Rust, making it a good alternative for anyone who'd rather not switch to nightly.
+
+1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler needs to be available.
+
+   ```text
+   cargo install cargo-afl --locked
+   ```
+
+2. Configure the machine for fuzzing.
+
+   ```text
+   cargo afl system-config
+   ```
+
+3. Create a fuzz target crate, for example in a `fuzz` directory inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because that's where the `Arbitrary` derive comes from and where the `fuzz!` macro looks up the trait.
+
+   ```toml
+   [dependencies]
+   afl = "0.18"
+   arbitrary = { version = "~1.3.0", features = ["derive"] }
+   soroban-sdk = { version = "*", features = ["testutils"] }
+   my-contract = { path = ".." }
+   ```
+
+4. Write the fuzz target. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
+
+   ```rust
+   use afl::fuzz;
+   use soroban_increment_with_fuzz_contract::{IncrementContract, IncrementContractClient};
+   use soroban_sdk::{
+       testutils::arbitrary::{arbitrary, Arbitrary},
+       Env,
+   };
+
+   #[derive(Debug, Arbitrary)]
+   pub struct Input {
+       pub by: u64,
+   }
+
+   fn main() {
+       fuzz!(|input: Input| {
+           // Create the `Env` inside the closure, not outside: AFL++ reuses the
+           // process for many inputs, and state created outside the closure
+           // would leak from one input into the next.
+           let env = Env::default();
+           let id = env.register(IncrementContract, ());
+           let client = IncrementContractClient::new(&env, &id);
+
+           let mut last: Option<u32> = None;
+           for _ in input.by.. {
+               match client.try_increment() {
+                   Ok(Ok(current)) => assert!(Some(current) > last),
+                   Err(Ok(_)) => {} // Expected error
+                   Ok(Err(_)) => panic!("success with wrong type returned"),
+                   Err(Err(_)) => panic!("unrecognised error"),
+               }
+           }
+       });
+   }
+   ```
+
+5. Build the target. `cargo afl build` is `cargo build` with AFL++'s instrumentation added.
+
+   ```text
+   cargo afl build
+   ```
+
+6. Fuzz the target, pointing at an input directory containing at least one seed input and an output directory to write results to.
+
+   ```text
+   cargo afl fuzz -i in -o out target/debug/fuzz_target_1
+   ```
+
+   :::tip
+
+   Fuzz debug builds, at least at first: they keep integer overflow checks and `debug_assert!`s enabled, and those catch bugs a release build would let through.
+
+   :::
+
+Crashing inputs are written to `out/default/crashes/`. The target reads an input on stdin when it isn't being driven by AFL++, so a crash can be replayed by feeding the file back in:
+
+```text
+RUST_BACKTRACE=1 ./target/debug/fuzz_target_1 < out/default/crashes/id:000000*
+```
+
+:::tip
+
+For a full, buildable example, see the [`fuzz_afl`] test crate in the `rs-soroban-sdk` repository.
 
 :::
 
@@ -170,6 +259,9 @@ To measure code coverage of regular Rust tests, see [Code Coverage].
 [unit tests]: ./unit-tests.mdx
 [stellar/rs-soroban-sdk#1360]: https://github.com/stellar/rs-soroban-sdk/issues/1360
 [fuzzing example]: ../../smart-contracts/example-contracts/fuzzing.mdx
-[Rust Fuzz Book]: https://rust-fuzz.github.io/book
 [Code Coverage]: code-coverage.mdx
 [Coverage Gutters]: https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters
+[`cargo-afl`]: https://github.com/rust-fuzz/afl.rs
+[AFL++]: https://aflplus.plus
+[`afl::fuzz!`]: https://docs.rs/afl/latest/afl/macro.fuzz.html
+[`fuzz_afl`]: https://github.com/stellar/rs-soroban-sdk/tree/main/tests/fuzz_afl

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -118,8 +118,6 @@ For a full detailed example, see the [fuzzing example].
 
 ## How to Write Fuzz Tests with `cargo-afl`
 
-_Available since soroban-sdk v28.0.0._
-
 [`cargo-afl`] drives [AFL++] and, unlike `cargo-fuzz`, runs on stable Rust, making it a good alternative for anyone who'd rather not switch to nightly.
 
 1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler needs to be available.

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -134,7 +134,7 @@ _Available since soroban-sdk v28.0.0._
    cargo afl system-config
    ```
 
-3. Create a fuzz target crate, for example in a `fuzz` directory inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because that's where the `Arbitrary` derive comes from and where the `fuzz!` macro looks up the trait.
+3. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because that's where the `Arbitrary` derive comes from and where the `fuzz!` macro looks up the trait. Add the following to the new crate's `Cargo.toml`:
 
    ```toml
    [dependencies]
@@ -146,9 +146,12 @@ _Available since soroban-sdk v28.0.0._
    [[bin]]
    name = "fuzz_target_1"
    path = "src/fuzz_target_1.rs"
+
+   # Keep this crate out of the contract's workspace, in case it's a member of one.
+   [workspace]
    ```
 
-4. Write the fuzz target in `src/fuzz_target_1.rs`. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
+4. Write the fuzz target at `src/fuzz_target_1.rs`, replacing the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
 
    ```rust
    use afl::fuzz;

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -211,12 +211,6 @@ Crashing inputs are written to `out/default/crashes/`. The target reads an input
 RUST_BACKTRACE=1 ./target/debug/fuzz_target_1 < out/default/crashes/id:000000*
 ```
 
-:::tip
-
-For a full, buildable example, see the [`fuzz_afl`] test crate in the `rs-soroban-sdk` repository.
-
-:::
-
 ## How to Get Code Coverage of Fuzz Tests
 
 Getting code coverage data for fuzz tests requires some different tooling than when doing the same for regular Rust tests.
@@ -270,4 +264,3 @@ To measure code coverage of regular Rust tests, see [Code Coverage].
 [`cargo-afl`]: https://github.com/rust-fuzz/afl.rs
 [AFL++]: https://aflplus.plus
 [`afl::fuzz!`]: https://docs.rs/afl/latest/afl/macro.fuzz.html
-[`fuzz_afl`]: https://github.com/stellar/rs-soroban-sdk/tree/main/tests/fuzz_afl

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -211,6 +211,12 @@ Crashing inputs are written to `out/default/crashes/`. The target reads an input
 RUST_BACKTRACE=1 ./target/debug/fuzz_target_1 < out/default/crashes/id:000000*
 ```
 
+:::tip
+
+See the [Rust Fuzz Book] for a more general tutorial on `cargo-afl`.
+
+:::
+
 ## How to Get Code Coverage of Fuzz Tests
 
 Getting code coverage data for fuzz tests requires some different tooling than when doing the same for regular Rust tests.
@@ -264,3 +270,4 @@ To measure code coverage of regular Rust tests, see [Code Coverage].
 [`cargo-afl`]: https://github.com/rust-fuzz/afl.rs
 [AFL++]: https://aflplus.plus
 [`afl::fuzz!`]: https://docs.rs/afl/latest/afl/macro.fuzz.html
+[Rust Fuzz Book]: https://rust-fuzz.github.io/book

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -147,11 +147,12 @@ _Available since soroban-sdk v28.0.0._
    name = "fuzz_target_1"
    path = "src/fuzz_target_1.rs"
 
-   # Keep this crate out of the contract's workspace, in case it's a member of one.
+   # Prevent this from interfering with the contract's workspace, if it has one.
    [workspace]
+   members = ["."]
    ```
 
-4. Write the fuzz target at `src/fuzz_target_1.rs`, replacing the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
+4. Write the fuzz target at `src/fuzz_target_1.rs`, and delete the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
 
    ```rust
    use afl::fuzz;

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -118,7 +118,7 @@ For a full detailed example, see the [fuzzing example].
 
 ## How to Write Fuzz Tests with `cargo-afl`
 
-[`cargo-afl`] drives [AFL++] and, unlike `cargo-fuzz`, runs on stable Rust, making it a good alternative for anyone who'd rather not switch to nightly.
+[`cargo-afl`] drives [AFL++] and, unlike `cargo-fuzz`, runs on stable Rust.
 
 1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler needs to be available.
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -186,7 +186,7 @@ For a full detailed example, see the [fuzzing example].
    }
    ```
 
-5. From inside the `fuzz` crate, build the target. `cargo afl build` is `cargo build` with AFL++'s instrumentation added.
+5. From inside the `fuzz` crate, build the target.
 
    ```text
    cd fuzz

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -11,7 +11,7 @@ Fuzz tests can also be written as property tests that instead of seeking to iden
 
 The following steps can be used in any Stellar contract workspace. If experimenting, try them in the [increment example]. The contract has an `increment` function that increases a counter value by one on every invocation.
 
-## How to Write Fuzz Tests
+## How to Write Fuzz Tests with `cargo-fuzz`
 
 1. Install the nightly Rust toolchain. Nightly Rust is required to run cargo-fuzz.
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -201,7 +201,7 @@ For a full detailed example, see the [fuzzing example].
 
    :::tip
 
-   Fuzz debug builds, at least at first: they keep integer overflow checks and `debug_assert!`s enabled, and those catch bugs a release build would let through.
+   Fuzz debug builds, at least at first: they keep integer overflow checks and `debug_assert!`s enabled, and those catch bugs a release build won't.
 
    :::
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -142,17 +142,19 @@ _Available since soroban-sdk v28.0.0._
    arbitrary = { version = "~1.3.0", features = ["derive"] }
    soroban-sdk = { version = "*", features = ["testutils"] }
    my-contract = { path = ".." }
+
+   [[bin]]
+   name = "fuzz_target_1"
+   path = "src/fuzz_target_1.rs"
    ```
 
-4. Write the fuzz target. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
+4. Write the fuzz target in `src/fuzz_target_1.rs`. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
 
    ```rust
    use afl::fuzz;
+   use arbitrary::Arbitrary;
    use soroban_increment_with_fuzz_contract::{IncrementContract, IncrementContractClient};
-   use soroban_sdk::{
-       testutils::arbitrary::{arbitrary, Arbitrary},
-       Env,
-   };
+   use soroban_sdk::Env;
 
    #[derive(Debug, Arbitrary)]
    pub struct Input {
@@ -181,9 +183,10 @@ _Available since soroban-sdk v28.0.0._
    }
    ```
 
-5. Build the target. `cargo afl build` is `cargo build` with AFL++'s instrumentation added.
+5. From inside the `fuzz` crate, build the target. `cargo afl build` is `cargo build` with AFL++'s instrumentation added.
 
    ```text
+   cd fuzz
    cargo afl build
    ```
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -13,7 +13,7 @@ The following steps can be used in any Stellar contract workspace. If experiment
 
 :::tip
 
-See the [Rust Fuzz Book] for a more general tutorial on both `cargo-fuzz` and `cargo-afl`.
+See the [Rust Fuzz Book] for a general tutorial on using both `cargo-fuzz` and `cargo-afl`.
 
 :::
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -138,11 +138,12 @@ For a full detailed example, see the [fuzzing example].
    cargo afl system-config
    ```
 
-3. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Add the following to the new crate's `Cargo.toml`:
+3. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because the `fuzz!` macro expands to code that refers to it by an absolute path, which only resolves if `arbitrary` is a direct dependency. Add the following to the new crate's `Cargo.toml`:
 
    ```toml
    [dependencies]
    afl = "0.18"
+   arbitrary = { version = "~1.3.0", features = ["derive"] }
    soroban-sdk = { version = "*", features = ["testutils"] }
    my-contract = { path = ".." }
 
@@ -159,11 +160,9 @@ For a full detailed example, see the [fuzzing example].
 
    ```rust
    use afl::fuzz;
+   use arbitrary::Arbitrary;
    use soroban_increment_with_fuzz_contract::{IncrementContract, IncrementContractClient};
-   use soroban_sdk::{
-       testutils::arbitrary::{arbitrary, Arbitrary},
-       Env,
-   };
+   use soroban_sdk::Env;
 
    #[derive(Debug, Arbitrary)]
    pub struct Input {
@@ -180,7 +179,7 @@ For a full detailed example, see the [fuzzing example].
            let client = IncrementContractClient::new(&env, &id);
 
            let mut last: Option<u32> = None;
-           for _ in input.by.. {
+           for _ in 0..input.by {
                match client.try_increment() {
                    Ok(Ok(current)) => assert!(Some(current) > last),
                    Err(Ok(_)) => {} // Expected error
@@ -202,6 +201,8 @@ For a full detailed example, see the [fuzzing example].
 6. Fuzz the target, pointing at an input directory containing at least one seed input and an output directory to write results to.
 
    ```text
+   mkdir in out
+   echo -n '00000000' > in/seed
    cargo afl fuzz -i in -o out target/debug/fuzz_target_1
    ```
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -11,6 +11,12 @@ Fuzz tests can also be written as property tests that instead of seeking to iden
 
 The following steps can be used in any Stellar contract workspace. If experimenting, try them in the [increment example]. The contract has an `increment` function that increases a counter value by one on every invocation.
 
+:::tip
+
+See the [Rust Fuzz Book] for a more general tutorial on both `cargo-fuzz` and `cargo-afl`.
+
+:::
+
 ## How to Write Fuzz Tests with `cargo-fuzz`
 
 1. Install the nightly Rust toolchain. Nightly Rust is required to run cargo-fuzz.
@@ -210,12 +216,6 @@ Crashing inputs are written to `out/default/crashes/`. The target reads an input
 ```text
 RUST_BACKTRACE=1 ./target/debug/fuzz_target_1 < out/default/crashes/id:000000*
 ```
-
-:::tip
-
-See the [Rust Fuzz Book] for a more general tutorial on `cargo-afl`.
-
-:::
 
 ## How to Get Code Coverage of Fuzz Tests
 

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -134,12 +134,11 @@ _Available since soroban-sdk v28.0.0._
    cargo afl system-config
    ```
 
-3. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because that's where the `Arbitrary` derive comes from and where the `fuzz!` macro looks up the trait. Add the following to the new crate's `Cargo.toml`:
+3. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Add the following to the new crate's `Cargo.toml`:
 
    ```toml
    [dependencies]
    afl = "0.18"
-   arbitrary = { version = "~1.3.0", features = ["derive"] }
    soroban-sdk = { version = "*", features = ["testutils"] }
    my-contract = { path = ".." }
 
@@ -152,13 +151,15 @@ _Available since soroban-sdk v28.0.0._
    members = ["."]
    ```
 
-4. Write the fuzz target at `src/fuzz_target_1.rs`, and delete the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro, rather than the `fuzz_target!` macro `cargo-fuzz` uses. For example, for the [increment example]:
+4. Write the fuzz target at `src/fuzz_target_1.rs`, and delete the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro. For example, for the [increment example]:
 
    ```rust
    use afl::fuzz;
-   use arbitrary::Arbitrary;
    use soroban_increment_with_fuzz_contract::{IncrementContract, IncrementContractClient};
-   use soroban_sdk::Env;
+   use soroban_sdk::{
+       testutils::arbitrary::{arbitrary, Arbitrary},
+       Env,
+   };
 
    #[derive(Debug, Arbitrary)]
    pub struct Input {

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -126,13 +126,13 @@ For a full detailed example, see the [fuzzing example].
 
 [`cargo-afl`] drives [AFL++] and, unlike `cargo-fuzz`, runs on stable Rust.
 
-1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler needs to be available.
+1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler and `make` need to be available. `cargo-afl` works on x86-64 Linux, x86-64 macOS and ARM64 macOS.
 
    ```text
    cargo install cargo-afl --locked
    ```
 
-2. Configure the machine for fuzzing.
+2. Configure the machine for fuzzing. This command needs root, so `cargo-afl` runs `sudo` for you.
 
    ```text
    cargo afl system-config

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -175,7 +175,7 @@ For a full detailed example, see the [fuzzing example].
 
    #[derive(Debug, Arbitrary)]
    pub struct Input {
-       pub by: u9,
+       pub by: u8,
    }
 
    fn main() {

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -232,11 +232,11 @@ Crashing inputs are written to `out/default/crashes/`. The target reads an input
 RUST_BACKTRACE=1 ./target/debug/fuzz_target_1 < out/default/crashes/id:000000*
 ```
 
-## How to Get Code Coverage of Fuzz Tests
+## How to Get Code Coverage of `cargo-fuzz` Tests
 
 Getting code coverage data for fuzz tests requires some different tooling than when doing the same for regular Rust tests.
 
-1. Run the fuzz tests until it has produced a corpus, just as in step 7 above.
+1. Run the `cargo-fuzz` target until it has produced a corpus.
 
    ```text
    cargo +nightly fuzz run --sanitizer thread fuzz_target_1

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -126,7 +126,7 @@ For a full detailed example, see the [fuzzing example].
 
 [`cargo-afl`] drives [AFL++] and, unlike `cargo-fuzz`, runs on stable Rust.
 
-1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler and `make` need to be available. `cargo-afl` works on x86-64 Linux, x86-64 macOS and ARM64 macOS.
+1. Install `cargo-afl`. Installing it builds AFL++ from source, so a C compiler needs to be available.
 
    ```text
    cargo install cargo-afl --locked

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -175,9 +175,7 @@ For a full detailed example, see the [fuzzing example].
 
    #[derive(Debug, Arbitrary)]
    pub struct Input {
-       // Keep the count small. An arbitrary `u64` makes a single execution do
-       // billions of invocations, and AFL++ stops on the timeout.
-       pub by: u8,
+       pub by: u9,
    }
 
    fn main() {

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -146,7 +146,7 @@ For a full detailed example, see the [fuzzing example].
    +crate-type = ["lib", "cdylib"]
    ```
 
-4. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because the `fuzz!` macro expands to code that refers to it by an absolute path, which only resolves if `arbitrary` is a direct dependency. Add the following to the new crate's `Cargo.toml`:
+4. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because the `fuzz!` macro expands to code that refers to it by an absolute path, which only resolves if `arbitrary` is a direct dependency. Put the following in the new crate's `Cargo.toml`. It replaces the empty `[dependencies]` table that `cargo new` generated.
 
    ```toml
    [dependencies]
@@ -154,7 +154,7 @@ For a full detailed example, see the [fuzzing example].
    arbitrary = { version = "~1.3.0", features = ["derive"] }
    soroban-sdk = { version = "*", features = ["testutils"] }
    # The contract to fuzz. Use the package name from its Cargo.toml.
-   soroban-increment-with-fuzz-contract = { path = ".." }
+   soroban-increment-contract = { path = ".." }
 
    [[bin]]
    name = "fuzz_target_1"
@@ -170,7 +170,7 @@ For a full detailed example, see the [fuzzing example].
    ```rust
    use afl::fuzz;
    use arbitrary::Arbitrary;
-   use soroban_increment_with_fuzz_contract::{IncrementContract, IncrementContractClient};
+   use soroban_increment_contract::{IncrementContract, IncrementContractClient};
    use soroban_sdk::Env;
 
    #[derive(Debug, Arbitrary)]
@@ -205,7 +205,7 @@ For a full detailed example, see the [fuzzing example].
    }
    ```
 
-6. From inside the `fuzz` crate, build the target.
+6. Build the target. The remaining steps also run from inside the `fuzz` crate.
 
    ```text
    cd fuzz

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -218,12 +218,6 @@ For a full detailed example, see the [fuzzing example].
    cargo afl fuzz -i in -o out target/debug/fuzz_target_1
    ```
 
-   :::tip
-
-   There is no need to add `--release`. `cargo afl build` always passes `-C debug-assertions`, `-C overflow_checks` and `-C opt-level=3`. The debug profile keeps the extra checks, and it is still optimized.
-
-   :::
-
 Crashing inputs are written to `out/default/crashes/`. The target reads an input on stdin when it isn't being driven by AFL++, so a crash can be replayed by feeding the file back in:
 
 ```text

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -132,7 +132,7 @@ For a full detailed example, see the [fuzzing example].
    cargo install cargo-afl --locked
    ```
 
-2. Configure the machine for fuzzing. This command needs root, so `cargo-afl` runs `sudo` for you.
+2. Configure the machine for fuzzing.
 
    ```text
    cargo afl system-config

--- a/docs/build/guides/testing/fuzzing.mdx
+++ b/docs/build/guides/testing/fuzzing.mdx
@@ -138,14 +138,23 @@ For a full detailed example, see the [fuzzing example].
    cargo afl system-config
    ```
 
-3. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because the `fuzz!` macro expands to code that refers to it by an absolute path, which only resolves if `arbitrary` is a direct dependency. Add the following to the new crate's `Cargo.toml`:
+3. Open the contract's `Cargo.toml` file. Add `lib` as a `crate-type`. The fuzz target imports the contract as a Rust library.
+
+   ```diff
+    [lib]
+   -crate-type = ["cdylib"]
+   +crate-type = ["lib", "cdylib"]
+   ```
+
+4. Create a fuzz target crate, for example with `cargo new --bin fuzz` inside your contract's directory. Unlike a `cargo-fuzz` target, an AFL++ target depends on the `arbitrary` crate directly, because the `fuzz!` macro expands to code that refers to it by an absolute path, which only resolves if `arbitrary` is a direct dependency. Add the following to the new crate's `Cargo.toml`:
 
    ```toml
    [dependencies]
    afl = "0.18"
    arbitrary = { version = "~1.3.0", features = ["derive"] }
    soroban-sdk = { version = "*", features = ["testutils"] }
-   my-contract = { path = ".." }
+   # The contract to fuzz. Use the package name from its Cargo.toml.
+   soroban-increment-with-fuzz-contract = { path = ".." }
 
    [[bin]]
    name = "fuzz_target_1"
@@ -156,7 +165,7 @@ For a full detailed example, see the [fuzzing example].
    members = ["."]
    ```
 
-4. Write the fuzz target at `src/fuzz_target_1.rs`, and delete the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro. For example, for the [increment example]:
+5. Write the fuzz target at `src/fuzz_target_1.rs`, and delete the default `src/main.rs` `cargo new` created. An AFL++ target is a regular binary crate with a `main` function that calls the [`afl::fuzz!`] macro. For example, for the [increment example]:
 
    ```rust
    use afl::fuzz;
@@ -166,7 +175,9 @@ For a full detailed example, see the [fuzzing example].
 
    #[derive(Debug, Arbitrary)]
    pub struct Input {
-       pub by: u64,
+       // Keep the count small. An arbitrary `u64` makes a single execution do
+       // billions of invocations, and AFL++ stops on the timeout.
+       pub by: u8,
    }
 
    fn main() {
@@ -181,7 +192,10 @@ For a full detailed example, see the [fuzzing example].
            let mut last: Option<u32> = None;
            for _ in 0..input.by {
                match client.try_increment() {
-                   Ok(Ok(current)) => assert!(Some(current) > last),
+                   Ok(Ok(current)) => {
+                       assert!(Some(current) > last);
+                       last = Some(current);
+                   }
                    Err(Ok(_)) => {} // Expected error
                    Ok(Err(_)) => panic!("success with wrong type returned"),
                    Err(Err(_)) => panic!("unrecognised error"),
@@ -191,14 +205,14 @@ For a full detailed example, see the [fuzzing example].
    }
    ```
 
-5. From inside the `fuzz` crate, build the target.
+6. From inside the `fuzz` crate, build the target.
 
    ```text
    cd fuzz
    cargo afl build
    ```
 
-6. Fuzz the target, pointing at an input directory containing at least one seed input and an output directory to write results to.
+7. Fuzz the target, pointing at an input directory containing at least one seed input and an output directory to write results to.
 
    ```text
    mkdir in out
@@ -208,7 +222,7 @@ For a full detailed example, see the [fuzzing example].
 
    :::tip
 
-   Fuzz debug builds, at least at first: they keep integer overflow checks and `debug_assert!`s enabled, and those catch bugs a release build won't.
+   There is no need to add `--release`. `cargo afl build` always passes `-C debug-assertions`, `-C overflow_checks` and `-C opt-level=3`. The debug profile keeps the extra checks, and it is still optimized.
 
    :::
 


### PR DESCRIPTION
### What
Add a step-by-step guide for fuzzing Soroban contracts with `cargo-afl` (AFL++) to the fuzzing guide, replacing the placeholder note that just pointed readers to the generic Rust Fuzz book.

### Why
We should demonstrate it as the fuzzing tools can be a bit overwhelming.