### PR TITLE
Document CRITICAL validator quality

### DIFF
--- a/docs/validators/admin-guide/configuring.mdx
+++ b/docs/validators/admin-guide/configuring.mdx
@@ -226,7 +226,7 @@ A critical quality validator has the same programmatically enforced requirements
 - publishes a history archive, and
 - belongs to a home domain with at least three validators.
 
-Reserve this rating for an entity you cannot afford to disagree with. Because a critical entity is always required, your node stops closing ledgers when that entity drops below a simple majority of its own validators. In other words, this rating trades liveness for safety, so `HIGH` is the right choice for most quorum sets.
+Reserve this rating for an entity you cannot afford to disagree with. Because a critical entity is always required, your node stops closing ledgers when that entity drops below a simple majority of its own validators. A critical entity also raises the top level threshold to `100%`, so the nested group of lower quality entities is required as well. In other words, this rating trades liveness for safety, so `HIGH` is the right choice for most quorum sets.
 
 #### HIGH Quality
 
@@ -260,8 +260,9 @@ Once you add validators to your configuration, stellar core automatically genera
 - Validators with the same home domain are automatically grouped together and given a threshold requiring a simple majority (`2f+1`)
 - Heterogeneous groups of validators are given a threshold assuming byzantine failure (`3f+1`)
 - Entities are grouped by `QUALITY` and nested from `CRITICAL` to `LOW`
-- `CRITICAL` quality entities are at the top level, where the threshold requires all of them (`100%`)
+- `CRITICAL` quality entities are at the top level, where the threshold requires every member (`100%`)
 - `HIGH` quality entities are nested below them, and are given decision-making priority over `MEDIUM` and `LOW`
+- The nested group below the `CRITICAL` entities counts as one member of the top level, so it is required as well
 - The combined weight of `MEDIUM` quality entities equals a single `HIGH` quality entity
 - The combined weight of `LOW` quality entities equals a single `MEDIUM` quality entity
 

--- a/docs/validators/admin-guide/configuring.mdx
+++ b/docs/validators/admin-guide/configuring.mdx
@@ -226,7 +226,7 @@ A critical quality validator has the same programmatically enforced requirements
 - publishes a history archive, and
 - belongs to a home domain with at least three validators.
 
-Reserve this rating for an entity you cannot afford to disagree with. Because a critical entity is always required, your node stops closing ledgers when that entity drops below a simple majority of its own validators. A critical entity also raises the top level threshold to `100%`, so the nested group of lower quality entities is required as well. In other words, this rating trades liveness for safety, so `HIGH` is the right choice for most quorum sets.
+Reserve this rating for an entity you cannot afford to disagree with. Because a critical entity is always required, your node stops closing ledgers when that entity drops below a simple majority of its own validators. A critical entity also raises the top level threshold to `100%`, so the nested group of lower quality entities is required as well. In other words, this rating trades liveness for safety. Use `HIGH` unless you need that trade.
 
 #### HIGH Quality
 
@@ -266,7 +266,7 @@ Once you add validators to your configuration, stellar core automatically genera
 - The combined weight of `MEDIUM` quality entities equals a single `HIGH` quality entity
 - The combined weight of `LOW` quality entities equals a single `MEDIUM` quality entity
 
-Most quorum sets declare no `CRITICAL` entity. The `HIGH` quality group then becomes the top level, as the diagram below shows.
+When a quorum set declares no `CRITICAL` entity, the `HIGH` quality group becomes the top level, as the diagram below shows.
 
 ![Diagram Automatic Quorum Set Generation](/assets/diagrams/validator_complete.png)
 

--- a/docs/validators/admin-guide/configuring.mdx
+++ b/docs/validators/admin-guide/configuring.mdx
@@ -96,7 +96,7 @@ QUALITY="MEDIUM"
 
 :::note[Tier 1 quality rating]
 
-The example above uses `QUALITY="MEDIUM"`, which is appropriate for a new validator building a track record. If your organization is a [Tier 1 participant](../tier-1-orgs.mdx) (or aspiring to become one), you should declare your own organization as `QUALITY="HIGH"`. Note that `HIGH` quality requires [publishing a history archive](./publishing-history-archives.mdx) — the requirement is programmatically enforced. Declaring a lower quality level significantly reduces your weight in [leader election](#impact-of-validator-quality-on-nomination) and may limit your participation in consensus.
+The example above uses `QUALITY="MEDIUM"`, which is appropriate for a new validator building a track record. If your organization is a [Tier 1 participant](../tier-1-orgs.mdx) (or aspiring to become one), you should declare your own organization as `QUALITY="HIGH"`. Note that `HIGH` quality requires [publishing a history archive](./publishing-history-archives.mdx) and at least three validators under the same home domain — both requirements are programmatically enforced. Declaring a lower quality level significantly reduces your weight in [leader election](#impact-of-validator-quality-on-nomination) and may limit your participation in consensus.
 
 :::
 
@@ -153,7 +153,7 @@ For each organization you want to add, create a separate `[[HOME_DOMAINS]]` tabl
 | Field | Requirements | Description |
 | --- | --- | --- |
 | HOME_DOMAIN | string | URL of home domain linked to a group of validators |
-| QUALITY | string | Rating for this organization's nodes: `HIGH`, `MEDIUM`, or `LOW` |
+| QUALITY | string | Rating for this organization's nodes: `CRITICAL`, `HIGH`, `MEDIUM`, or `LOW` |
 
 Here is an example `[[HOME_DOMAINS]]` array, which creates two `[[HOME_DOMAINS]]` tables:
 
@@ -174,7 +174,7 @@ For each node you would like to add to your quorum set, complete a `[[VALIDATORS
 | Field | Requirements | Description |
 | --- | --- | --- |
 | NAME | string | A unique alias for the node |
-| QUALITY | string | Rating for node (required unless specified in `[[HOME_DOMAINS]]`): `HIGH`, `MEDIUM`, or `LOW`. |
+| QUALITY | string | Rating for node (required unless specified in `[[HOME_DOMAINS]]`): `CRITICAL`, `HIGH`, `MEDIUM`, or `LOW`. |
 | HOME_DOMAIN | string | URL of home domain linked to validator |
 | PUBLIC_KEY | string | Stellar public key associated with validator |
 | ADDRESS | string | Peer:port associated with validator (optional) |
@@ -215,18 +215,29 @@ Your quorum set is automatically configured based on the information you provide
 
 ### Validator Quality
 
-`QUALITY` is a required field for each node you add to your quorum set. Whether you specify it for a suite of nodes in a `[[HOME_DOMAINS]]` table, or for a single node in a `[[VALIDATORS]]` table, it means the same thing, and you have the same three rating options: `HIGH`, `MEDIUM`, or `LOW`.
+`QUALITY` is a required field for each node you add to your quorum set. Whether you specify it for a suite of nodes in a `[[HOME_DOMAINS]]` table, or for a single node in a `[[VALIDATORS]]` table, it means the same thing, and you have the same four rating options: `CRITICAL`, `HIGH`, `MEDIUM`, or `LOW`.
+
+#### CRITICAL Quality
+
+**CRITICAL** quality validators sit above high quality validators, at the top of your quorum set. Stellar Core requires _every_ critical entity to agree before your node can reach consensus.
+
+A critical quality validator has the same programmatically enforced requirements as a high quality validator:
+
+- publishes a history archive, and
+- belongs to a home domain with at least three validators.
+
+Reserve this rating for an entity you cannot afford to disagree with. Because a critical entity is always required, your node stops closing ledgers when that entity drops below a simple majority of its own validators. In other words, this rating trades liveness for safety, so `HIGH` is the right choice for most quorum sets.
 
 #### HIGH Quality
 
-**HIGH** quality validators are given the most weight in automatic quorum set configuration. Before assigning a high quality rating to a node, make sure it has low latency and good uptime, and that the organization running the node is reliable and trustworthy.
+**HIGH** quality validators are given the most weight in automatic quorum set configuration, unless you also configure a critical quality entity. Before assigning a high quality rating to a node, make sure it has low latency and good uptime, and that the organization running the node is reliable and trustworthy.
 
 A high quality validator:
 
 - publishes an archive, and
-- belongs to a suite of nodes that provide redundancy.
+- belongs to a home domain with at least three validators.
 
-Choosing redundant nodes is good practice. The archive requirement is programmatically enforced.
+Both requirements are programmatically enforced. Stellar Core stops with a configuration error when a high or critical quality node declares no `HISTORY` archive, or when its home domain holds fewer than three validators.
 
 #### MEDIUM Quality
 
@@ -248,14 +259,17 @@ Once you add validators to your configuration, stellar core automatically genera
 
 - Validators with the same home domain are automatically grouped together and given a threshold requiring a simple majority (`2f+1`)
 - Heterogeneous groups of validators are given a threshold assuming byzantine failure (`3f+1`)
-- Entities are grouped by `QUALITY` and nested from `HIGH` to `LOW`
-- `HIGH` quality entities are at the top, and are given decision-making priority
+- Entities are grouped by `QUALITY` and nested from `CRITICAL` to `LOW`
+- `CRITICAL` quality entities are at the top level, where the threshold requires all of them (`100%`)
+- `HIGH` quality entities are nested below them, and are given decision-making priority over `MEDIUM` and `LOW`
 - The combined weight of `MEDIUM` quality entities equals a single `HIGH` quality entity
 - The combined weight of `LOW` quality entities equals a single `MEDIUM` quality entity
 
+Most quorum sets declare no `CRITICAL` entity. The `HIGH` quality group then becomes the top level, as the diagram below shows.
+
 ![Diagram Automatic Quorum Set Generation](/assets/diagrams/validator_complete.png)
 
-_Diagram: Depiction of the nested quality levels and how they interact._
+_Diagram: Depiction of the nested quality levels and how they interact. It shows a quorum set with no `CRITICAL` entity._
 
 ### Quorum and Overlay Network
 


### PR DESCRIPTION
Automated triage bot, acting for the docs maintainers.

Closes #985

`QUALITY` accepts four values, but this page listed three. The diff adds `CRITICAL` to both field tables, gives it its own subsection, and corrects the automatic quorum set generation rules, where every `CRITICAL` entity is required. It also corrects the `HIGH` requirements, because stellar-core enforces a three-validator redundancy as well as the archive. Every statement here comes from `src/main/Config.cpp` and `docs/stellar-core_example.cfg` at stellar-core v28.0.1.

Two notes for the reviewer:

- The leader election section needs no change. It defines the top weight as the highest quality assigned to any organization, so it already covers `CRITICAL`.
- `validator_complete.png` still shows three levels. I cannot regenerate the image, so the caption now states that the diagram shows a quorum set with no `CRITICAL` entity.
