### PR TITLE
Document the CLI pages that are generated from stellar-cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Before diving in, please read the org-wide [Stellar Contribution Guide](https://
     - [Terminology and style](#terminology-and-style)
   - [Site Code and Infrastructure](#site-code-and-infrastructure)
     - [API reference pages are generated](#api-reference-pages-are-generated)
+    - [CLI pages come from the `stellar-cli` repo](#cli-pages-come-from-the-stellar-cli-repo)
     - [URLs are forever](#urls-are-forever)
     - [Patches and swizzles are a last resort](#patches-and-swizzles-are-a-last-resort)
     - [Tooling, editor config, and build settings](#tooling-editor-config-and-build-settings)
@@ -94,6 +95,14 @@ The bar for changes to the site itself (components, theme, config, dependencies)
 The Horizon, Anchor Platform, and Stellar Disbursement Platform API reference pages are generated from the OpenAPI specs in `openapi/`. **Edit the spec sources, then regenerate** (`pnpm api`) and commit both together. PRs that hand-edit generated `*.api.mdx` files will be closed — the next regeneration would erase them.
 
 The same is true for Stellar RPC, and a subset of Anchor Platform functionality. They are generated from spec files in `openrpc/`. **Edit the spec sources, then regenerate** (`pnpm rpcspec:build`) and commit both together. PRs that hand-edit generated `*.openrpc.json` files only will be closed.
+
+### CLI pages come from the `stellar-cli` repo
+
+Three groups of pages under `docs/tools/cli/` are not authored here, so fixing even a typo means editing something else. The build runs `pnpm stellar-cli:build` before `pnpm build` (see `.github/workflows/build.yml` and the `Dockerfile`).
+
+- **The cookbook guides** (`docs/tools/cli/cookbook/*.mdx`) — each guide page in this repo is a one-line stub. The build copies the `cookbook/` directory of [`stellar/stellar-cli`](https://github.com/stellar/stellar-cli/tree/main/cookbook) over it, so an edit made here is overwritten. Edit the file in `stellar-cli` instead; the "Edit this page" link on each rendered cookbook page already points there. The category's own `README.mdx` and `_category_.json` have no upstream counterpart, so those two are ours and you can edit them here.
+- **The CLI manual** (`docs/tools/cli/stellar-cli.mdx`) — also a stub. The build fills it from `FULL_HELP_DOCS.md` in `stellar/stellar-cli`, and that file is itself generated from the CLI's own `--help` text (`make docs` in that repo). To change this page, change the help text in the CLI's Rust sources.
+- **The plugin list** (`docs/tools/cli/plugins-list.mdx`) — committed output rather than a stub. `scripts/stellar_cli_plugins.mjs` rebuilds it from the public GitHub repositories that carry the `stellar-cli-plugin` topic. To get a plugin listed, add that topic to its repository; a hand-written entry is lost at the next regeneration.
 
 ### URLs are forever
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,11 +98,11 @@ The same is true for Stellar RPC, and a subset of Anchor Platform functionality.
 
 ### CLI pages come from the `stellar-cli` repo
 
-Three groups of pages under `docs/tools/cli/` are not authored here, so fixing even a typo means editing something else. The build runs `pnpm stellar-cli:build` before `pnpm build` (see `.github/workflows/build.yml` and the `Dockerfile`).
+Three groups of pages under `docs/tools/cli/` are not authored here, so fixing even a typo means editing something else. The first two come from the build, which runs `pnpm stellar-cli:build` before `pnpm build` (see `.github/workflows/build.yml` and the `Dockerfile`).
 
 - **The cookbook guides** (`docs/tools/cli/cookbook/*.mdx`) — each guide page in this repo is a one-line stub. The build copies the `cookbook/` directory of [`stellar/stellar-cli`](https://github.com/stellar/stellar-cli/tree/main/cookbook) over it, so an edit made here is overwritten. Edit the file in `stellar-cli` instead; the "Edit this page" link on each rendered cookbook page already points there. The category's own `README.mdx` and `_category_.json` have no upstream counterpart, so those two are ours and you can edit them here.
 - **The CLI manual** (`docs/tools/cli/stellar-cli.mdx`) — also a stub. The build fills it from `FULL_HELP_DOCS.md` in `stellar/stellar-cli`, and that file is itself generated from the CLI's own `--help` text (`make docs` in that repo). To change this page, change the help text in the CLI's Rust sources.
-- **The plugin list** (`docs/tools/cli/plugins-list.mdx`) — committed output rather than a stub. `scripts/stellar_cli_plugins.mjs` rebuilds it from the public GitHub repositories that carry the `stellar-cli-plugin` topic. To get a plugin listed, add that topic to its repository; a hand-written entry is lost at the next regeneration.
+- **The plugin list** (`docs/tools/cli/plugins-list.mdx`) — committed output rather than a stub. `scripts/stellar_cli_plugins.mjs` rebuilds it from the public GitHub repositories that carry the `stellar-cli-plugin` topic. Forks and archived repositories are skipped. To get a plugin listed, add that topic to its repository; a hand-written entry is lost at the next regeneration.
 
 ### URLs are forever
 


### PR DESCRIPTION
Triage bot, acting for @kaankacar.

Refs #1013.

The CLI cookbook guides and the CLI manual are stubs in this repo. `pnpm stellar-cli:build` overwrites them from `stellar/stellar-cli` before `pnpm build`, so a typo fix made here is thrown away. The plugin list is regenerated from a GitHub topic search. This adds a CONTRIBUTING section that names each group and its real source. It follows the approach @ElliotFriend proposed in the issue.

The other half of that proposal is partly done: stellar/stellar-cli#1608 added `custom_edit_url` to all 19 cookbook pages, so their "Edit this page" links point upstream today. The CLI manual and plugin list pages still have no `custom_edit_url`, so their edit buttons open the stub. The issue stays open for that part, which needs a target choice.
