### PR TITLE
docs: add data products comparison table to Data Overview

### DIFF
--- a/docs/data/README.mdx
+++ b/docs/data/README.mdx
@@ -7,6 +7,29 @@ There are several products to choose from when interacting with the Stellar Netw
 
 Use the summaries below to determine which types of data tools are right for your use case.
 
+## Compare Data Products
+
+SDF maintains four data products. Two are APIs and two are for bulk historical data, so start by picking the row that matches how you want to consume the data.
+
+|  | [RPC](./apis/rpc/README.mdx) | [Horizon](./apis/horizon/README.mdx) | [Hubble](./analytics/hubble/README.mdx) | [Galexie](./indexers/build-your-own/galexie/README.mdx) |
+| --- | --- | --- | --- | --- |
+| Type | API | API | Data warehouse | Ledger export tool |
+| Interface | JSON-RPC | REST | SQL (BigQuery) | Files in your data lake |
+| Real-time data | ✅ | ✅ | ❌ | ❌ |
+| Historical data | ❌ About 7 days | ❌ 1 year\* | ✅ Full | ✅ Full |
+| Smart contract data | ✅ | ❌ | ✅ | ✅ Raw |
+| Transaction submission | ✅ | ✅ | ❌ | ❌ |
+| Transaction simulation | ✅ | ❌ | ❌ | ❌ |
+| Curated and parsed data | ❌ | ✅ | ✅ | ❌ Raw XDR |
+| Run it yourself | ✅ | ✅ | ✅ Fork | ✅ |
+| Hosted by SDF | Testnet only | ✅ Deprecating | ✅ Public dataset | ❌\*\* |
+
+\*_The SDF-hosted Horizon keeps one year of history. A self-hosted Horizon can serve full history, but Hubble or Galexie are the recommended tools for that._
+
+\*\*_SDF does not host a Galexie data lake, but [several providers](./indexers/build-your-own/galexie/providers.mdx) make public ones available._
+
+The [Ingest SDK](./indexers/build-your-own/ingest-sdk/README.mdx) and [Processors](./indexers/build-your-own/processors/README.mdx) are libraries for building on top of these products rather than data products themselves. Third-party APIs, indexers, and analytics platforms are listed on their own pages in each section below.
+
 ## [Analytics](./analytics/README.mdx)
 
 Explore and analyze Stellar network data to uncover trends, track activity, and generate insights for decision-making and reporting.

--- a/docs/data/README.mdx
+++ b/docs/data/README.mdx
@@ -14,17 +14,16 @@ SDF maintains four data products. Two are APIs and two are for bulk historical d
 |  | [RPC](./apis/rpc/README.mdx) | [Horizon](./apis/horizon/README.mdx) | [Hubble](./analytics/hubble/README.mdx) | [Galexie](./indexers/build-your-own/galexie/README.mdx) |
 | --- | --- | --- | --- | --- |
 | Type | API | API | Data warehouse | Ledger export tool |
-| Interface | JSON-RPC | REST | SQL (BigQuery) | Files in your data lake |
+| Interface | JSON-RPC | REST | SQL (BigQuery) | XDR files in your data lake |
 | Real-time data | ✅ | ✅ | ❌ | ❌ |
-| Historical data | ❌ About 7 days | ❌ 1 year\* | ✅ Full | ✅ Full |
-| Smart contract data | ✅ | ❌ | ✅ | ✅ Raw |
+| Historical data | About 7 days | 1 year\* | Full | Full |
+| Smart contract data | ✅ | ❌ | ✅ | ✅ |
 | Transaction submission | ✅ | ✅ | ❌ | ❌ |
 | Transaction simulation | ✅ | ❌ | ❌ | ❌ |
-| Curated and parsed data | ❌ | ✅ | ✅ | ❌ Raw XDR |
-| Run it yourself | ✅ | ✅ | ✅ Fork | ✅ |
-| Hosted by SDF | Testnet only | ✅ Deprecating | ✅ Public dataset | ❌\*\* |
+| Curated and parsed data | ❌ | ✅ | ✅ | ❌ |
+| Hosted by SDF | Testnet and futurenet | Mainnet, testnet, and futurenet\* | Public BigQuery dataset | None\*\* |
 
-\*_The SDF-hosted Horizon keeps one year of history. A self-hosted Horizon can serve full history, but Hubble or Galexie are the recommended tools for that._
+\*_The SDF-hosted Horizon keeps one year of history and is nearing end-of-life in favor of RPC. A self-hosted Horizon can serve full history, but Hubble or Galexie are the recommended tools for that._
 
 \*\*_SDF does not host a Galexie data lake, but [several providers](./indexers/build-your-own/galexie/providers.mdx) make public ones available._
 

--- a/docs/data/apis/README.mdx
+++ b/docs/data/apis/README.mdx
@@ -13,7 +13,7 @@ Learn about the services that provide access to real-time Stellar network data
 | Transaction Simulation  | ✅  | ❌      |
 | Curated and Parsed Data | ❌  | ✅      |
 
-\*_Please note that Horizon can provide full historical data but is not the recommended tool for full historical data access. Please use [Hubble](../analytics/hubble/README.mdx) or [Galexie](../indexers/build-your-own/galexie/README.mdx) instead._
+\*_Horizon can provide full historical data if you run your own instance, but it is not the recommended tool for that. Use [Hubble](../analytics/hubble/README.mdx) or [Galexie](../indexers/build-your-own/galexie/README.mdx) instead. For a side-by-side comparison of all four SDF data products, see [Compare Data Products](../README.mdx#compare-data-products)._
 
 ## [RPC](./rpc/README.mdx)
 


### PR DESCRIPTION
Closes #1619

## What

Adds a **Compare Data Products** section to the Data Overview page (`docs/data/README.mdx`) with one table across SDF's four data products: RPC, Horizon, Hubble, and Galexie. Type and Interface rows make it clear which are APIs and which are bulk historical data tools, followed by the feature rows from the existing RPC/Horizon table plus transaction submission and SDF hosting.

Two footnotes cover the details that don't fit a cell: the SDF-hosted Horizon keeps one year of history and is nearing end-of-life, and SDF doesn't host a Galexie data lake but providers do. Rows are either all marks or all words to match the other comparison tables in the docs. A closing paragraph explains why Ingest SDK and Processors are not columns (they're libraries) and where third-party providers are listed.

## Why

The APIs Overview compares only RPC and Horizon, then points at Hubble and Galexie in a footnote without comparing them. The Data Overview already introduces all four categories and tells readers to pick the right tool for their use case, so it's the natural home for a side-by-side view. This is option 1 from the discussion on #1619, which Leigh signed off on.

## Other changes

- `docs/data/apis/README.mdx`: the Horizon history footnote now links to the new table. The RPC/Horizon table itself is unchanged.
- No URL or sidebar changes. `routes.txt` unchanged.

## Checks

- `pnpm build` passes with no broken links (node 24).
- Prettier passes on both files.
- Cell values were checked against the RPC, Horizon, Hubble, and Galexie pages in this repo.
