### PR TITLE
Update asset issuance tutorial to use RPC instead of Horizon

### DIFF
--- a/docs/tokens/how-to-issue-an-asset.mdx
+++ b/docs/tokens/how-to-issue-an-asset.mdx
@@ -188,6 +188,8 @@ You’ll want to make sure you publish information about your asset to establish
 
 ## Network transactions
 
+These examples read accounts from and submit transactions to [Stellar RPC](../data/apis/rpc/README.mdx). RPC takes a transaction and answers immediately with the status `PENDING`, so you then poll for the final result. See [sendTransaction](../data/apis/rpc/api-reference/methods/sendTransaction.mdx) and [getTransaction](../data/apis/rpc/api-reference/methods/getTransaction.mdx).
+
 ### Build transaction to establish distributor trustline
 
 Accounts must establish a [trustline](../learn/fundamentals/stellar-data-structures/accounts.mdx#trustlines) with the issuing account to hold that issuer’s asset. This is true for all assets except for the network’s native token, [Lumens](../learn/fundamentals/lumens.mdx).
@@ -202,10 +204,8 @@ If you’d like to avoid your users having to deal with trustlines or XLM, consi
 
 ```js
 const StellarSdk = require("@stellar/stellar-sdk");
-const server = new StellarSdk.Horizon.Server(
-  "https://horizon-testnet.stellar.org",
-);
-const account = await server.loadAccount(distributorKeypair.publicKey());
+const server = new StellarSdk.rpc.Server("https://soroban-testnet.stellar.org");
+const account = await server.getAccount(distributorKeypair.publicKey());
 
 // This step only builds the transaction.  It still needs to be signed.
 const transaction = new StellarSdk.TransactionBuilder(account, {
@@ -225,9 +225,9 @@ const transaction = new StellarSdk.TransactionBuilder(account, {
 ```
 
 ```python
-from stellar_sdk import Keypair, Asset, Network, Server, TransactionBuilder
+from stellar_sdk import Keypair, Asset, Network, SorobanServer, TransactionBuilder
 
-server = Server("https://horizon-testnet.stellar.org")
+server = SorobanServer("https://soroban-testnet.stellar.org")
 distributor_account = server.load_account(distributor_keypair.public_key)
 
 transaction = (
@@ -243,8 +243,8 @@ transaction = (
 ```
 
 ```java
-Server server = new Server("https://horizon-testnet.stellar.org");
-AccountResponse distributorAccount = server.accounts().account(distributorKeypair.getAccountId());
+SorobanServer server = new SorobanServer("https://soroban-testnet.stellar.org");
+TransactionBuilderAccount distributorAccount = server.getAccount(distributorKeypair.getAccountId());
 
 Transaction transaction = new TransactionBuilder(distributorAccount, Network.TESTNET)
   .addOperation(
@@ -261,19 +261,21 @@ Transaction transaction = new TransactionBuilder(distributorAccount, Network.TES
 
 ```go
 import (
-  "github.com/stellar/go-stellar-sdk/clients/horizonclient"
+  "context"
+
+  "github.com/stellar/go-stellar-sdk/clients/rpcclient"
   "github.com/stellar/go-stellar-sdk/keypair"
   "github.com/stellar/go-stellar-sdk/network"
   "github.com/stellar/go-stellar-sdk/txnbuild"
 )
 
-client := horizonclient.DefaultTestNetClient
-distributorAccountRequest := horizonclient.AccountRequest{AccountID: distributorKeypair.Address()}
-distributorAccount, _ := client.AccountDetail(distributorAccountRequest)
+ctx := context.Background()
+client := rpcclient.NewClient("https://soroban-testnet.stellar.org", nil)
+distributorAccount, _ := client.LoadAccount(ctx, distributorKeypair.Address())
 
 transaction, _ := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        &distributorAccount,
+    SourceAccount:        distributorAccount,
     IncrementSequenceNum: true,
     BaseFee:              txnbuild.MinBaseFee,
     Operations: []txnbuild.Operation{
@@ -339,7 +341,7 @@ Transaction transaction = new TransactionBuilder(...)
 // to show that these operations can be "chained" together.
 transaction, _ := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        &issuerAccount,
+    SourceAccount:        issuerAccount,
     IncrementSequenceNum: true,
     BaseFee:              txnbuild.MinBaseFee,
     Operations: []txnbuild.Operation{
@@ -405,7 +407,7 @@ Transaction lockAccountTransaction = new TransactionBuilder(...)
 ```go
 lockAccountTransaction, _ := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        &issuerAccount,
+    SourceAccount:        issuerAccount,
     IncrementSequenceNum: true,
     BaseFee:              txnbuild.MinBaseFee,
     Operations: []txnbuild.Operation{
@@ -427,7 +429,7 @@ If you enable the [authorization flag](./control-asset-access.mdx#authorization-
 <CodeExample>
 
 ```js
-const issuingAccount = await server.loadAccount(issuerKeypair.publicKey());
+const issuingAccount = await server.getAccount(issuerKeypair.publicKey());
 const transaction = new StellarSdk.TransactionBuilder(...)
   .addOperation(
     StellarSdk.Operation.setTrustLineFlags({
@@ -443,9 +445,9 @@ const transaction = new StellarSdk.TransactionBuilder(...)
 ```
 
 ```python
-from stellar_sdk import Server, Keypair, Network, TransactionBuilder, SetTrustLineFlags
+from stellar_sdk import SorobanServer, Keypair, Network, TransactionBuilder, SetTrustLineFlags
 
-server = Server("https://horizon-testnet.stellar.org")
+server = SorobanServer("https://soroban-testnet.stellar.org")
 issuer_account = server.load_account(issuer_keypair.public_key)
 
 transaction = (
@@ -461,7 +463,7 @@ transaction = (
 ```
 
 ```java
-AccountResponse issuerAccount = server.accounts().account(issuerKeys.getAccountId());
+TransactionBuilderAccount issuerAccount = server.getAccount(issuerKeys.getAccountId());
 Transaction transaction = new TransactionBuilder(...)
   .addOperation(SetTrustlineFlagsOperation.builder()
     .trustor(distributorKeys.getAccountId())
@@ -475,12 +477,11 @@ Transaction transaction = new TransactionBuilder(...)
 ```
 
 ```go
-issuerAccountRequest := horizonclient.AccountRequest{AccountID: issuerKeypair.Address()}
-issuerAccount, _ := client.AccountDetail(issuerAccountRequest)
+issuerAccount, _ := client.LoadAccount(ctx, issuerKeypair.Address())
 
 transaction, _ := txnbuild.NewTransaction(
   txnbuild.TransactionParams{
-    SourceAccount:        &issuerAccount,
+    SourceAccount:        issuerAccount,
     IncrementSequenceNum: true,
     BaseFee:              txnbuild.MinBaseFee,
     Operations: []txnbuild.Operation{
@@ -503,9 +504,7 @@ transaction, _ := txnbuild.NewTransaction(
 
 ```js
 var StellarSdk = require("@stellar/stellar-sdk");
-var server = new StellarSdk.Horizon.Server(
-  "https://horizon-testnet.stellar.org",
-);
+var server = new StellarSdk.rpc.Server("https://soroban-testnet.stellar.org");
 
 // Keys for accounts to issue and receive the new asset
 var issuerKeys = StellarSdk.Keypair.fromSecret(
@@ -518,66 +517,90 @@ var receivingKeys = StellarSdk.Keypair.fromSecret(
 // Create an object to represent the new asset
 var astroDollar = new StellarSdk.Asset("AstroDollar", issuerKeys.publicKey());
 
-// First, the receiving account must trust the asset
-server
-  .loadAccount(receivingKeys.publicKey())
-  .then(function (receiver) {
-    var transaction = new StellarSdk.TransactionBuilder(receiver, {
-      fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET,
-    })
-      // The `changeTrust` operation creates (or alters) a trustline
-      // The `limit` parameter below is optional
-      .addOperation(
-        StellarSdk.Operation.changeTrust({
-          asset: astroDollar,
-          limit: "1000",
-        }),
-      )
-      // setTimeout is required for a transaction
-      .setTimeout(100)
-      .build();
-    transaction.sign(receivingKeys);
-    return server.submitTransaction(transaction);
+// RPC accepts a transaction and answers `PENDING`, so we poll for the result
+async function submit(transaction) {
+  var sendResponse = await server.sendTransaction(transaction);
+  if (sendResponse.status !== "PENDING") {
+    throw new Error("Submission failed: " + sendResponse.status);
+  }
+
+  var finalResponse = await server.pollTransaction(sendResponse.hash);
+  if (finalResponse.status !== "SUCCESS") {
+    throw new Error("Transaction failed: " + finalResponse.status);
+  }
+
+  return finalResponse;
+}
+
+async function issueAstroDollar() {
+  // First, the receiving account must trust the asset
+  var receiver = await server.getAccount(receivingKeys.publicKey());
+  var trustTransaction = new StellarSdk.TransactionBuilder(receiver, {
+    fee: 100,
+    networkPassphrase: StellarSdk.Networks.TESTNET,
   })
-  .then(console.log)
+    // The `changeTrust` operation creates (or alters) a trustline
+    // The `limit` parameter below is optional
+    .addOperation(
+      StellarSdk.Operation.changeTrust({
+        asset: astroDollar,
+        limit: "1000",
+      }),
+    )
+    // setTimeout is required for a transaction
+    .setTimeout(100)
+    .build();
+  trustTransaction.sign(receivingKeys);
+  console.log(await submit(trustTransaction));
 
   // Second, the issuing account actually sends a payment using the asset
-  .then(function () {
-    return server.loadAccount(issuerKeys.publicKey());
+  var issuer = await server.getAccount(issuerKeys.publicKey());
+  var paymentTransaction = new StellarSdk.TransactionBuilder(issuer, {
+    fee: 100,
+    networkPassphrase: StellarSdk.Networks.TESTNET,
   })
-  .then(function (issuer) {
-    var transaction = new StellarSdk.TransactionBuilder(issuer, {
-      fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET,
-    })
-      .addOperation(
-        StellarSdk.Operation.payment({
-          destination: receivingKeys.publicKey(),
-          asset: astroDollar,
-          amount: "10",
-        }),
-      )
-      // setTimeout is required for a transaction
-      .setTimeout(100)
-      .build();
-    transaction.sign(issuerKeys);
-    return server.submitTransaction(transaction);
-  })
-  .then(console.log)
-  .catch(function (error) {
-    console.error("Error!", error);
-  });
+    .addOperation(
+      StellarSdk.Operation.payment({
+        destination: receivingKeys.publicKey(),
+        asset: astroDollar,
+        amount: "10",
+      }),
+    )
+    // setTimeout is required for a transaction
+    .setTimeout(100)
+    .build();
+  paymentTransaction.sign(issuerKeys);
+  console.log(await submit(paymentTransaction));
+}
+
+issueAstroDollar().catch(function (error) {
+  console.error("Error!", error);
+});
 ```
 
 ```python
-from stellar_sdk import Asset, Keypair, Network, Server, TransactionBuilder
+from stellar_sdk import Asset, Keypair, Network, SorobanServer, TransactionBuilder
+from stellar_sdk.soroban_rpc import GetTransactionStatus, SendTransactionStatus
 
-# Configure Stellar SDK to talk to the Horizon instance hosted by SDF
-# To use the live network, set the hostname to horizon_url for mainnet
-server = Server(horizon_url="https://horizon-testnet.stellar.org")
+# Configure Stellar SDK to talk to the Stellar RPC instance hosted by SDF
+# To use the live network, set the hostname to a mainnet RPC provider
+server = SorobanServer("https://soroban-testnet.stellar.org")
 # Use test network, if you need to use public network, please set it to `Network.PUBLIC_NETWORK_PASSPHRASE`
 network_passphrase = Network.TESTNET_NETWORK_PASSPHRASE
+
+
+# RPC accepts a transaction and answers PENDING, so we poll for the result
+def submit(transaction):
+    send_response = server.send_transaction(transaction)
+    if send_response.status != SendTransactionStatus.PENDING:
+        raise RuntimeError(f"Submission failed: {send_response.status}")
+
+    final_response = server.poll_transaction(send_response.hash)
+    if final_response.status != GetTransactionStatus.SUCCESS:
+        raise RuntimeError(f"Transaction failed: {final_response.status}")
+
+    return final_response
+
 
 # Keys for accounts to issue and receive the new asset
 issuerKeypair = Keypair.from_secret(
@@ -591,7 +614,7 @@ distributor_keypair = Keypair.from_secret(
 distributor_public = distributor_keypair.public_key
 
 # Transactions require a valid sequence number that is specific to this account.
-# We can fetch the current sequence number for the source account from Horizon.
+# We can fetch the current sequence number for the source account from RPC.
 distributor_account = server.load_account(distributor_public)
 
 # Create an object to represent the new asset
@@ -612,7 +635,7 @@ trust_transaction = (
 )
 
 trust_transaction.sign(distributor_keypair)
-trust_transaction_resp = server.submit_transaction(trust_transaction)
+trust_transaction_resp = submit(trust_transaction)
 print(f"Change Trust Transaction Resp:\n{trust_transaction_resp}")
 
 issuer_account = server.load_account(issuer_public)
@@ -631,12 +654,12 @@ payment_transaction = (
     .build()
 )
 payment_transaction.sign(issuerKeypair)
-payment_transaction_resp = server.submit_transaction(payment_transaction)
+payment_transaction_resp = submit(payment_transaction)
 print(f"Payment Transaction Resp:\n{payment_transaction_resp}")
 ```
 
 ```java
-Server server = new Server("https://horizon-testnet.stellar.org");
+SorobanServer server = new SorobanServer("https://soroban-testnet.stellar.org");
 
 // Keys for accounts to issue and receive the new asset
 KeyPair issuerKeys = KeyPair
@@ -648,7 +671,7 @@ KeyPair receivingKeys = KeyPair
 Asset astroDollar = Asset.createNonNativeAsset("AstroDollar", issuerKeys.getAccountId());
 
 // First, the receiving account must trust the asset
-AccountResponse receiving = server.accounts().account(receivingKeys.getAccountId());
+TransactionBuilderAccount receiving = server.getAccount(receivingKeys.getAccountId());
 Transaction allowAstroDollars = new TransactionBuilder(receiving, Network.TESTNET)
   .addOperation(
     // The `ChangeTrust` operation creates (or alters) a trustline
@@ -658,10 +681,17 @@ Transaction allowAstroDollars = new TransactionBuilder(receiving, Network.TESTNE
   .setTimeout(180)
   .build();
 allowAstroDollars.sign(receivingKeys);
-server.submitTransaction(allowAstroDollars);
+
+// RPC accepts a transaction and answers PENDING, so we poll for the result
+SendTransactionResponse trustSend = server.sendTransaction(allowAstroDollars);
+if (trustSend.getStatus() != SendTransactionStatus.PENDING) {
+  throw new RuntimeException("Submission failed: " + trustSend.getStatus());
+}
+GetTransactionResponse trustResult = server.pollTransaction(trustSend.getHash());
+System.out.println("Change Trust Transaction: " + trustResult.getStatus());
 
 // Second, the issuing account actually sends a payment using the asset
-AccountResponse issuer = server.accounts().account(issuerKeys.getAccountId());
+TransactionBuilderAccount issuer = server.getAccount(issuerKeys.getAccountId());
 Transaction sendAstroDollars = new TransactionBuilder(issuer, Network.TESTNET)
   .addOperation(
     PaymentOperation.builder().destination(receivingKeys.getAccountId()).asset(astroDollar).amount(new BigDecimal("10")).build())
@@ -669,22 +699,60 @@ Transaction sendAstroDollars = new TransactionBuilder(issuer, Network.TESTNET)
   .setTimeout(180)
   .build();
 sendAstroDollars.sign(issuerKeys);
-server.submitTransaction(sendAstroDollars);
+
+SendTransactionResponse paymentSend = server.sendTransaction(sendAstroDollars);
+if (paymentSend.getStatus() != SendTransactionStatus.PENDING) {
+  throw new RuntimeException("Submission failed: " + paymentSend.getStatus());
+}
+GetTransactionResponse paymentResult = server.pollTransaction(paymentSend.getHash());
+System.out.println("Payment Transaction: " + paymentResult.getStatus());
 ```
 
 ```go
 package main
 
 import (
-  "github.com/stellar/go-stellar-sdk/clients/horizonclient"
+  "context"
+  "log"
+
+  "github.com/stellar/go-stellar-sdk/clients/rpcclient"
   "github.com/stellar/go-stellar-sdk/keypair"
   "github.com/stellar/go-stellar-sdk/network"
   "github.com/stellar/go-stellar-sdk/txnbuild"
-  "log"
+
+  protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
+// RPC accepts a transaction and answers PENDING, so we poll for the result
+func submit(ctx context.Context, client *rpcclient.Client, tx *txnbuild.Transaction) protocol.GetTransactionResponse {
+  txnB64, err := tx.Base64()
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  sendResp, err := client.SendTransaction(ctx, protocol.SendTransactionRequest{Transaction: txnB64})
+  if err != nil {
+    log.Fatal(err)
+  }
+  if sendResp.Status != "PENDING" {
+    log.Fatalf("Submission failed: %s", sendResp.Status)
+  }
+
+  finalResp, err := client.PollTransaction(ctx, sendResp.Hash)
+  if err != nil {
+    log.Fatal(err)
+  }
+  if finalResp.Status != protocol.TransactionStatusSuccess {
+    log.Fatalf("Transaction failed: %s", finalResp.Status)
+  }
+
+  return finalResp
+}
+
 func main() {
-  client := horizonclient.DefaultTestNetClient
+  ctx := context.Background()
+  client := rpcclient.NewClient("https://soroban-testnet.stellar.org", nil)
+  defer client.Close()
 
   // Remember, these are just examples, so replace them with your own seeds.
   issuerSeed := "SDR4C2CKNCVK4DWMTNI2IXFJ6BE3A6J3WVNCGR6Q3SCMJDTSVHMJGC6U"
@@ -699,11 +767,8 @@ func main() {
   issuer, err := keypair.ParseFull(issuerSeed)
   distributor, err := keypair.ParseFull(distributorSeed)
 
-  request := horizonclient.AccountRequest{AccountID: issuer.Address()}
-  issuer_account, err := client.AccountDetail(request)
-
-  request = horizonclient.AccountRequest{AccountID: distributor.Address()}
-  distributorAccount, err := client.AccountDetail(request)
+  issuerAccount, err := client.LoadAccount(ctx, issuer.Address())
+  distributorAccount, err := client.LoadAccount(ctx, distributor.Address())
 
   // Create an object to represent the new asset
   astroDollar := txnbuild.CreditAsset{Code: "AstroDollar", Issuer: issuer.Address()}
@@ -712,7 +777,7 @@ func main() {
   // issuer.
   tx, err := txnbuild.NewTransaction(
     txnbuild.TransactionParams{
-      SourceAccount:        distributorAccount.AccountID,
+      SourceAccount:        distributorAccount,
       IncrementSequenceNum: true,
       BaseFee:              txnbuild.MinBaseFee,
       Preconditions: txnbuild.Preconditions{
@@ -728,17 +793,15 @@ func main() {
   )
 
   signedTx, err := tx.Sign(network.TestNetworkPassphrase, distributor)
-  resp, err := client.SubmitTransaction(signedTx)
   if err != nil {
     log.Fatal(err)
-  } else {
-    log.Printf("Trust: %s\n", resp.Hash)
   }
+  log.Printf("Trust: %s\n", submit(ctx, client, signedTx).TransactionHash)
 
   // Second, the issuing account actually sends a payment using the asset
   tx, err = txnbuild.NewTransaction(
     txnbuild.TransactionParams{
-      SourceAccount:        issuer_account.AccountID,
+      SourceAccount:        issuerAccount,
       IncrementSequenceNum: true,
       BaseFee:              txnbuild.MinBaseFee,
       Preconditions: txnbuild.Preconditions{
@@ -755,13 +818,10 @@ func main() {
   )
 
   signedTx, err = tx.Sign(network.TestNetworkPassphrase, issuer)
-  resp, err = client.SubmitTransaction(signedTx)
-
   if err != nil {
     log.Fatal(err)
-  } else {
-    log.Printf("Pay: %s\n", resp.Hash)
   }
+  log.Printf("Pay: %s\n", submit(ctx, client, signedTx).TransactionHash)
 }
 ```
 


### PR DESCRIPTION
🤖 Automated triage bot, acting for @kaankacar.

Closes #1777

The asset issuance tutorial called Horizon in all four languages. This points every example at Stellar RPC. Account loads become `getAccount`, `load_account`, `LoadAccount` and `getAccount`. Submission becomes `sendTransaction` plus a poll, because RPC answers `PENDING` first. The page keeps its four languages, and no example needs an endpoint that RPC lacks.
