### PR TITLE
docs: add node101 as a Stellar RPC provider

### DIFF
--- a/docs/data/apis/rpc/providers.mdx
+++ b/docs/data/apis/rpc/providers.mdx
@@ -24,6 +24,7 @@ These providers allow access to the Futurenet, Testnet and Mainnet network.
 | [Exaion](https://crypto.exaion.com) | ❌ | ❌ | ✅ | ✅ | ✅ |
 | [Alchemy](https://dashboard.alchemy.com) | ❌ | ✅ | ✅ | ✅ | ❌ |
 | [GetBlock](https://getblock.io/nodes/xlm/) | ❌ | ❌ | ✅ | ✅ | ✅ |
+| [node101](https://node101.io/en/rpc/stellar) | ❌ | ✅ | ✅ | ✅ | ✅ |
 
 \*_RPC Archive is a new option for those looking to retrieve full ledger history. Currently only the [getLedgers](./api-reference/methods/getLedgers.mdx) RPC method supports this feature. You can choose one of the providers above, or create your own getLedgers archive by following [these steps](./admin-guide/data-lake-integration.mdx)._
 


### PR DESCRIPTION
Adds [node101](https://node101.io/en/rpc/stellar) to the Stellar RPC provider comparison table, following the existing provider rows. node101 offers paid managed infrastructure and dedicated nodes, with testnet and archive services available on request.

RPC Archive support through `getLedgers` is available as an optional service on request; it is not included by default in every plan.

The change adds one provider row. It does not add a free public endpoint or change the publicly accessible API list.


Validation: compared with the existing provider rows; only one provider row is added.
