### PR TITLE
Correct fee and transfer-time claims on /launch/usdt0

### DIFF
--- a/static/launch/usdt0.html
+++ b/static/launch/usdt0.html
@@ -714,9 +714,11 @@ gtag('js',new Date());gtag('config','G-ZCT4GYX8KN',{anonymize_ip:true});</script
 
     </div>
     <div class="dep-note">Balances move into and out of Stellar without a custodial bridge or a
-    wrapped representation. Fees are LayerZero messaging costs,
-    <a href='https://docs.usdt0.to/technical-documentation/developer/' target='_blank' rel='noopener noreferrer'>quoted per route</a>
-    before you send. Receiving USDT0 needs a trustline on the destination account &mdash;
+    wrapped representation. Transfer time is set by the chain you send from &mdash; a couple of minutes
+    from some networks, hours from others. The cost is that network's gas plus the LayerZero
+    message, <a href='https://docs.usdt0.to/technical-documentation/developer/' target='_blank' rel='noopener noreferrer'>quoted per route</a>
+    before you send. USDT0 itself charges no protocol fee on most routes; where one applies it is
+    0.03%, set per route. Receiving USDT0 needs a trustline on the destination account &mdash;
     see <a href="#build">requirements and limitations</a>.</div>
   </section>
 
@@ -822,7 +824,7 @@ gtag('js',new Date());gtag('config','G-ZCT4GYX8KN',{anonymize_ip:true});</script
     <div><dt>USDT in circulation</dt><dd><a href='https://coinmarketcap.com/currencies/tether/' target='_blank' rel='noopener noreferrer'>$180B+</a></dd></div>
     <div><dt>Stellar settlement</dt><dd><a href='https://developers.stellar.org/docs/learn/fundamentals/stellar-stack' target='_blank' rel='noopener noreferrer'>5&ndash;7s</a></dd></div>
     <div><dt>Stellar fee</dt><dd><a href='https://developers.stellar.org/docs/learn/fundamentals/fees-resource-limits-metering' target='_blank' rel='noopener noreferrer'>100 stroops min</a></dd></div>
-    <div><dt>Cross-chain transfer</dt><dd><a href='https://docs.usdt0.to/technical-documentation/developer/' target='_blank' rel='noopener noreferrer'>30s&ndash;3min</a></dd></div>
+    <div><dt>Transfer to Stellar</dt><dd><a href='https://usdt0.to/transfer' target='_blank' rel='noopener noreferrer'>~20min typical</a></dd></div>
   </dl>
 
   <div class="sources">


### PR DESCRIPTION
Two accuracy corrections to the Day one section of `/launch/usdt0`. No design or layout changes — the spec box keeps its seven rows, with one row replaced in place.

### Fees

The footnote described transfer costs as "Fees are LayerZero messaging costs". That understated them in two ways: the sending network's gas is usually the larger component, and USDT0's own protocol fee was not mentioned anywhere on the page.

The footnote now reads:

> The cost is that network's gas plus the LayerZero message, quoted per route before you send. USDT0 itself charges no protocol fee on most routes; where one applies it is 0.03%, set per route.

Sourced from the USDT0 developer guide ("A small fee (0.03% in basis points) is deducted from each transfer. The `feeBps` variable defines the rate.") and the use-cases page ("most pathways have zero fees"). The docs state the rate and that most routes are free, but do not publish which routes charge it, so no chains are named.

### Transfer time

The spec row read `Cross-chain transfer — 30s–3min`. Two problems: that figure describes the USDT0 network generally rather than routes into Stellar, where measured medians are considerably higher; and it quoted the best case as the expectation, which invites complaints from anyone whose transfer takes longer.

The row now reads `Transfer to Stellar — ~20min typical`, and the footnote names both tails so the figure cannot be read as a guarantee:

> Transfer time is set by the chain you send from — a couple of minutes from some networks, hours from others.

It is renamed from "Cross-chain transfer" because every measurement is inbound. Transfer time is set by the sending chain, so outbound from Stellar is not the same figure and the old label covered both directions.

Timing measurements come from the transfer atlas published by [Everdawn Labs](https://everdawn.to/), who operate USDT0. That atlas is not linked here: it currently lives on a deploy URL rather than a permanent one, and is a point-in-time snapshot rather than a live feed. The row links to the live per-route quote on usdt0.to instead, which reflects the actual route a user is taking.

### Verification

- Every claim traces to `docs.usdt0.to`, `developers.stellar.org`, or first-party Everdawn measurements.
- All outbound links return 200.
- Remaining spec rows re-checked against their sources: `5–7s` and `100 stroops min` match the linked Stellar docs verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
