### PR TITLE
Separate the Protocol 20 software release date from the Mainnet activation date

### DIFF
--- a/docs/networks/software-versions.mdx
+++ b/docs/networks/software-versions.mdx
@@ -765,7 +765,9 @@ This is the first version of the Soroban SDK that supports protocol 21. It is ma
 - Revert "[Epic] Separating soroban-rpc to prepare for repo change"
 - [Epic] Separating soroban-rpc to prepare for repo change
 
-## Protocol 20: Soroban Phase 1 (Mainnet Edition) (February 5, 2024)
+## Protocol 20: Soroban Phase 0 (software release, February 5, 2024)
+
+February 5, 2024 is the release date of this software, not a network upgrade date. Mainnet activated Protocol 20 on February 20, 2024 at 1700 UTC and ran the Phase 0 limits and fees listed below. Read more in the [Protocol 20 Upgrade Guide](https://stellar.org/blog/developers/protocol-20-upgrade-guide).
 
 ### Software
 


### PR DESCRIPTION
🤖 Automated triage bot, acting for @kaankacar.

Closes #2843.

The February 5, 2024 entry was headed "Soroban Phase 1 (Mainnet Edition)". Sibling headings use the Mainnet token for an activation date, so a reader took February 5 as the Protocol 20 Mainnet activation date. The heading also said Phase 1 while its own table lists Phase 0 limits and fees. This renames the heading and records the activation date in one line.

Verification:

- The SDF Protocol 20 Upgrade Guide, published 2024-02-20T17:00:00Z, states Mainnet upgraded to Protocol 20 on February 20 at 1700 UTC.
- The validator guide to Soroban Mainnet Phase 1, published 2024-02-21, states Mainnet was then running Protocol 20.
- Stellar Core `v20.2.0`, the version in this entry's table, was published 2024-02-05T20:44:03Z. So February 5 is a software release date.
- The sibling convention is an activation date: the page heads Protocol 27 "(Mainnet, July 8, 2026)", and Horizon shows pubnet ledger 63385000 at 14:02 UTC on 2026-07-08 was still protocol 26 while ledger 63387000 at 17:17 UTC was protocol 27.
- No other page or heading label changes. The rest of the page keeps its current convention.
- No page in the repo links the old heading anchor, so no redirects.conf or routes.txt change.

One note for the maintainers: PR #2675 rewrites this same heading and keeps "Soroban Phase 1, Mainnet Edition". Whichever merges second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
