### PR TITLE
Surface CLI install instructions on the CLI landing pages

### DIFF
--- a/docs/tools/cli/README.mdx
+++ b/docs/tools/cli/README.mdx
@@ -8,6 +8,17 @@ sidebar_position: 20
 
 The command line interface to Soroban smart contracts. It allows you to build, deploy, and interact with smart contracts; configure identities; generate key pairs; manage networks; and more.
 
-Install Stellar CLI as explained in [Setup](../../build/smart-contracts/getting-started/setup.mdx#install-the-stellar-cli). For examples on how to use the Stellar CLI, please see [Stellar CLI Guides](./cookbook/README.mdx).
+## Install
 
-The auto-generated comprehensive reference documentation is available [here](stellar-cli.mdx).
+Install the latest release on macOS, Linux or WSL with the install script:
+
+```sh
+curl -fsSL https://github.com/stellar/stellar-cli/raw/main/install.sh | sh
+```
+
+For Homebrew, winget, cargo, GitHub Actions and shell autocomplete, see [Install the CLI](./install-cli.mdx). To install the CLI with Rust, the Wasm target and an editor, see [Setup](../../build/smart-contracts/getting-started/setup.mdx#install-the-stellar-cli).
+
+## Learn more
+
+- [Stellar CLI Guides](./cookbook/README.mdx) gives examples of how to use the CLI.
+- [Stellar CLI Manual](./stellar-cli.mdx) is the auto-generated reference for every command.

--- a/docs/tools/cli/cookbook/README.mdx
+++ b/docs/tools/cli/cookbook/README.mdx
@@ -8,3 +8,5 @@ sidebar_position: 150
 import DocCardList from "@theme/DocCardList";
 
 Guides that will help you use the Stellar CLI.
+
+If you do not have the CLI yet, see [Install the CLI](../install-cli.mdx).


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

Refs #1791

The two CLI landing pages did not show how to install the CLI. `docs/tools/cli/README.mdx` now opens with an Install section that holds the install script one-liner and links `install-cli.mdx` for the other methods. The Cookbook index links the install page too, because `/docs/build/guides/cli`, the Google entry point in the issue, redirects there.

The PR says "Refs", not "Closes". `/docs/tools/cli/stellar-cli` is generated from the upstream `FULL_HELP_DOCS.md`, so an install pointer on that page needs a change to `scripts/stellar_cli.mjs`.

`docs/tools/cli/cookbook/README.mdx` survives the build: the upstream `cookbook/` directory that cpSync copies over it holds 19 guide files and no `README.mdx`.
