### PR TITLE
Document muxed addresses in SAC transfer calls

### DIFF
--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -103,6 +103,28 @@ A few things to keep in mind:
 - When a trustline is actually created, the SAC requires authorization from `addr`, preserving the opt-in nature of trustlines.
 - The account holding the new trustline must satisfy the network's [base reserve](../learn/fundamentals/lumens.mdx#base-reserves) requirement for the additional ledger entry.
 
+### Sending to a muxed address
+
+As of Whisk, Protocol 23 ([CAP-67]), the `to` argument of the SAC's `transfer` function is a `MuxedAddress` rather than an `Address`. A `MuxedAddress` is either a plain address or an `M...` [muxed account](../build/guides/transactions/pooled-accounts-muxed-accounts-memos.mdx) address, which pairs a `G...` account with a 64-bit multiplexing id. This is how a contract payment identifies one user of a pooled account, the way a memo does for a classic payment: a transaction that invokes a contract must set `MEMO_NONE`, so before Whisk there was no way to tag a SAC payment at all.
+
+`transfer` is the only SAC function that accepts a `MuxedAddress`. `approve`, `balance`, `transfer_from`, `burn`, `burn_from`, `mint`, `clawback`, `set_authorized` and `trust` all still take an `Address`.
+
+The multiplexing id changes nothing on the ledger. The SAC strips the id off the address, moves the balance exactly as it would for the underlying address, and reports the id in the event instead:
+
+- The trustline rules for `Address::Account` are unchanged: the underlying `G...` account still needs an authorized trustline for the asset, or the transfer fails.
+- The `to` topic of the emitted event is the underlying address, never the muxed address. The id travels in the event `data`, which becomes a map, `{ amount: i128, to_muxed_id: u64 }`, in place of the plain `amount: i128`.
+- When one side of the transfer is the asset issuer, the SAC emits `mint` or `burn` rather than `transfer`. The `mint` event keeps the id; the `burn` event drops it. See [Events: SEP-41 Tokens vs. Stellar Asset Contracts](./token-interface.mdx#events-sep-41-tokens-vs-stellar-asset-contracts).
+
+A muxed address is not interchangeable with an address everywhere:
+
+- The Soroban host rejects a muxed address in a contract data key, including instance storage. A contract that must keep both parts stores the address and the id as separate values.
+- A contract function that declares an `Address` argument fails if the caller passes a muxed address. The reverse is safe: a function that declares a `MuxedAddress` still accepts a plain `Address`, so a contract token that moves its `transfer` argument to `MuxedAddress` does not break its existing callers.
+- Only Stellar accounts can be multiplexed. Muxed contract addresses do not exist in the current protocol.
+
+Both parts are readable from the contract. In the Rust SDK, `MuxedAddress::address()` returns the address part, and `MuxedAddress::id()` returns `Some(id)` for a muxed address and `None` for a plain one. On the client side, the JavaScript SDK builds the argument from the strkey with `new Address('M...').toScVal()`.
+
+See [Send to and receive payments from Contract Accounts](../build/guides/transactions/send-and-receive-c-accounts.mdx) for a worked flow, including how the muxed id appears in Horizon and RPC responses.
+
 ## Authorization semantics
 
 See the [authorization overview](../learn/fundamentals/contract-development/authorization.mdx) and [auth example](../build/smart-contracts/example-contracts/auth.mdx) for general information about authorization in Soroban.
@@ -287,4 +309,5 @@ Source: https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src
 [`StellarAssetClient` struct]: https://docs.rs/soroban-sdk/latest/soroban_sdk/token/struct.StellarAssetClient.html
 [cap-46-6 smart contract standardized asset]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0046-06.md
 [sep-41 token interface]: ./token-interface.mdx
+[CAP-67]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0067.md
 [CAP-73]: https://github.com/stellar/stellar-protocol/blob/master/core/cap-0073.md

--- a/docs/tokens/stellar-asset-contract.mdx
+++ b/docs/tokens/stellar-asset-contract.mdx
@@ -112,7 +112,7 @@ As of Whisk, Protocol 23 ([CAP-67]), the `to` argument of the SAC's `transfer` f
 The multiplexing id changes nothing on the ledger. The SAC strips the id off the address, moves the balance exactly as it would for the underlying address, and reports the id in the event instead:
 
 - The trustline rules for `Address::Account` are unchanged: the underlying `G...` account still needs an authorized trustline for the asset, or the transfer fails.
-- The `to` topic of the emitted event is the underlying address, never the muxed address. The id travels in the event `data`, which becomes a map, `{ amount: i128, to_muxed_id: u64 }`, in place of the plain `amount: i128`.
+- The `to` topic of the emitted event is the underlying address, never the muxed address. The id travels in the event `data` instead. Only a call that passes a muxed address makes `data` a map, `{ amount: i128, to_muxed_id: u64 }`; a call that passes a plain address keeps the plain `amount: i128`.
 - When one side of the transfer is the asset issuer, the SAC emits `mint` or `burn` rather than `transfer`. The `mint` event keeps the id; the `burn` event drops it. See [Events: SEP-41 Tokens vs. Stellar Asset Contracts](./token-interface.mdx#events-sep-41-tokens-vs-stellar-asset-contracts).
 
 A muxed address is not interchangeable with an address everywhere:

--- a/docs/tokens/token-interface.mdx
+++ b/docs/tokens/token-interface.mdx
@@ -31,6 +31,8 @@ For any given contract function, there are three requirements that should be con
 
 The interface below uses the Rust [soroban-sdk](../tools/sdks/contract-sdks.mdx#soroban-rust-sdk) to declare a trait that complies with the [SEP-41](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0041.md) token interface.
 
+The `to` argument of `transfer` is a `MuxedAddress`, which accepts either a plain address or an `M...` muxed account address. See [sending to a muxed address](./stellar-asset-contract.mdx#sending-to-a-muxed-address) for what the id does and where it is not accepted.
+
 ```rust
 pub trait TokenInterface {
     /// Returns the allowance for `spender` to transfer from `from`.
@@ -91,7 +93,7 @@ pub trait TokenInterface {
     ///
     /// Emits an event with:
     /// * topics `["transfer", from: Address, to: Address]`
-    /// * data `{ to_muxed_id: Option<u64>, amount: i128 }: Map`
+    /// * data `{ amount: i128, to_muxed_id: Option<u64> }: Map`
     ///
     /// Legacy implementations may emit an event with:
     /// * topics `["transfer", from: Address, to: Address]`


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Closes #1727

The Stellar Asset Contract page showed `to: MuxedAddress` in the interface but never explained it. This adds a "Sending to a muxed address" section: which SAC function takes a muxed address, what the multiplexing id does to the balance and the event, and the three places a muxed address is not accepted. Sources are CAP-67, `rs-soroban-env` `stellar_asset_contract/{contract,event}.rs`, `soroban-sdk` 27.0.6 and `stellar-core` `TransactionFrame.cpp`. It also corrects the `transfer` event data map on the Token Interface page to the key order the SDK doc comment uses, and links the two pages together.
