### PR TITLE
Document which contract errors try_call can recover from

### DIFF
--- a/docs/build/guides/conventions/cross-contract.mdx
+++ b/docs/build/guides/conventions/cross-contract.mdx
@@ -87,7 +87,7 @@ client::ContractAEnum::SomeField
 
 In the examples above, we have used `env.invoke_contract` and `client.some_function`. In both cases, if there is an issue with the underlying contract call, the contract will panic. This might be a valid approach, but in some cases we want to catch errors and handle them depending on the outcome. This allows you to forward a custom error message, or even trigger an alternative code path.
 
-Enter `try_`. By using `env.try_invoke_contract` or `client.try_some_function`, underlying errors won't make the contract panic. Instead, errors will be wrapped and can be handled. For example if we wanted to default to 0 in case of an error:
+Enter `try_`. By using `env.try_invoke_contract` or `client.try_some_function`, most underlying errors won't make the contract panic. Instead, errors will be wrapped and can be handled. For example if we wanted to default to 0 in case of an error:
 
 ```rust
 client.try_add(&x, &y).unwrap_or(Ok(0)).unwrap()
@@ -106,6 +106,12 @@ match client.try_add(&x, &y) {
     Err(Err(status)) => todo!("do something when an unrecognized error, or system error, occurs"),
 }
 ```
+
+:::caution[Some errors cannot be caught]
+
+`try_` does not catch every error. A resource limit error, a footprint violation, or an internal host error still traps the contract, and the transaction fails. See [Recoverable and Non-Recoverable Errors](../../../learn/fundamentals/contract-development/contract-interactions/overview.mdx#recoverable-and-non-recoverable-errors).
+
+:::
 
 ## Depending on another contract
 

--- a/docs/learn/fundamentals/contract-development/contract-interactions/overview.mdx
+++ b/docs/learn/fundamentals/contract-development/contract-interactions/overview.mdx
@@ -16,7 +16,7 @@ sidebar_position: 5
 
 Contracts are invoked through a pair of host functions `call` and `try_call`:
 
-- `try_call(contract, function, args)` calls `function` exported from `contract`, passing `args` and returning a `Error` on any error.
+- `try_call(contract, function, args)` calls `function` exported from `contract`, passing `args` and returning an `Error` on a recoverable error. A non-recoverable error traps instead.
 - `call(contract, function, args)` just calls `try_call` with its arguments and traps on `Error`, essentially propagating the error.
 
 In both cases `contract` is a `Binary` host object containing the contract ID, `function` is a `Symbol` holding the name of an exported function to call, and `args` is a `Vector` of values to pass as arguments.
@@ -37,3 +37,18 @@ When a call occurs from outside the host, any arguments will typically be provid
 When a call occurs from inside the host, the caller and callee contracts _share the same host_ and the caller can pass references to host objects directly to the callee without any need to serialize or deserialize them.
 
 Since host objects are immutable, there is limited risk to passing a shared reference from one contract to another: the callee cannot modify the object in a way that would surprise the caller, only create new objects.
+
+## Recoverable and Non-Recoverable Errors
+
+`try_call` returns an `Error` value only for a recoverable error. A non-recoverable error traps the caller instead: the invocation aborts and the transaction fails, and the calling contract cannot handle the error. A contract does not choose which errors are recoverable. The host decides, and the rule is the same for every contract.
+
+Two groups of errors are non-recoverable:
+
+- **Resource limit errors**, which carry the error code `ExceededLimit` and the error type `Budget` or `Storage`. A `Budget` error means the transaction ran out of CPU instructions or memory. A `Storage` error means the contract accessed a ledger entry that the transaction footprint does not list.
+- **Internal errors**, which carry the error code `InternalError` and any error type other than `Contract`. The host found a fault in its own logic. This should not happen in practice.
+
+Both groups break a precondition of the invocation, so the host cannot let the contract continue. A budget error recurs on a retry, because the transaction is still out of budget. A footprint violation recurs too, because a transaction cannot add an entry to its own footprint while it runs.
+
+The footprint case is the one to watch, because it is not obvious. A contract that derives a storage key from volatile state, such as a random value or the ledger sequence, can read an entry that [`simulateTransaction`](../../../../data/apis/rpc/api-reference/methods/simulateTransaction.mdx) never saw. The footprint then misses that entry and the call traps. [Debugging Contract Errors](../errors-and-debugging/debugging-errors.mdx) lists the diagnostic events for this case and the other errors of the apply step.
+
+Every other error is recoverable. `try_call` passes a contract error code through unchanged. It reports every other recoverable host error as an error of type `Context` with the code `InvalidAction`, and the granular code stays visible in the diagnostic events.


### PR DESCRIPTION
Triage bot, acting for @kaankacar.

Closes #1074

Two pages said `try_` catches every error from a contract call. It does not. `HostError::is_recoverable` in `rs-soroban-env` v28.0.2 makes two groups non-recoverable, and `try_call` re-raises those, so the guest traps and the transaction fails. This corrects both sentences and adds one section that states the rule, on the page that already defines `call` and `try_call`. @dmkozh named the same two groups in the issue.

Non-recoverable, from `soroban-env-host/src/host/error.rs`:

- code `ExceededLimit` with type `Budget` or `Storage`
- code `InternalError` with any type other than `Contract`

The `Storage` case is the footprint violation. The issue calls it the one non-obvious case, so it gets its own paragraph.

Two notes. This adds no page and no new URL, so it does not answer the "common gotchas page" idea in the issue. Open PR #2732 edits the `<head>` block of the same overview page, four lines from my hunk.
