### PR TITLE
Fix broken code in the choosing-the-right-storage guide

### DIFF
--- a/docs/build/guides/storage/choosing-the-right-storage.mdx
+++ b/docs/build/guides/storage/choosing-the-right-storage.mdx
@@ -43,7 +43,7 @@ Examples of data that may be stored on persistent storage include user balances,
 Let's look at a contract for a loyalty points system where users can accumulate points and redeem them for rewards. Each user's point balance will be stored in persistent storage.
 
 ```rust
-use soroban_sdk::{contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 #[contracttype]
 pub enum DataKey {
@@ -97,12 +97,14 @@ Instance storage is best suited for data that has a well-known size limit and is
 Let's look at additional functions for the loyalty points contract from the previous section, specifically the functions that define the contract admin and add points to the users:
 
 ```rust
-use soroban_sdk::{contractimpl, Address,  Env};
+use soroban_sdk::{contractimpl, contracttype, Address, Env};
 
+// This is the `DataKey` from the previous section, with `Admin` added. Declare
+// it only once in your contract.
 #[contracttype]
 pub enum DataKey {
     Points(Address),
-    Admin
+    Admin,
 }
 
 #[contractimpl]
@@ -152,10 +154,10 @@ It is also unsafe to rely on an entry expiring as it can be extended by anyone. 
 
 Temporary storage is best suited for easily replaceable data, or data that is only relevant within a certain time period. For example, oracle price feed data that is only relevant for a few minutes, or limited time authorizations such as token allowances, session tokens, auctions, timelocks, etc. Nonces for the Soroban signatures are also stored in the temporary storage, at least until the signature itself expires.
 
-Let's look at how temporary storage may be implemented in a contract that runs auctions periodically, and users can place bids that are only valid only until some user-defined time point:
+Let's look at how temporary storage may be implemented in a contract that runs auctions periodically, and users can place bids that are valid only until some user-defined time point:
 
 ```rust
-use soroban_sdk::{contracttype, contractimpl, Env, Address};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 #[contracttype]
 pub enum DataKey {
@@ -171,6 +173,9 @@ pub struct Bid {
     expiration_ledger_seq: u32,
 }
 
+#[contract]
+pub struct AuctionContract;
+
 #[contractimpl]
 impl AuctionContract {
     // This function lets a user place a bid that lives only until the auction ends.
@@ -185,21 +190,21 @@ impl AuctionContract {
         });
         // Compute the TTL that the bid requires.
         let bid_ttl = bid_expiration_ledger_seq
-            .checked_sub(e.ledger().sequence())
+            .checked_sub(env.ledger().sequence())
             .unwrap();
         // Extend the TTL for the bid, such that it's guaranteed to live at
         // least until the `bid_expiration_ledger_seq` that the user has
-        // requested. This operation is will fail in
-        // case if extension is longer than the protocol allows, so there is
-        // no need to further validate `bid_ttl`.
+        // requested. This operation will fail if the extension is longer than
+        // the protocol allows, so there is no need to further validate
+        // `bid_ttl`.
         env.storage().temporary().extend_ttl(&bid_key, bid_ttl, bid_ttl);
     }
 
     // This function returns a user's bid (0 if it has expired).
-    pub fn get_bid(env: Env, user: Symbol) -> i64 {
-        let maybe_bid: Bid = env.storage().temporary().get(&DataKey::Bid(user));
+    pub fn get_bid(env: Env, user: Address) -> i128 {
+        let maybe_bid: Option<Bid> = env.storage().temporary().get(&DataKey::Bid(user));
         if let Some(bid) = maybe_bid {
-            if bid.expiration_ledger_seq <= e.ledger().sequence() {
+            if bid.expiration_ledger_seq >= env.ledger().sequence() {
                 bid.value
             } else {
                 // Even though the entry is still in the storage, it has
@@ -207,7 +212,6 @@ impl AuctionContract {
                 // order to trick our contract, so return 0.
                 0
             }
-
         } else {
             // There is no bid for the user - it either hasn't existed at all,
             // or has been removed from the temporary storage. In either case,


### PR DESCRIPTION
🤖 _Automated message from Kaan's Automated Triage Bot._

The temporary storage snippet on this guide could not compile, and its expiry check was inverted: it returned a bid's value after the bid expired, and 0 while the bid was still valid. This fixes that check and the compile errors around it, and adds the two missing SDK imports in the persistent and instance snippets. Prose, links and the storage table are unchanged.

Refs #1841

I checked every construct against soroban-sdk v26.1.1 source, because `cargo` is not available in my environment. `storage().temporary().get()` returns `Option<V>` (`soroban-sdk/src/storage.rs:458`) and `Ledger::sequence()` returns `u32` (`ledger.rs:65`). Two `#[contractimpl]` blocks on one contract are legal, so the second block stays as it is (`lib.rs:447`).

I used "Refs", not "Closes". The issue asks for a full guide review, and two prose claims stay unverified: that the instance entry size limit can never go down, and the relative order of the "Cost" column. Please close #1841 if you read this as the review being done.
