### PR TITLE
docs: reconcile memo framing in pooled accounts guide intro

### DIFF
--- a/docs/build/guides/transactions/pooled-accounts-muxed-accounts-memos.mdx
+++ b/docs/build/guides/transactions/pooled-accounts-muxed-accounts-memos.mdx
@@ -6,7 +6,7 @@ sidebar_position: 60
 
 When building an application or service on Stellar, one of the first things you have to decide is how to handle user accounts.
 
-You can create a Stellar account for each user, but most custodial services, including cryptocurrency exchanges, choose to use a single pooled Stellar account to handle transactions on behalf of their users. In these cases, an internal customer database maps transactions to individual accounts, using either the muxed account feature or, historically, transaction memos.
+You can create a Stellar account for each user, but most custodial services, including cryptocurrency exchanges, choose to use a single pooled Stellar account to handle transactions on behalf of their users. In these cases, an internal customer database maps transactions to individual accounts, using either the muxed account feature or transaction memos.
 
 :::note
 

--- a/docs/build/guides/transactions/pooled-accounts-muxed-accounts-memos.mdx
+++ b/docs/build/guides/transactions/pooled-accounts-muxed-accounts-memos.mdx
@@ -6,11 +6,11 @@ sidebar_position: 60
 
 When building an application or service on Stellar, one of the first things you have to decide is how to handle user accounts.
 
-You can create a Stellar account for each user, but most custodial services, including cryptocurrency exchanges, choose to use a single pooled Stellar account to handle transactions on behalf of their users. In these cases, the muxed account feature can map transactions to individual accounts via an internal customer database.
+You can create a Stellar account for each user, but most custodial services, including cryptocurrency exchanges, choose to use a single pooled Stellar account to handle transactions on behalf of their users. In these cases, an internal customer database maps transactions to individual accounts, using either the muxed account feature or, historically, transaction memos.
 
 :::note
 
-We used memos in the past for this purpose, however, using muxed accounts is better in the long term. At this time, there isn't support for muxed accounts by all wallets, exchanges, and anchors, so you may want to support both memos and muxed accounts, at least for a while.
+Transaction memos were traditionally used for this purpose, and many services still rely on them. Muxed accounts are better in the long term, but they aren't yet supported by all wallets, exchanges, and anchors, so you may want to support both memos and muxed accounts, at least for a while. This guide covers both approaches.
 
 :::
 


### PR DESCRIPTION
Fixes #2769

The pooled-accounts guide opened by framing memos as a thing of the past, then later sections instructed readers to keep supporting them during the transition to muxed accounts. This reworks the intro paragraph and the opening note so the framing is consistent throughout: memos are the legacy mechanism still in active use, muxed accounts are preferred going forward, and the guide covers both approaches.

No content beyond the two intro passages was changed.