### PR TITLE
Add MCP server card and AI catalog for agent discovery

### DIFF
--- a/nginx/includes/agent-discovery-headers.conf
+++ b/nginx/includes/agent-discovery-headers.conf
@@ -1,0 +1,14 @@
+# Shared response headers for the agent-discovery documents under
+# /.well-known (MCP Server Card, AI Catalog). CORS set and caching follow
+# the SEP-2127 discovery doc:
+# https://github.com/modelcontextprotocol/ext-server-card/blob/main/docs/discovery.md
+# The documents are public, read-only metadata, so wide-open CORS is safe.
+add_header 'Access-Control-Allow-Origin' '*' always;
+add_header 'Access-Control-Allow-Methods' 'GET' always;
+add_header 'Access-Control-Allow-Headers' 'Content-Type, If-None-Match' always;
+add_header 'Access-Control-Expose-Headers' 'ETag' always;
+add_header 'Cache-Control' 'public, max-age=3600' always;
+# Browser preflight. The static handler would answer OPTIONS with 405.
+if ($request_method = OPTIONS) {
+    return 204;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,5 +45,15 @@ http {
     location = /.well-known/api-catalog {
         types { } default_type application/linkset+json;
     }
+    # AI Catalog (SEP-2127 discovery, ARD). Public read-only metadata, so
+    # wide-open CORS is fine.
+    location = /.well-known/ai-catalog.json {
+        types { } default_type application/ai-catalog+json;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+    }
+    # MCP Server Card (SEP-2127). Same CORS reasoning.
+    location = /.well-known/mcp/server-card.json {
+        add_header 'Access-Control-Allow-Origin' '*' always;
+    }
   }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,15 +45,15 @@ http {
     location = /.well-known/api-catalog {
         types { } default_type application/linkset+json;
     }
-    # AI Catalog (SEP-2127 discovery, ARD). Public read-only metadata, so
-    # wide-open CORS is fine.
+    # AI Catalog (SEP-2127 discovery, ARD)
     location = /.well-known/ai-catalog.json {
         types { } default_type application/ai-catalog+json;
-        add_header 'Access-Control-Allow-Origin' '*' always;
+        include includes/agent-discovery-headers.conf;
     }
-    # MCP Server Card (SEP-2127). Same CORS reasoning.
+    # MCP Server Card (SEP-2127)
     location = /.well-known/mcp/server-card.json {
-        add_header 'Access-Control-Allow-Origin' '*' always;
+        types { } default_type application/mcp-server-card+json;
+        include includes/agent-discovery-headers.conf;
     }
   }
 }

--- a/static/.well-known/ai-catalog.json
+++ b/static/.well-known/ai-catalog.json
@@ -2,7 +2,6 @@
   "specVersion": "1.0",
   "host": {
     "displayName": "Stellar Developer Documentation",
-    "identifier": "did:web:developers.stellar.org",
     "documentationUrl": "https://developers.stellar.org/"
   },
   "entries": [

--- a/static/.well-known/ai-catalog.json
+++ b/static/.well-known/ai-catalog.json
@@ -1,0 +1,42 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "Stellar Developer Documentation",
+    "identifier": "did:web:developers.stellar.org",
+    "documentationUrl": "https://developers.stellar.org/"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:stellar.org:mcp:raven",
+      "displayName": "Stellar Raven MCP server",
+      "type": "application/mcp-server-card+json",
+      "url": "https://developers.stellar.org/.well-known/mcp/server-card.json",
+      "description": "Server card for Stellar Raven, the remote MCP server that gives agents Stellar docs, live ecosystem data, and tested playbooks.",
+      "tags": ["stellar", "mcp", "raven"]
+    },
+    {
+      "identifier": "urn:air:stellar.org:skills:index",
+      "displayName": "Stellar Agent Skills index",
+      "type": "application/agent-skills+json",
+      "url": "https://developers.stellar.org/.well-known/agent-skills/index.json",
+      "description": "Index of the official Stellar agent skills with pinned download URLs and digests.",
+      "tags": ["stellar", "agent-skills"]
+    },
+    {
+      "identifier": "urn:air:stellar.org:api:catalog",
+      "displayName": "Stellar API Catalog",
+      "type": "application/linkset+json",
+      "url": "https://developers.stellar.org/.well-known/api-catalog",
+      "description": "RFC 9727 API catalog for Stellar RPC, Horizon, Anchor Platform, and Stellar Disbursement Platform.",
+      "tags": ["stellar", "api", "rfc9727"]
+    },
+    {
+      "identifier": "urn:air:stellar.org:docs:llms-txt",
+      "displayName": "Stellar Docs llms.txt",
+      "type": "text/plain",
+      "url": "https://developers.stellar.org/llms.txt",
+      "description": "Text index of the Stellar developer documentation for AI systems.",
+      "tags": ["stellar", "documentation", "llms.txt"]
+    }
+  ]
+}

--- a/static/.well-known/mcp/server-card.json
+++ b/static/.well-known/mcp/server-card.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+  "name": "org.stellar/raven",
+  "title": "Stellar Raven",
+  "version": "0.1.0",
+  "description": "Stellar MCP server for AI agents: official docs search, live ecosystem data, and tested playbooks.",
+  "websiteUrl": "https://raven.stellar.org",
+  "repository": {
+    "url": "https://github.com/stellar-experimental/stellar-raven",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://raven.stellar.org/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #2555

## What
- Add `static/.well-known/mcp/server-card.json`. It describes the Stellar Raven MCP server at `https://raven.stellar.org/mcp` with the SEP-2127 v1 card schema.
- Add `static/.well-known/ai-catalog.json`. It lists the server card, the agent-skills index, the api-catalog, and llms.txt.
- Serve the catalog as `application/ai-catalog+json`. Set `Access-Control-Allow-Origin: *` on both files.

## Why
Agents can now find the official MCP server from the docs domain. The current SEP-2127 draft recommends the AI Catalog path. The isitagentready scanner reads `/.well-known/mcp/server-card.json`. This PR covers both.

DNS-AID is out of scope. The reasons are in #2555.

## Verification
- Both JSON files parse.
- The server card validates against the ext-server-card `schema.json` (ajv, JSON Schema 2020-12).
- The card version matches Raven's runtime `serverInfo` (0.1.0). The endpoint matches the Raven README.
- All catalog URLs except the new card return 200 on production today.

## Verified on the PR preview
- `GET /.well-known/mcp/server-card.json`: 200, `application/mcp-server-card+json`, the four CORS headers from the SEP-2127 discovery doc, ETag. Body matches the repo file.
- `OPTIONS` on the card: 204.
- `GET /.well-known/ai-catalog.json`: 200, `application/ai-catalog+json`, CORS.
- isitagentready scan of the preview host: MCP Server Card pass, ARD pass, API Catalog pass, Agent Skills pass.
- Note: the edge in front of the site replaces `Cache-Control` with `no-cache`. The nginx `max-age=3600` value does not reach clients. This is the same for every file on the site today.
