### PR TITLE
State the pool share trustline two-reserve exception on the Lumens and Accounts pages

### DIFF
--- a/docs/learn/fundamentals/lumens.mdx
+++ b/docs/learn/fundamentals/lumens.mdx
@@ -27,7 +27,7 @@ Validators can vote to change the base reserve, but that’s uncommon and should
 
 ## Minimum balance
 
-Stellar accounts must maintain a minimum balance to exist, which is calculated using the base reserve. An account must always maintain a minimum balance of two base reserves (currently 1 XLM). Every subentry after that requires an additional base reserve (currently 0.5 XLM) and increases the account’s minimum balance. Subentries include trustlines (for both traditional assets and pool shares), offers, signers, and data entries. An account cannot have more than 1,000 subentries.
+Stellar accounts must maintain a minimum balance to exist, which is calculated using the base reserve. An account must always maintain a minimum balance of two base reserves (currently 1 XLM). Every subentry after that requires an additional base reserve (currently 0.5 XLM) and increases the account’s minimum balance. Subentries include trustlines (for both traditional assets and pool shares), offers, signers, and data entries. A pool share trustline is the one exception: it counts as two subentries, so it requires two base reserves (currently 1 XLM) instead of one. Learn more in the [Liquidity Pools section](./liquidity-on-stellar-sdex-liquidity-pools.mdx#trustlines). An account cannot have more than 1,000 subentries.
 
 Data also lives on the ledger as ledger entries. Ledger entries include claimable balances (which require a base reserve per claimant) and liquidity pool deposits and withdrawals.
 

--- a/docs/learn/fundamentals/lumens.mdx
+++ b/docs/learn/fundamentals/lumens.mdx
@@ -33,7 +33,7 @@ Data also lives on the ledger as ledger entries. Ledger entries include claimabl
 
 For example, an account with one trustline, two offers, and a claimable balance with one claimant has a minimum balance of:
 
-2 base reserves (1 XLM) + 3 subentries/base reserves (1.5 XLM) + 1 ledger entry/base reserve (1 XLM) = 3.5 XLM
+2 base reserves (1 XLM) + 3 subentries/base reserves (1.5 XLM) + 1 claimant/base reserve (0.5 XLM) = 3 XLM
 
 Minimum balance is not the same as the balance an account can spend. Selling liabilities (the amount an account has committed to open sell offers) are not part of the minimum balance. They reduce the balance available above it: `available balance` = `balance` - `minimum balance` - `liabilities.selling`.
 

--- a/docs/learn/fundamentals/stellar-data-structures/accounts.mdx
+++ b/docs/learn/fundamentals/stellar-data-structures/accounts.mdx
@@ -43,10 +43,13 @@ A base reserve is a unit of measurement used to calculate an account’s minimum
 
 Account data is stored in subentries, each of which increases an account’s minimum balance by one base reserve (0.5 XLM). An account cannot have more than 1,000 subentries. Possible subentries are:
 
-- Trustlines (includes traditional assets and pool shares)
+- Trustlines for traditional assets (one subentry each)
+- Trustlines for pool shares (two subentries each)
 - Offers
 - Additional signers
 - Data entries (includes data made with the `manageData` operation, not smart contract ledger entries)
+
+A pool share trustline is the one exception to the rule above: it counts as two subentries, so it requires two base reserves (currently 1 XLM) and it counts twice toward the 1,000 subentry limit. Learn more in the [Liquidity Pools section](../liquidity-on-stellar-sdex-liquidity-pools.mdx#trustlines).
 
 ## Trustlines
 


### PR DESCRIPTION
🤖 Automated triage bot, acting for @kaankacar.

Closes #2842.

The Lumens and Accounts pages listed pool share trustlines with ordinary trustlines as one subentry each. A pool share trustline counts as two subentries and needs two base reserves. This adds the exception to both pages and links the Liquidity Pools section.

Verification:

- CAP-0038 states the pool share trust line counts as two subentries and needs two base reserves.
- stellar-core `computeMultiplier` (SponsorshipUtils.cpp) returns 2 for a `ASSET_TYPE_POOL_SHARE` trustline and 1 for other trustlines.
- stellar-core `calculateDelta` (invariant/AccountSubEntriesCountIsValid.cpp) adds 2 to `numSubEntries` for a pool share trustline, so the entry also counts twice toward the 1,000 subentry cap.
- The `#trustlines` anchor is the only Trustlines heading on the Liquidity Pools page.
- No new page, so routes.txt and redirects.conf need no change.

## Second commit: an arithmetic defect in the same section

The minimum balance example on the Lumens page charged 1 XLM for a claimable balance with one claimant, and totalled 3.5 XLM. One claimant costs one base reserve, which is 0.5 XLM, so the total is 3 XLM. Sources:

- The [Claimable Balances guide](https://github.com/stellar/stellar-docs/blob/main/docs/build/guides/transactions/claimable-balances.mdx) says each claimant increases the source account's minimum balance by one base reserve.
- stellar-core `computeMultiplier` returns `claimants.size()` for a `CLAIMABLE_BALANCE` entry.

I found this while verifying #2842 and no open issue covers it. It sits three lines below the new text, so leaving it would ship a wrong number beside a reserve correction. Happy to split it into its own PR if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
