### PR TITLE
docs: add Public Dashboards page to Analytics

### DIFF
--- a/config/theme/navbar.ts
+++ b/config/theme/navbar.ts
@@ -354,6 +354,11 @@ const data: NavbarItem = {
       activeBasePath: 'docs/data/analytics/hubble'
     },
     {
+      to: '/docs/data/analytics/public-dashboards',
+      label: 'Dashboards',
+      activeBasePath: 'docs/data/analytics/public-dashboards'
+    },
+    {
       to: '/docs/data/analytics/analytics-providers',
       label: 'Providers',
       activeBasePath: 'docs/data/analytics/analytics-providers'

--- a/docs/data/analytics/README.mdx
+++ b/docs/data/analytics/README.mdx
@@ -11,6 +11,10 @@ Hubble is an open-source, read-only BigQuery data warehouse maintained by SDF th
 
 Within Hubble, the stellar-etl product powers the extraction and transformation of Stellar network data into BigQuery. This open-source pipeline allows developers to extend or customize data ingestion workflows based on their analytical needs. Stellar-etl provides flexibility in how data is processed, enabling users to extract specific ledger entries, operations, or event logs based on their requirements.
 
+## [Public Dashboards](./public-dashboards.mdx)
+
+Public Dashboards is a directory of free, browser-based dashboards that track Stellar network activity, real-world assets, stablecoins, and DeFi. Most are maintained by ecosystem analytics platforms rather than SDF. Start here if you want to look at Stellar metrics without writing a query.
+
 ## [Data Analytics Providers](./analytics-providers/analytics-providers.mdx)
 
 Data Analytics Providers provide a complete historical record of Pubnet Stellar network data for analysis and insights. These platforms enable users to explore network trends but are not designed for real-time data access or transaction execution. The key difference is that these ecosystem platforms operate independently of SDF and provide metrics and dashboards about the Stellar network.

--- a/docs/data/analytics/analytics-providers/analytics-providers.mdx
+++ b/docs/data/analytics/analytics-providers/analytics-providers.mdx
@@ -5,7 +5,7 @@ title: Data Analytics Providers
 
 The following is a list of data analytics platforms that make a complete historical record of Pubnet Stellar network data available.
 
-If you only want to view pre-built charts rather than query data yourself, see the [Public Dashboards](../public-dashboards.mdx) page.
+For curated dashboards you can browse without writing queries, see the [Public Dashboards](../public-dashboards.mdx) page.
 
 | Platform | Description | Home page and Signup | Pricing | Data Access | Dashboard access |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/data/analytics/analytics-providers/analytics-providers.mdx
+++ b/docs/data/analytics/analytics-providers/analytics-providers.mdx
@@ -5,6 +5,8 @@ title: Data Analytics Providers
 
 The following is a list of data analytics platforms that make a complete historical record of Pubnet Stellar network data available.
 
+If you only want to view pre-built charts rather than query data yourself, see the [Public Dashboards](../public-dashboards.mdx) page.
+
 | Platform | Description | Home page and Signup | Pricing | Data Access | Dashboard access |
 | --- | --- | --- | --- | --- | --- |
 | Hubble | SDF provides a publicly available raw dataset with a complete historical record of Stellar network data, updated every 15 minutes. | [Hubble](https://console.cloud.google.com/bigquery?project=crypto-stellar&ws=!1m4!1m3!3m2!1scrypto-stellar!2scrypto_stellar) <br></br> [Signup](https://cloud.google.com/?hl=en) | End users incur the cost to execute queries. Visit the [BigQuery Pricing](https://cloud.google.com/bigquery/pricing#analysis_pricing_models) page to learn more. | Please see the [Analyst Guide](./hubble/analyst-guide) for more information. | N/A |

--- a/docs/data/analytics/public-dashboards.mdx
+++ b/docs/data/analytics/public-dashboards.mdx
@@ -14,13 +14,13 @@ Chain-level activity: transactions, operations, accounts, fees, and comparisons 
 
 | Dashboard | Published by | What it shows |
 | --- | --- | --- |
-| [Stellar Network Dashboard](https://dashboard.stellar.org) | SDF | Live metrics for the public network and testnet, plus lumen supply figures. |
-| [Stellar on Dune](https://dune.com/blockchains/stellar) | Dune | Network overview with links to community-built dashboards and the raw Stellar datasets. Data is updated hourly. |
-| [Stellar Portal](https://stellar.messari.io) | Messari | Network metrics, ecosystem projects, research reports and news articles on Stellar. |
-| [Stellar on Artemis](https://app.artemis.xyz/project/stellar) | Artemis | Fees, revenue, active addresses, transactions, and TVL for Stellar, with comparisons against other chains. |
-| [Stellar Project Page](https://tokenterminal.com/explorer/projects/stellar) | Token Terminal | Standardized financial and usage metrics for Stellar. |
-| [Stellar Intelligence](https://stellar.range.org) | Range | Network, cross-chain, and security-focused analytics for Stellar. |
-| [Stellar Dapps](https://dappradar.com/chain/stellar) | DappRadar | Dapp discovery and usage rankings on Stellar. |
+| [Stellar Network](https://dashboard.stellar.org) | SDF | Real-time network liveness for developers and validators: ledger close times, transaction throughput, and testnet status. The first place to check during a protocol upgrade. |
+| [Stellar on Dune](https://dune.com/blockchains/stellar) | Dune | Entry point to Dune's Stellar datasets and community dashboards. Best when you want to fork a query or build your own chart. |
+| [Stellar Ecosystem Portal](https://stellar.messari.io) | Messari | Metrics alongside research reports, news, and ecosystem project profiles. Aimed at investors and analysts who want context, not just charts. |
+| [Stellar on Artemis](https://app.artemis.xyz/project/stellar) | Artemis | Fees, revenue, active addresses, and TVL in a standard format for comparing Stellar against other chains. |
+| [Stellar on Token Terminal](https://tokenterminal.com/explorer/projects/stellar) | Token Terminal | Financial statement style metrics for Stellar. Useful for analysts benchmarking Stellar with the same definitions Token Terminal applies to every chain. |
+| [Stellar Cross-Chain Explorer](https://stellar.range.org) | Range | Cross-chain transfers into and out of Stellar at the transaction level, with bridge hops and counterparties. For compliance and bridge users. |
+| [Stellar on DappRadar](https://dappradar.com/chain/stellar) | DappRadar | Dapp discovery and usage rankings. Best for finding which Soroban apps have users. |
 
 ## Real-World Assets and Stablecoins
 
@@ -28,8 +28,8 @@ Tokenized assets, stablecoin supply, and related transaction volume on Stellar.
 
 | Dashboard | Published by | What it shows |
 | --- | --- | --- |
-| [RWAs on Stellar](https://dune.com/stellar/rwas) | SDF | Combined market cap and growth of real-world assets and stablecoins on Stellar, with transaction volume for reserve-verified stablecoins. |
-| [Stellar Network](https://app.rwa.xyz/networks/stellar) | rwa.xyz | Tokenized real-world asset value on Stellar by asset class and issuer, compared with other networks. |
+| [RWAs on Stellar](https://dune.com/stellar/rwas) | SDF | SDF's own view of tokenized assets and stablecoins on Stellar. Lists an asset as it launches, so it's the first look at an RWA before it clears rwa.xyz due diligence. |
+| [Stellar on rwa.xyz](https://app.rwa.xyz/networks/stellar) | rwa.xyz | Tokenized asset value on Stellar by asset class and issuer, using the same vetted methodology rwa.xyz applies to every network. The reference point for cross-chain RWA comparisons. |
 
 ## DeFi and Lending
 
@@ -37,9 +37,5 @@ Total value locked, protocol activity, and lending metrics for Soroban-based pro
 
 | Dashboard | Published by | What it shows |
 | --- | --- | --- |
-| [Stellar Chain](https://defillama.com/chain/stellar) | DefiLlama | Total value locked on Stellar, broken down by protocol, with historical trends. |
-| [Blend Protocol Analytics](https://dune.com/stellar/blend-protocol-analytics) | Stellar team on Dune | TVL, supply and borrow, utilization, volume, and activity across Blend lending pools. |
-
-## Adding a Dashboard
-
-To suggest a dashboard for this page, open a pull request against this file. Entries should describe what the dashboard shows and who maintains it. Dashboards must be publicly viewable without an account. See the [contributing guide](https://github.com/stellar/stellar-docs/blob/main/CONTRIBUTING.md#promotional-and-third-party-content) for conventions on third-party content.
+| [Stellar on DefiLlama](https://defillama.com/chain/stellar) | DefiLlama | TVL by protocol on Stellar, with history. The industry standard TVL figure most media and research cite. |
+| [Blend Protocol Analytics](https://dune.com/stellar/blend-protocol-analytics) | SDF | SDF-maintained view of Blend lending pools: TVL, supply and borrow, utilization, and volume. The only public dashboard focused on a single Soroban protocol. |

--- a/docs/data/analytics/public-dashboards.mdx
+++ b/docs/data/analytics/public-dashboards.mdx
@@ -42,4 +42,4 @@ Total value locked, protocol activity, and lending metrics for Soroban-based pro
 
 ## Adding a Dashboard
 
-To suggest a dashboard for this page, open a pull request against this file. Entries should describe what the dashboard shows and who maintains it. Dashboards must be publicly viewable without an account. See the [contributing guide](https://github.com/stellar/stellar-docs/blob/main/CONTRIBUTING.md) for conventions on third-party content.
+To suggest a dashboard for this page, open a pull request against this file. Entries should describe what the dashboard shows and who maintains it. Dashboards must be publicly viewable without an account. See the [contributing guide](https://github.com/stellar/stellar-docs/blob/main/CONTRIBUTING.md#promotional-and-third-party-content) for conventions on third-party content.

--- a/docs/data/analytics/public-dashboards.mdx
+++ b/docs/data/analytics/public-dashboards.mdx
@@ -28,8 +28,8 @@ Tokenized assets, stablecoin supply, and related transaction volume on Stellar.
 
 | Dashboard | Published by | What it shows |
 | --- | --- | --- |
-| [RWAs on Stellar](https://dune.com/stellar/rwas) | SDF | SDF's own view of tokenized assets and stablecoins on Stellar. Lists an asset as it launches, so it's the first look at an RWA before it clears rwa.xyz due diligence. |
-| [Stellar on rwa.xyz](https://app.rwa.xyz/networks/stellar) | rwa.xyz | Tokenized asset value on Stellar by asset class and issuer, using the same vetted methodology rwa.xyz applies to every network. The reference point for cross-chain RWA comparisons. |
+| [RWAs on Stellar](https://dune.com/stellar/rwas) | SDF | SDF's own view of tokenized assets and stablecoins on Stellar. Lists assets as they launch on Stellar, including ones not yet tracked by rwa.xyz. |
+| [Stellar on rwa.xyz](https://app.rwa.xyz/networks/stellar) | rwa.xyz | Tokenized asset value on Stellar by asset class and issuer, using the same vetted methodology rwa.xyz applies to every network. Useful for comparing Stellar's RWA footprint with other networks on a like-for-like basis. |
 
 ## DeFi and Lending
 
@@ -37,5 +37,5 @@ Total value locked, protocol activity, and lending metrics for Soroban-based pro
 
 | Dashboard | Published by | What it shows |
 | --- | --- | --- |
-| [Stellar on DefiLlama](https://defillama.com/chain/stellar) | DefiLlama | TVL by protocol on Stellar, with history. The industry standard TVL figure most media and research cite. |
-| [Blend Protocol Analytics](https://dune.com/stellar/blend-protocol-analytics) | SDF | SDF-maintained view of Blend lending pools: TVL, supply and borrow, utilization, and volume. The only public dashboard focused on a single Soroban protocol. |
+| [Stellar on DefiLlama](https://defillama.com/chain/stellar) | DefiLlama | TVL by protocol on Stellar, with history. The TVL figure most commonly cited in third-party research. |
+| [Blend Protocol Analytics](https://dune.com/stellar/blend-protocol-analytics) | SDF | SDF-maintained view of Blend lending pools: TVL, supply and borrow, utilization, and volume. Currently the one dashboard here focused on a single Soroban protocol. |

--- a/docs/data/analytics/public-dashboards.mdx
+++ b/docs/data/analytics/public-dashboards.mdx
@@ -28,7 +28,7 @@ Tokenized assets, stablecoin supply, and related transaction volume on Stellar.
 
 | Dashboard | Published by | What it shows |
 | --- | --- | --- |
-| [RWAs on Stellar](https://dune.com/stellar/rwas) | Stellar team on Dune | Combined market cap and growth of real-world assets and stablecoins on Stellar, with transaction volume for reserve-verified stablecoins. |
+| [RWAs on Stellar](https://dune.com/stellar/rwas) | SDF | Combined market cap and growth of real-world assets and stablecoins on Stellar, with transaction volume for reserve-verified stablecoins. |
 | [Stellar Network](https://app.rwa.xyz/networks/stellar) | rwa.xyz | Tokenized real-world asset value on Stellar by asset class and issuer, compared with other networks. |
 
 ## DeFi and Lending

--- a/docs/data/analytics/public-dashboards.mdx
+++ b/docs/data/analytics/public-dashboards.mdx
@@ -16,7 +16,7 @@ Chain-level activity: transactions, operations, accounts, fees, and comparisons 
 | --- | --- | --- |
 | [Stellar Network Dashboard](https://dashboard.stellar.org) | SDF | Live metrics for the public network and testnet, plus lumen supply figures. |
 | [Stellar on Dune](https://dune.com/blockchains/stellar) | Dune | Network overview with links to community-built dashboards and the raw Stellar datasets. Data is updated hourly. |
-| [Stellar Portal](https://stellar.messari.io) | Messari | Network metrics, ecosystem projects, and research on Stellar. |
+| [Stellar Portal](https://stellar.messari.io) | Messari | Network metrics, ecosystem projects, research reports and news articles on Stellar. |
 | [Stellar on Artemis](https://app.artemis.xyz/project/stellar) | Artemis | Fees, revenue, active addresses, transactions, and TVL for Stellar, with comparisons against other chains. |
 | [Stellar Project Page](https://tokenterminal.com/explorer/projects/stellar) | Token Terminal | Standardized financial and usage metrics for Stellar. |
 | [Stellar Intelligence](https://stellar.range.org) | Range | Network, cross-chain, and security-focused analytics for Stellar. |

--- a/docs/data/analytics/public-dashboards.mdx
+++ b/docs/data/analytics/public-dashboards.mdx
@@ -1,0 +1,45 @@
+---
+title: Public Dashboards
+description: A directory of free, public dashboards that track Stellar network activity, real-world assets, stablecoins, and DeFi.
+sidebar_position: 500
+---
+
+This page lists public dashboards that show what is happening on the Stellar network. Every dashboard here can be opened in a browser without an account, though some platforms offer extra views to signed-in users. Most are built and maintained by third parties, not SDF, so refresh cadence and methodology vary by platform.
+
+If you want to run your own queries against the underlying data instead, see [Hubble](./hubble/README.mdx) or the [Data Analytics Providers](./analytics-providers/analytics-providers.mdx) page. For looking up a specific transaction, account, or contract, use a [block explorer](../../tools/developer-tools/block-explorers.mdx).
+
+## Network Overview
+
+Chain-level activity: transactions, operations, accounts, fees, and comparisons with other networks.
+
+| Dashboard | Published by | What it shows |
+| --- | --- | --- |
+| [Stellar Network Dashboard](https://dashboard.stellar.org) | SDF | Live metrics for the public network and testnet, plus lumen supply figures. |
+| [Stellar on Dune](https://dune.com/blockchains/stellar) | Dune | Network overview with links to community-built dashboards and the raw Stellar datasets. Data is updated hourly. |
+| [Stellar Portal](https://stellar.messari.io) | Messari | Network metrics, ecosystem projects, and research on Stellar. |
+| [Stellar on Artemis](https://app.artemis.xyz/project/stellar) | Artemis | Fees, revenue, active addresses, transactions, and TVL for Stellar, with comparisons against other chains. |
+| [Stellar Project Page](https://tokenterminal.com/explorer/projects/stellar) | Token Terminal | Standardized financial and usage metrics for Stellar. |
+| [Stellar Intelligence](https://stellar.range.org) | Range | Network, cross-chain, and security-focused analytics for Stellar. |
+| [Stellar Dapps](https://dappradar.com/chain/stellar) | DappRadar | Dapp discovery and usage rankings on Stellar. |
+
+## Real-World Assets and Stablecoins
+
+Tokenized assets, stablecoin supply, and related transaction volume on Stellar.
+
+| Dashboard | Published by | What it shows |
+| --- | --- | --- |
+| [RWAs on Stellar](https://dune.com/stellar/rwas) | Stellar team on Dune | Combined market cap and growth of real-world assets and stablecoins on Stellar, with transaction volume for reserve-verified stablecoins. |
+| [Stellar Network](https://app.rwa.xyz/networks/stellar) | rwa.xyz | Tokenized real-world asset value on Stellar by asset class and issuer, compared with other networks. |
+
+## DeFi and Lending
+
+Total value locked, protocol activity, and lending metrics for Soroban-based protocols.
+
+| Dashboard | Published by | What it shows |
+| --- | --- | --- |
+| [Stellar Chain](https://defillama.com/chain/stellar) | DefiLlama | Total value locked on Stellar, broken down by protocol, with historical trends. |
+| [Blend Protocol Analytics](https://dune.com/stellar/blend-protocol-analytics) | Stellar team on Dune | TVL, supply and borrow, utilization, volume, and activity across Blend lending pools. |
+
+## Adding a Dashboard
+
+To suggest a dashboard for this page, open a pull request against this file. Entries should describe what the dashboard shows and who maintains it. Dashboards must be publicly viewable without an account. See the [contributing guide](https://github.com/stellar/stellar-docs/blob/main/CONTRIBUTING.md) for conventions on third-party content.

--- a/routes.txt
+++ b/routes.txt
@@ -274,6 +274,7 @@
 /docs/data/analytics/hubble/developer-guide/visualization
 /docs/data/analytics/hubble/developer-guide/visualization/getting-started
 /docs/data/analytics/hubble/developer-guide/visualization/overview
+/docs/data/analytics/public-dashboards
 /docs/data/apis
 /docs/data/apis/horizon
 /docs/data/apis/horizon/admin-guide


### PR DESCRIPTION
## What

Adds a new page, **Data > Analytics > Public Dashboards**, that lists free, browser-viewable dashboards tracking the Stellar network. Entries are grouped by what a reader wants to see rather than by vendor:

- **Network Overview**: Stellar Network Dashboard (SDF), Dune, Messari, Artemis, Token Terminal, Range, DappRadar
- **Real-World Assets and Stablecoins**: RWAs on Stellar (Dune), rwa.xyz
- **DeFi and Lending**: DefiLlama, Blend Protocol Analytics (Dune)

Each row has the dashboard name linked to the Stellar-specific view, who publishes it, and one line on what it shows. Descriptions are kept descriptive, not promotional, per the contributing guide.

## Why

The existing Data Analytics Providers page is a vendor comparison table (pricing, signup, data access). Several of these dashboards are already linked there, but buried in the last column. There was no single place to send someone who just wants to look at Stellar metrics without writing a query.

## Other changes

- `docs/data/analytics/README.mdx`: adds a short Public Dashboards section linking to the new page.
- `docs/data/analytics/analytics-providers/analytics-providers.mdx`: adds one sentence under the intro pointing readers who only want charts to the new page. The table is unchanged.
- `routes.txt`: regenerated by `pnpm build`, one new route added. No routes removed.

## Checks

- `pnpm build` passes with no broken links (node 24).
- Prettier check passes on all changed files.
- Every dashboard URL was verified to land on a Stellar-specific view.

## Related

#2156 proposes flattening the Analytics and Indexers provider pages. This page fits either structure and does not change the existing ones.