### PR TITLE
Link the USDT0 docs page to the USDT0 launch guide

### DIFF
--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -11,6 +11,8 @@ description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, 
 
 On Stellar, USDT0 is a **classic asset with a SAC**. Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
 
+For an overview of what USDT0 unlocks on Stellar, the partners supporting it today, and a deployment checklist, see the [USDT0 on Stellar launch guide](/launch/usdt0).
+
 :::info[Full documentation]
 
 For the architecture, the OFT interface, supported chains, and the transfer UI:

--- a/docs/tokens/usdt0-layerzero.mdx
+++ b/docs/tokens/usdt0-layerzero.mdx
@@ -11,7 +11,7 @@ description: "Use USDT0, Tether's USDT delivered over LayerZero's OFT standard, 
 
 On Stellar, USDT0 is a **classic asset with a SAC**. Classic flows use a trustline plus a payment. Soroban contracts call the SAC. See the [tokenization model comparison](./anatomy-of-an-asset.mdx#tokenization-model-comparison) for what that implies.
 
-For an overview of what USDT0 unlocks on Stellar, the partners supporting it today, and a deployment checklist, see the [USDT0 on Stellar launch guide](/launch/usdt0).
+For an overview of what USDT0 unlocks on Stellar, the partners supporting it today, and a deployment checklist, see the [USDT0 on Stellar launch guide](pathname:///launch/usdt0).
 
 :::info[Full documentation]
 


### PR DESCRIPTION
Adds one link from `docs/tokens/usdt0-layerzero.mdx` to `/launch/usdt0`.

`/launch/usdt0` currently has no inbound links from anywhere on developers.stellar.org. This page is its most natural referrer: a reader here is already looking at USDT0 on Stellar, and the launch guide covers what it unlocks, which partners support it today, and a deployment checklist — none of which this page goes into.

It also helps crawlers, which reach orphaned pages less often and pass them no internal link equity.

The link uses descriptive anchor text rather than "read more", so both readers and crawlers can tell where it goes.

One line, no other changes. Split out from #2840 so it can land independently of the sitemap configuration change there, which needs a build to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
