### PR TITLE
Document the Galexie data lake storage format

### DIFF
--- a/docs/data/apis/rpc/admin-guide/data-lake-integration.mdx
+++ b/docs/data/apis/rpc/admin-guide/data-lake-integration.mdx
@@ -24,6 +24,8 @@ You have two options for utilizing a data lake:
 - **Public Data Lake:** The simplest way is to use a publicly available data lake. For example, Stellar ledger data lake is available through the AWS Open Data program at `s3://aws-public-blockchain/v1.1/stellar/ledgers/pubnet`.
 - **Self-Hosted Data Lake:** This method lets you have more control over data integrity, availability and access, but requires you to create and manage your own data lake. The **Galexie** tool can help you deploy a data lake on either AWS S3 or Google Cloud Storage (GCS). For detailed instructions, refer to the [Galexie Admin Guide](../../../../data/indexers/build-your-own/galexie/README.mdx).
 
+RPC reads the data lake for you. If you also want to read the stored files directly, see [Data Lake Storage Format](../../../../data/indexers/build-your-own/galexie/data-lake-format.mdx).
+
 ### 2. Configuring RPC for Data Lake Integration
 
 #### Pre-requisite

--- a/docs/data/indexers/build-your-own/galexie/README.mdx
+++ b/docs/data/indexers/build-your-own/galexie/README.mdx
@@ -22,6 +22,8 @@ Galexie is designed to make streamlined and efficient export of ledger metadata 
 
 Exporting data in XDR—the native Stellar Core format—enables Galexie to preserve full transaction metadata, ensuring data integrity while keeping storage efficient. The XDR format maintains compatibility with all Stellar components, providing a solid foundation for applications that require consistent access to historical data. Refer to the [XDR](../../../../learn/fundamentals/data-format/xdr.mdx) documentation for more information on this format.
 
+The [Data Lake Storage Format](./data-lake-format.mdx) page describes how Galexie names and compresses these files. Read it if your application reads the data lake directly instead of through the ingest SDK or Stellar RPC.
+
 ## Why Run Galexie?
 
 Galexie enables you to make a copy of Stellar ledger metadata over which you have complete control. Galexie can continuously sync your data lake with the latest ledger data freeing you up from tedious data ingestion and allowing you to focus on building customized applications that consume and analyze exported data.

--- a/docs/data/indexers/build-your-own/galexie/admin_guide/configuring.mdx
+++ b/docs/data/indexers/build-your-own/galexie/admin_guide/configuring.mdx
@@ -45,6 +45,8 @@ ledgers_per_file = 1
 files_per_partition = 64000
 ```
 
+These two settings decide the object keys in the bucket. See [Data Lake Storage Format](../data-lake-format.mdx) for the naming rules and for the `.config.json` file that records these values in the data lake.
+
 #### Use a Custom Core Config (Optional)
 
 You can specify a custom `core.cfg` file in the Galexie `config.toml` to use that will override the default core parameters used with the Stellar Network specified in the `network` parameter.

--- a/docs/data/indexers/build-your-own/galexie/data-lake-format.mdx
+++ b/docs/data/indexers/build-your-own/galexie/data-lake-format.mdx
@@ -69,7 +69,7 @@ Older data stores use the `.xdr.zstd` suffix instead of `.xdr.zst`. Both suffixe
 
 ## Configuration file
 
-Every data store holds a JSON configuration object at `<ledgers-path>/.config.json`. A client reads it to learn the batch and partition sizes before it builds any object key.
+SEP-54 requires a JSON configuration object at `<ledgers-path>/.config.json`. A client reads it to learn the batch and partition sizes before it builds any object key.
 
 | Property | Type | Description |
 | --- | --- | --- |
@@ -80,6 +80,8 @@ Every data store holds a JSON configuration object at `<ledgers-path>/.config.js
 | `batchesPerPartition` | integer | The number of batch files in each partition directory. |
 
 The Galexie configuration file names the last two values [`ledgers_per_file` and `files_per_partition`](./admin_guide/configuring.mdx#data-organization-optional).
+
+Older data stores do not hold this file. A client that reads one must get the batch and partition sizes from its own configuration. The Go `datastore` package does that when the file is absent.
 
 ## The public Stellar data lake
 

--- a/docs/data/indexers/build-your-own/galexie/data-lake-format.mdx
+++ b/docs/data/indexers/build-your-own/galexie/data-lake-format.mdx
@@ -1,0 +1,143 @@
+---
+title: Data Lake Storage Format
+sidebar_position: 10
+---
+
+# Data Lake Storage Format
+
+Galexie stores ledger metadata in an object store as compressed XDR files.
+
+Most applications never read those files directly. Read them through the [ingest SDK](../ingest-sdk/README.mdx) or through [Stellar RPC](../../../apis/rpc/admin-guide/data-lake-integration.mdx) instead. Both hide the layout described here.
+
+Read this page if your application reads the object store itself, or if you build a data store that other Stellar tools must be able to read.
+
+[SEP-54: Ledger Metadata Storage](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0054.md) is the specification for this format. This page summarizes the specification and shows the layout of the public Stellar data lake.
+
+## Object keys
+
+Galexie writes all ledger files under one configurable path in the bucket. Inside that path, each file sits in a partition directory:
+
+```
+<ledgers-path>/<partition>/<batch>.xdr.zst
+```
+
+Galexie omits the partition directory when [`files_per_partition`](./admin_guide/configuring.mdx#data-organization-optional) is 1.
+
+Both the partition name and the batch name start with 8 hexadecimal digits. That value is `0xFFFFFFFF` minus the first ledger sequence of the range. The subtraction reverses the order, so a listing returns the newest ledgers first. A client finds the latest ledger with one listing request and no index.
+
+The partition name then repeats the first and last ledger sequence of the partition:
+
+```
+FFFFFFFF--0-15
+```
+
+The batch name repeats the first and last ledger sequence of the batch. When a batch holds one ledger, the name carries that one sequence only:
+
+```
+FFFFFFFD--2-3.xdr.zst
+FFFFFFFD--2.xdr.zst
+```
+
+:::note
+
+A data store does not necessarily hold the whole ledger history. List the oldest partition to find where its history starts.
+
+:::
+
+## File contents
+
+Each ledger file is a [Zstandard](https://facebook.github.io/zstd/) compressed [`LedgerCloseMetaBatch`](https://github.com/stellar/stellar-xdr/blob/curr/Stellar-exporter.x) XDR value:
+
+```cpp
+// Batch of ledgers along with their transaction metadata
+struct LedgerCloseMetaBatch
+{
+    // starting ledger sequence number in the batch
+    uint32 startSequence;
+
+    // ending ledger sequence number in the batch
+    uint32 endSequence;
+
+    // Ledger close meta for each ledger within the batch
+    LedgerCloseMeta ledgerCloseMetas<>;
+};
+```
+
+Every batch in one data store holds the same number of ledgers. Refer to the [XDR](../../../../learn/fundamentals/data-format/xdr.mdx) documentation for more information on the encoding.
+
+Older data stores use the `.xdr.zstd` suffix instead of `.xdr.zst`. Both suffixes mean Zstandard. A client reads the suffix from an existing object rather than assuming one.
+
+## Configuration file
+
+Every data store holds a JSON configuration object at `<ledgers-path>/.config.json`. A client reads it to learn the batch and partition sizes before it builds any object key.
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `networkPassphrase` | string | The passphrase of the Stellar network that produced the ledgers. |
+| `version` | string | The version of the configuration file schema. |
+| `compression` | string | The compression algorithm. Only `zstd` is supported. |
+| `ledgersPerBatch` | integer | The number of ledgers in each batch file. |
+| `batchesPerPartition` | integer | The number of batch files in each partition directory. |
+
+The Galexie configuration file names the last two values [`ledgers_per_file` and `files_per_partition`](./admin_guide/configuring.mdx#data-organization-optional).
+
+## The public Stellar data lake
+
+A Stellar ledger data lake is available through the [AWS Open Data program](https://registry.opendata.aws/aws-public-blockchain). The bucket is public and needs no credentials. It carries one path per network:
+
+```
+s3://aws-public-blockchain/v1.1/stellar/ledgers/pubnet
+s3://aws-public-blockchain/v1.1/stellar/ledgers/testnet
+```
+
+The Pubnet configuration file holds one ledger per batch and 64,000 batches per partition:
+
+```json title="v1.1/stellar/ledgers/pubnet/.config.json"
+{
+  "networkPassphrase": "Public Global Stellar Network ; September 2015",
+  "version": "1.0",
+  "compression": "zstd",
+  "ledgersPerBatch": 1,
+  "batchesPerPartition": 64000
+}
+```
+
+With those sizes, ledger 50000000 falls in the partition that starts at ledger 49984000, so its object key is:
+
+```
+v1.1/stellar/ledgers/pubnet/FD054DFF--49984000-50047999/FD050F7F--50000000.xdr.zst
+```
+
+Download that ledger and print it as JSON with [`stellar xdr decode`](../../../../tools/cli/stellar-cli.mdx#stellar-xdr-decode):
+
+```sh
+curl -s https://aws-public-blockchain.s3.amazonaws.com/v1.1/stellar/ledgers/pubnet/FD054DFF--49984000-50047999/FD050F7F--50000000.xdr.zst \
+  | zstd -dc \
+  | stellar xdr decode --type LedgerCloseMetaBatch --input single --output json-formatted
+```
+
+## Object metadata
+
+Galexie also attaches metadata to each ledger object. The metadata lets a client filter objects without downloading them. Data stores that cannot hold user-defined object metadata, such as a plain file system, omit it.
+
+| Key | Description |
+| --- | --- |
+| `start-ledger` | The first ledger sequence in the batch. |
+| `end-ledger` | The last ledger sequence in the batch. |
+| `start-ledger-close-time` | The Unix timestamp of the close time of the first ledger. |
+| `end-ledger-close-time` | The Unix timestamp of the close time of the last ledger. |
+| `protocol-version` | The protocol version of the last ledger. |
+| `core-version` | The version of Stellar Core that produced the ledgers. |
+| `network-passphrase` | The passphrase of the Stellar network that produced the ledgers. |
+| `compression-type` | The compression algorithm of the object. |
+| `version` | The version of Galexie that wrote the object. |
+
+On Amazon S3 these arrive as `x-amz-meta-` response headers:
+
+```sh
+curl -sI https://aws-public-blockchain.s3.amazonaws.com/v1.1/stellar/ledgers/pubnet/FD054DFF--49984000-50047999/FD050F7F--50000000.xdr.zst
+```
+
+## Data integrity
+
+The format carries no proof that the ledgers in a data store are the ledgers the network closed. Verifying that is outside the scope of SEP-54. Read from a data store you run, or from an operator you trust.

--- a/docs/data/indexers/build-your-own/galexie/data-lake-format.mdx
+++ b/docs/data/indexers/build-your-own/galexie/data-lake-format.mdx
@@ -17,7 +17,7 @@ Read this page if your application reads the object store itself, or if you buil
 
 Galexie writes all ledger files under one configurable path in the bucket. Inside that path, each file sits in a partition directory:
 
-```
+```text
 <ledgers-path>/<partition>/<batch>.xdr.zst
 ```
 
@@ -27,13 +27,13 @@ Both the partition name and the batch name start with 8 hexadecimal digits. That
 
 The partition name then repeats the first and last ledger sequence of the partition:
 
-```
+```text
 FFFFFFFF--0-15
 ```
 
 The batch name repeats the first and last ledger sequence of the batch. When a batch holds one ledger, the name carries that one sequence only:
 
-```
+```text
 FFFFFFFD--2-3.xdr.zst
 FFFFFFFD--2.xdr.zst
 ```
@@ -83,12 +83,19 @@ The Galexie configuration file names the last two values [`ledgers_per_file` and
 
 ## The public Stellar data lake
 
-A Stellar ledger data lake is available through the [AWS Open Data program](https://registry.opendata.aws/aws-public-blockchain). The bucket is public and needs no credentials. It carries one path per network:
+A Stellar ledger data lake is available through the [AWS Open Data program](https://registry.opendata.aws/aws-public-blockchain). The bucket is public and needs no credentials. The Pubnet ledgers sit in one data store:
 
-```
+```text
 s3://aws-public-blockchain/v1.1/stellar/ledgers/pubnet
-s3://aws-public-blockchain/v1.1/stellar/ledgers/testnet
 ```
+
+Testnet resets. Each reset starts a new data store, in a directory named after the reset date:
+
+```text
+s3://aws-public-blockchain/v1.1/stellar/ledgers/testnet/<reset-date>
+```
+
+List `v1.1/stellar/ledgers/testnet/` to find the current reset directory. Use the directory itself as the `<ledgers-path>`, because each one holds its own `.config.json`.
 
 The Pubnet configuration file holds one ledger per batch and 64,000 batches per partition:
 
@@ -104,7 +111,7 @@ The Pubnet configuration file holds one ledger per batch and 64,000 batches per 
 
 With those sizes, ledger 50000000 falls in the partition that starts at ledger 49984000, so its object key is:
 
-```
+```text
 v1.1/stellar/ledgers/pubnet/FD054DFF--49984000-50047999/FD050F7F--50000000.xdr.zst
 ```
 

--- a/routes.txt
+++ b/routes.txt
@@ -465,6 +465,7 @@
 /docs/data/indexers/build-your-own/galexie/admin_guide/prerequisites
 /docs/data/indexers/build-your-own/galexie/admin_guide/running
 /docs/data/indexers/build-your-own/galexie/admin_guide/setup
+/docs/data/indexers/build-your-own/galexie/data-lake-format
 /docs/data/indexers/build-your-own/galexie/examples
 /docs/data/indexers/build-your-own/galexie/examples/gcs-export
 /docs/data/indexers/build-your-own/galexie/providers


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

This adds a Data Lake Storage Format page for readers who consume a Galexie data lake directly, instead of through the ingest SDK or Stellar RPC. It summarizes [SEP-54](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0054.md) and links to it as the specification: the object key layout, the reversed-sequence hex prefix, the zstd-compressed `LedgerCloseMetaBatch` payload, the `.config.json` manifest and the per-object metadata. Three existing pages now link to it: the Galexie overview, the Data Organization settings in the Galexie admin guide, and the RPC data lake integration guide.

Every fact came from a primary source or a live read:

- SEP-54 is now a numbered SEP at `ecosystem/sep-0054.md`, status Draft, updated 2026-01-07.
- The key format matches `DataStoreSchema.GetObjectKeyFromSequenceNumber` in `go-stellar-sdk/support/datastore/schema.go`.
- `.config.json` and the field names match `DatastoreManifest` and `manifestFilename` in the same package.
- The current suffix is `.xdr.zst` (`ZstdCompressor.Name()` returns `zst`); `.xdr.zstd` is the legacy form the code still reads.
- `LedgerCloseMetaBatch` is in stellar-xdr `Stellar-exporter.x` and in stellar-xdr v28.0.0, which the Stellar CLI depends on.
- The worked example key was fetched from the public bucket. It returns 200 and carries the metadata headers the page lists.

Refs #1605 (and not `Closes`), because SEP-54 is still status Draft. Please close the issue when you are satisfied with that half.
