### PR TITLE
docs: qualify Freighter HTTPS requirement for localhost

### DIFF
--- a/docs/build/guides/dapps/frontend-guide.mdx
+++ b/docs/build/guides/dapps/frontend-guide.mdx
@@ -75,7 +75,7 @@ When prompted, choose the following options:
 
 ### Setup HTTPS on Localhost
 
-Freighter wallet requires a secure connection to interact with your dapp. Browsers treat `http://localhost` and `http://127.0.0.1` as secure contexts per the W3C Secure Contexts specification, so local development over plain HTTP works without extra setup. To enable HTTPS on localhost anyway, you can use a tool like `mkcert`. Fortunately, Next.js provides built-in support for HTTPS.
+Freighter wallet requires a secure connection to interact with your dapp. Browsers treat `http://localhost` and `http://127.0.0.1` as secure contexts per the [W3C Secure Contexts specification](https://www.w3.org/TR/secure-contexts/), so local development over plain HTTP works without extra setup. To enable HTTPS on localhost anyway, you can use a tool like `mkcert`. Fortunately, Next.js provides built-in support for HTTPS.
 
 To enable HTTPS in your Next.js project, open the `package.json` file and edit the `scripts` section as follows:
 

--- a/docs/build/guides/dapps/frontend-guide.mdx
+++ b/docs/build/guides/dapps/frontend-guide.mdx
@@ -75,7 +75,7 @@ When prompted, choose the following options:
 
 ### Setup HTTPS on Localhost
 
-Freighter wallet requires a secure connection (HTTPS) to interact with your dapp. To enable HTTPS on localhost, you can use a tool like `mkcert`. Fortunately, Next.js provides built-in support for HTTPS.
+Freighter wallet requires a secure connection to interact with your dapp. Browsers treat `http://localhost` and `http://127.0.0.1` as secure contexts per the W3C Secure Contexts specification, so local development over plain HTTP works without extra setup. To enable HTTPS on localhost anyway, you can use a tool like `mkcert`. Fortunately, Next.js provides built-in support for HTTPS.
 
 To enable HTTPS in your Next.js project, open the `package.json` file and edit the `scripts` section as follows:
 


### PR DESCRIPTION
## What and why

The dapp frontend guide stated one unqualified requirement: "Freighter wallet requires a secure connection (HTTPS) to interact with your dapp", then pointed readers at HTTPS setup for localhost. `http://localhost` and `http://127.0.0.1` are already `Potentially Trustworthy` origins under the W3C Secure Contexts specification, so plain HTTP on loopback satisfies Freighter's secure-context requirement and the sentence overstates what is needed.

The paragraph now names the loopback exception and keeps the HTTPS setup steps as optional. Nothing else in the guide changes.

Fixes #2773

## Testing

Docs-only change; verified the surrounding section still reads correctly and the mkcert / `next dev --experimental-https` steps remain intact.
