### PR TITLE
Document the --enable-core-manual-close flag in Quickstart advanced usage

### DIFF
--- a/docs/tools/quickstart/advanced-usage/operation-modes.mdx
+++ b/docs/tools/quickstart/advanced-usage/operation-modes.mdx
@@ -53,4 +53,4 @@ With manual close enabled, ledgers only advance when you explicitly trigger a cl
 curl "http://localhost:11626/manualclose"
 ```
 
-Each `manualclose` invocation advances the ledger by exactly one. Support for closing multiple ledgers per invocation is requested in [stellar-core issue 4040](https://github.com/stellar/stellar-core/issues/4040). For a complete example of starting a local network with the flag enabled, see [Run Commands](./run-command-examples.mdx).
+With no parameters, each `manualclose` invocation advances the ledger by one. On a standalone network, the command also accepts an optional `ledgerSeq` parameter to close up to a specific ledger sequence, and an optional `closeTime` parameter to set the close time of the next ledger. Support for closing multiple consecutive ledgers with a single `count` parameter is requested in [stellar-core issue 4040](https://github.com/stellar/stellar-core/issues/4040). For a complete example of starting a local network with the flag enabled, see [Run Commands](./run-command-examples.mdx).

--- a/docs/tools/quickstart/advanced-usage/operation-modes.mdx
+++ b/docs/tools/quickstart/advanced-usage/operation-modes.mdx
@@ -45,7 +45,7 @@ Upon launching a persistent mode container for the first time, the launch script
 
 ## Manual close mode
 
-By default, ledgers close automatically every few seconds. For deterministic local testing, you can disable automatic closing by passing the `--enable-core-manual-close` flag when starting the container. The flag sets the `MANUAL_CLOSE` setting in the container's generated `etc/stellar-core.cfg`, and defaults to `false` when not specified.
+By default, ledgers close automatically every few seconds. For deterministic local testing, you can disable automatic closing by passing the `--enable-core-manual-close` flag when starting the container. The flag sets the `MANUAL_CLOSE` setting in the `etc/stellar-core.cfg` file that the container generates when it initializes, and defaults to `false` when not specified. The configuration is only generated on first initialization, so adding the flag to a container that already has one (for example, on a persistent volume) has no effect until the configuration is regenerated.
 
 With manual close enabled, ledgers only advance when you explicitly trigger a close by sending the `manualclose` command to stellar-core's HTTP endpoint on port `11626`:
 
@@ -53,4 +53,4 @@ With manual close enabled, ledgers only advance when you explicitly trigger a cl
 curl "http://localhost:11626/manualclose"
 ```
 
-With no parameters, each `manualclose` invocation advances the ledger by one. On a standalone network, the command also accepts an optional `ledgerSeq` parameter to close up to a specific ledger sequence, and an optional `closeTime` parameter to set the close time of the next ledger. Support for closing multiple consecutive ledgers with a single `count` parameter is requested in [stellar-core issue 4040](https://github.com/stellar/stellar-core/issues/4040). For a complete example of starting a local network with the flag enabled, see [Run Commands](./run-command-examples.mdx).
+With no parameters, each `manualclose` invocation advances the ledger by one. On a standalone network, the command also accepts an optional `ledgerSeq` parameter that selects the sequence number of the ledger to close (intermediate ledgers are skipped), and an optional `closeTime` parameter to set the close time of the next ledger. Support for closing multiple consecutive ledgers with a single `count` parameter is requested in [stellar-core issue 4040](https://github.com/stellar/stellar-core/issues/4040). For a complete example of starting a local network with the flag enabled, see [Run Commands](./run-command-examples.mdx).

--- a/docs/tools/quickstart/advanced-usage/operation-modes.mdx
+++ b/docs/tools/quickstart/advanced-usage/operation-modes.mdx
@@ -42,3 +42,15 @@ Upon launching a persistent mode container for the first time, the launch script
 1. Run an interactive session of the container at first, ensuring that all services start and run correctly.
 2. Shut down the interactive container (using Ctrl-C).
 3. Start a new container using the same host directory in the background.
+
+## Manual close mode
+
+By default, ledgers close automatically every few seconds. For deterministic local testing, you can disable automatic closing by passing the `--enable-core-manual-close` flag when starting the container. The flag sets the `MANUAL_CLOSE` setting in the container's generated `etc/stellar-core.cfg`, and defaults to `false` when not specified.
+
+With manual close enabled, ledgers only advance when you explicitly trigger a close by sending the `manualclose` command to stellar-core's HTTP endpoint on port `11626`:
+
+```sh
+curl "http://localhost:11626/manualclose"
+```
+
+Each `manualclose` invocation advances the ledger by exactly one. Support for closing multiple ledgers per invocation is requested in [stellar-core issue 4040](https://github.com/stellar/stellar-core/issues/4040). For a complete example of starting a local network with the flag enabled, see [Run Commands](./run-command-examples.mdx).

--- a/docs/tools/quickstart/advanced-usage/operation-modes.mdx
+++ b/docs/tools/quickstart/advanced-usage/operation-modes.mdx
@@ -45,7 +45,7 @@ Upon launching a persistent mode container for the first time, the launch script
 
 ## Manual close mode
 
-By default, ledgers close automatically every few seconds. For deterministic local testing, you can disable automatic closing by passing the `--enable-core-manual-close` flag when starting the container. The flag sets the `MANUAL_CLOSE` setting in the `etc/stellar-core.cfg` file that the container generates when it initializes, and defaults to `false` when not specified. The configuration is only generated on first initialization, so adding the flag to a container that already has one (for example, on a persistent volume) has no effect until the configuration is regenerated.
+By default, ledgers close automatically every few seconds. For deterministic local testing, you can disable automatic closing by passing the `--enable-core-manual-close` flag when starting the container. The flag sets the `MANUAL_CLOSE` setting in the `etc/stellar-core.cfg` file that the container generates when it initializes, and defaults to `false` when not specified. It applies to the `--local` network: stellar-core refuses to start with `MANUAL_CLOSE` enabled unless `NODE_IS_VALIDATOR` is set, and the Quickstart local network configuration is the one that sets it. The configuration is only generated on first initialization, so adding the flag to a container that already has one (for example, on a persistent volume) has no effect until the configuration is regenerated.
 
 With manual close enabled, ledgers only advance when you explicitly trigger a close by sending the `manualclose` command to stellar-core's HTTP endpoint on port `11626`:
 

--- a/docs/tools/quickstart/advanced-usage/run-command-examples.mdx
+++ b/docs/tools/quickstart/advanced-usage/run-command-examples.mdx
@@ -102,3 +102,35 @@ docker run -it --rm `
 </TabItem>
 
 </Tabs>
+
+Start an ephemeral local network with manual ledger close enabled. Ledgers only advance when you send the `manualclose` command to stellar-core's HTTP endpoint (see [Operation Modes](./operation-modes.mdx)):
+
+<Tabs groupId="platform" defaultValue={getPlatform()}>
+
+<TabItem value="unix" label="macOS/Linux">
+
+```sh
+docker run -d \
+  -p "8000:8000" \
+  --name stellar \
+  stellar/quickstart \
+  --local \
+  --enable-core-manual-close
+```
+
+</TabItem>
+
+<TabItem value="windows" label="Windows (PowerShell)">
+
+```powershell
+docker run -d `
+  -p "8000:8000" `
+  --name stellar `
+  stellar/quickstart `
+  --local `
+  --enable-core-manual-close
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs/tools/quickstart/advanced-usage/run-command-examples.mdx
+++ b/docs/tools/quickstart/advanced-usage/run-command-examples.mdx
@@ -112,6 +112,7 @@ Start an ephemeral local network with manual ledger close enabled. Ledgers only 
 ```sh
 docker run -d \
   -p "8000:8000" \
+  -p "11626:11626" \
   --name stellar \
   stellar/quickstart \
   --local \
@@ -125,6 +126,7 @@ docker run -d \
 ```powershell
 docker run -d `
   -p "8000:8000" `
+  -p "11626:11626" `
   --name stellar `
   stellar/quickstart `
   --local `

--- a/docs/tools/quickstart/advanced-usage/run-command-examples.mdx
+++ b/docs/tools/quickstart/advanced-usage/run-command-examples.mdx
@@ -112,7 +112,7 @@ Start an ephemeral local network with manual ledger close enabled. Ledgers only 
 ```sh
 docker run -d \
   -p "8000:8000" \
-  -p "11626:11626" \
+  -p "127.0.0.1:11626:11626" \
   --name stellar \
   stellar/quickstart \
   --local \
@@ -126,7 +126,7 @@ docker run -d \
 ```powershell
 docker run -d `
   -p "8000:8000" `
-  -p "11626:11626" `
+  -p "127.0.0.1:11626:11626" `
   --name stellar `
   stellar/quickstart `
   --local `


### PR DESCRIPTION
Fixes #2772

The Quickstart container supports manual ledger close via `--enable-core-manual-close`, but no Quickstart page named the flag. This adds it to the advanced usage section:

- A "Manual close mode" section on the Operation Modes page covering the flag name, its default value of `false`, the `MANUAL_CLOSE` setting it writes into `etc/stellar-core.cfg`, and how a close is triggered via the `manualclose` command on stellar-core's HTTP endpoint (port `11626`).
- A run-command example on the Run Commands page that starts an ephemeral local network with the flag enabled, in the existing macOS/Linux and Windows tab format.
- A note that each `manualclose` invocation advances exactly one ledger, linking [stellar-core#4040](https://github.com/stellar/stellar-core/issues/4040) where support for closing N ledgers is requested, so the docs do not imply a count parameter exists.

Flag behavior was verified against the `start` script on the current `stellar/quickstart` main: the flag is boolean, defaults to `false` (`ENABLE_CORE_MANUAL_CLOSE`), and replaces `__MANUAL_CLOSE__` in the generated core config.