### PR TITLE
docs: add Scopuly to x402 compatible wallets

### DIFF
--- a/docs/build/agentic-payments/x402/README.mdx
+++ b/docs/build/agentic-payments/x402/README.mdx
@@ -29,6 +29,7 @@ To support x402 on Stellar, a wallet must support [auth-entry signing](../../gui
 - HOT
 - Klever
 - OneKey
+- Scopuly
 
 :::note
 


### PR DESCRIPTION
Adds Scopuly to the x402 compatible-wallet list.

Scopuly Mobile on iOS and Android supports Soroban authorization-entry signing for Stellar x402 v2 `exact` payments, both through the in-app browser and the paired browser extension. The mobile wallet validates the transfer parameters and requires explicit user approval before signing.

The payment flow has been tested through Mainnet settlement and protected-resource delivery.

Verification:

- iOS: https://apps.apple.com/us/app/id1383402218
- Android: https://play.google.com/store/apps/details?id=com.sdex.app
- Browser extension: https://chromewebstore.google.com/detail/scopuly-stellar-mobile-si/gfblddiiepicpjpffokeojikcphggmmd
- Live demo: https://app.scopuly.com/x402-demo/
- Mainnet transaction: https://stellar.expert/explorer/public/tx/35806f61672cceee39c263f6a1ce66b41267621ec19103d81edab269f49558b5

Closes #2816