### PR TITLE
docs: add Vellar x402 facilitator to Stellar ecosystem

### DIFF
--- a/docs/build/agentic-payments/x402/README.mdx
+++ b/docs/build/agentic-payments/x402/README.mdx
@@ -123,10 +123,11 @@ payment asset and no XLM.
 :::note
 
 Vellar runs on **Testnet only** and is pre-production; there is no mainnet
-instance. An external security audit is still open, and the project's mainnet
-checklist treats it as a blocker for tagging a mainnet release rather than for
-running an instance. The hosted instance runs on a free tier, so the first
-request after an idle period can take up to a minute.
+instance. The pre-mainnet security review of the facilitator is complete, with
+findings tracked to closure. A mainnet release is additionally gated on a
+separate audit of the spending-limit policy contract, which has not yet been
+run. The hosted instance runs on a free tier, so the first request after an
+idle period can take up to a minute.
 
 :::
 

--- a/docs/build/agentic-payments/x402/README.mdx
+++ b/docs/build/agentic-payments/x402/README.mdx
@@ -59,7 +59,7 @@ x402 on Stellar supports any [SEP-41](https://stellar.org/protocol/sep-41) compl
 
 ## x402 Facilitators
 
-You can use a facilitator to verify and settle x402 payments. Two options are available for Stellar, plus community-operated facilitators listed at the end of this section:
+You can use a facilitator to verify and settle x402 payments. Two production implementations are available for Stellar, plus one community-run pre-production option listed at the end of this section:
 
 ### Coinbase x402 Facilitator
 

--- a/docs/build/agentic-payments/x402/README.mdx
+++ b/docs/build/agentic-payments/x402/README.mdx
@@ -59,7 +59,7 @@ x402 on Stellar supports any [SEP-41](https://stellar.org/protocol/sep-41) compl
 
 ## x402 Facilitators
 
-You can use a facilitator to verify and settle x402 payments. Two options are available for Stellar:
+You can use a facilitator to verify and settle x402 payments. Two options are available for Stellar, plus community-operated facilitators listed at the end of this section:
 
 ### Coinbase x402 Facilitator
 
@@ -105,11 +105,16 @@ current status before depending on it.
 
 [Vellar](https://github.com/Vellar-Wallet/vellar-facilitator) is an Apache-2.0
 x402 facilitator that pairs the standard `/verify`, `/settle`, and `/supported`
-endpoints with a **Bazaar discovery layer**: a resource is added to a searchable
-catalog the first time a payment settles for it, so sellers are listed without a
-separate registration step. It also exposes that catalog to AI agents over
-[MCP](https://modelcontextprotocol.io), and sponsors the network fee on
-settlement, so buyers hold only the payment asset and no XLM.
+endpoints with a **Bazaar discovery layer**: when a payment settles and its
+payload carries the Bazaar discovery extension, the resource is added to a
+searchable catalog, so sellers that use the extension are listed without a
+separate registration step. Payments without the extension settle normally but
+are not cataloged. The catalog is also reachable by AI agents through an
+[MCP](https://modelcontextprotocol.io) discovery server (`src/mcp.ts` in the
+repository), which is a separate stdio process you run locally and point at the
+facilitator URL; the hosted instance does not expose an MCP endpoint itself. The
+facilitator sponsors the network fee on settlement, so buyers hold only the
+payment asset and no XLM.
 
 - **Facilitator**: `https://vellar-facilitator.onrender.com`
 - **Source**: https://github.com/Vellar-Wallet/vellar-facilitator
@@ -117,10 +122,11 @@ settlement, so buyers hold only the payment asset and no XLM.
 
 :::note
 
-Vellar runs on **Testnet only** and is pre-production. A mainnet deployment is
-gated on an external security review that has not yet been completed. The hosted
-instance runs on a free tier, so the first request after an idle period can take
-up to a minute.
+Vellar runs on **Testnet only** and is pre-production; there is no mainnet
+instance. An external security audit is still open, and the project's mainnet
+checklist treats it as a blocker for tagging a mainnet release rather than for
+running an instance. The hosted instance runs on a free tier, so the first
+request after an idle period can take up to a minute.
 
 :::
 

--- a/docs/build/agentic-payments/x402/README.mdx
+++ b/docs/build/agentic-payments/x402/README.mdx
@@ -95,6 +95,35 @@ This version supports x402 v2 specification. For x402 v1 support, please use a p
 
 :::
 
+### Community facilitators
+
+The following facilitators are built and operated by the community. They are not
+maintained by SDF and are at varying stages of readiness, so check each project's
+current status before depending on it.
+
+#### Vellar Facilitator
+
+[Vellar](https://github.com/Vellar-Wallet/vellar-facilitator) is an Apache-2.0
+x402 facilitator that pairs the standard `/verify`, `/settle`, and `/supported`
+endpoints with a **Bazaar discovery layer**: a resource is added to a searchable
+catalog the first time a payment settles for it, so sellers are listed without a
+separate registration step. It also exposes that catalog to AI agents over
+[MCP](https://modelcontextprotocol.io), and sponsors the network fee on
+settlement, so buyers hold only the payment asset and no XLM.
+
+- **Facilitator**: `https://vellar-facilitator.onrender.com`
+- **Source**: https://github.com/Vellar-Wallet/vellar-facilitator
+- **Docs**: https://docs.vellar.xyz
+
+:::note
+
+Vellar runs on **Testnet only** and is pre-production. A mainnet deployment is
+gated on an external security review that has not yet been completed. The hosted
+instance runs on a free tier, so the first request after an idle period can take
+up to a minute.
+
+:::
+
 ## Examples
 
 - **x402 on Stellar (Stellar repo)** — Tools, examples, and references for the x402 protocol on Stellar. Use this as the canonical source for Stellar-specific x402 demos and tooling. [View on GitHub](https://github.com/stellar/x402-stellar)

--- a/docs/build/agentic-payments/x402/README.mdx
+++ b/docs/build/agentic-payments/x402/README.mdx
@@ -106,15 +106,19 @@ current status before depending on it.
 [Vellar](https://github.com/Vellar-Wallet/vellar-facilitator) is an Apache-2.0
 x402 facilitator that pairs the standard `/verify`, `/settle`, and `/supported`
 endpoints with a **Bazaar discovery layer**: when a payment settles and its
-payload carries the Bazaar discovery extension, the resource is added to a
-searchable catalog, so sellers that use the extension are listed without a
-separate registration step. Payments without the extension settle normally but
-are not cataloged. The catalog is also reachable by AI agents through an
+payload carries the Bazaar discovery extension, the facilitator may add the
+resource to a searchable catalog, so sellers that use the extension are listed
+without a separate registration step. Cataloging is conditional and can be
+refused for invalid discovery data, or when the resource URL is already bound
+to a different recipient; settlement succeeds either way, and payments without
+the extension settle normally but are never cataloged. The catalog is also
+reachable by AI agents through an
 [MCP](https://modelcontextprotocol.io) discovery server (`src/mcp.ts` in the
 repository), which is a separate stdio process you run locally and point at the
 facilitator URL; the hosted instance does not expose an MCP endpoint itself. The
-facilitator sponsors the network fee on settlement, so buyers hold only the
-payment asset and no XLM.
+facilitator sponsors the settlement transaction fee, so buyers do not need XLM
+to pay for the transaction itself. Classic Stellar accounts still maintain their
+own base and trustline reserves.
 
 - **Facilitator**: `https://vellar-facilitator.onrender.com`
 - **Source**: https://github.com/Vellar-Wallet/vellar-facilitator
@@ -123,11 +127,12 @@ payment asset and no XLM.
 :::note
 
 Vellar runs on **Testnet only** and is pre-production; there is no mainnet
-instance. The pre-mainnet security review of the facilitator is complete, with
-findings tracked to closure. A mainnet release is additionally gated on a
-separate audit of the spending-limit policy contract, which has not yet been
-run. The hosted instance runs on a free tier, so the first request after an
-idle period can take up to a minute.
+instance. The facilitator has completed an internal pre-mainnet security review,
+with most findings closed and the remainder documented as open or deferred. A
+mainnet release is separately gated on an external audit covering the
+facilitator and its three provenance contracts, which has not yet been
+commissioned. The hosted instance runs on a free tier, so the first request
+after an idle period can take up to a minute.
 
 :::
 


### PR DESCRIPTION
Adds Vellar to the x402 facilitators section under a new Community Facilitators subsection.

Vellar is a hosted x402 facilitator for Stellar with:

- Bazaar auto-discovery (resources cataloged on first settlement carrying the discovery extension)
- MCP discovery server for AI agents (run locally, pointed at a facilitator)
- Fee-sponsored payments (buyers need no XLM for the transaction fee; classic accounts still maintain their own reserves)
- Policy-governed agent spending limits
- Open source, Apache-2.0

Live on Testnet and Mainnet: https://vellar-facilitator.onrender.com
GitHub: https://github.com/Vellar-Wallet/vellar-facilitator
Docs: https://docs.vellar.xyz

Status: pre-production. An external security audit has not yet been commissioned and is a hard blocker for a versioned Mainnet release tag; the Mainnet instance is running but not yet production-grade.

## A note on placement

I added a new `### Community Facilitators` subsection rather than a third entry alongside the Coinbase and Build on Stellar facilitators, because those two are production-grade and this one is pre-production. The "The following options are available for Stellar" sentence is deliberately left without a hardcoded count. The new subsection carries a line stating these are not maintained by SDF, so it should also serve any future community entries rather than being Vellar-specific.

Filed as a draft originally; all review comments from ElliotFriend addressed in subsequent commits.